### PR TITLE
스크롤 모드 줌

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -62,6 +63,7 @@ internal fun EditorView(
   val incomingContentHandler = LocalEditorIncomingContentHandler.current
   val zoomController = LocalEditorZoomController.current
   val displayZoom = zoomController.displayZoom
+  val renderZoom = zoomController.renderZoom
   val themeVariant = currentEditorThemeVariant()
   val canCreateEditor = runtime.canCreateEditor
   val environment =
@@ -73,10 +75,34 @@ internal fun EditorView(
     )
   val currentLoad by rememberUpdatedState(load)
   val currentEnvironment by rememberUpdatedState(environment)
+  val attachedEditor = runtime.editor
   var editorThemeVariant by remember(load) { mutableStateOf<ThemeVariant?>(null) }
+  var attachedEditorRenderZoom by remember(load, attachedEditor) { mutableFloatStateOf(renderZoom) }
 
-  LaunchedEffect(load, canCreateEditor, environment) {
+  LaunchedEffect(load, canCreateEditor, environment, attachedEditor, layoutSpec, renderZoom) {
     if (!environment.isValid) {
+      return@LaunchedEffect
+    }
+    if (attachedEditor != null && layoutSpec is EditorDocumentLayoutSpec.Continuous) {
+      if (zoomEquals(attachedEditorRenderZoom, renderZoom)) {
+        return@LaunchedEffect
+      }
+      val resizeApplied = attachedEditor.runEffect {
+        attachedEditor.update {
+          enqueue(
+            Message.System(
+              SystemEvent.Resize(
+                width = environment.width,
+                height = environment.height,
+                scaleFactor = environment.scaleFactor,
+              )
+            )
+          )
+        }
+      }
+      if (resizeApplied) {
+        attachedEditorRenderZoom = renderZoom
+      }
       return@LaunchedEffect
     }
     if (!canCreateEditor) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomState.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.body.documentZoomWidth
 import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -33,10 +34,10 @@ internal class EditorZoomController(
   var renderZoom by mutableFloatStateOf(1f)
     private set
 
-  val isPaginated: Boolean
-    get() = currentLayoutSpec is EditorDocumentLayoutSpec.Paginated
+  val isZoomEnabled: Boolean
+    get() = initializedLayoutKey != null
 
-  private var initializedPaginatedPageWidth: Float = Float.NaN
+  private var initializedLayoutKey: String? = null
   private var currentLayoutSpec: EditorDocumentLayoutSpec = EditorDocumentLayoutSpec.Continuous(0f)
   private var currentViewportWidth: Float = 0f
   private var renderZoomJob: Job? = null
@@ -45,48 +46,30 @@ internal class EditorZoomController(
     currentLayoutSpec = layoutSpec
     currentViewportWidth = viewportWidth
 
-    when (layoutSpec) {
-      is EditorDocumentLayoutSpec.Continuous -> {
-        initializedPaginatedPageWidth = Float.NaN
-        setZoomInternal(
-          zoom = 1f,
-          layoutSpec = layoutSpec,
-          viewportWidth = viewportWidth,
-          commitRender = true,
-        )
+    if (viewportWidth <= 0f) return
+    val width = layoutSpec.documentZoomWidth()
+    val key =
+      when (layoutSpec) {
+        is EditorDocumentLayoutSpec.Continuous -> "continuous:$width"
+        is EditorDocumentLayoutSpec.Paginated -> "paginated:$width"
       }
-
-      is EditorDocumentLayoutSpec.Paginated -> {
-        if (layoutSpec.pageWidth <= 0f || viewportWidth <= 0f) {
-          return
-        }
-
-        val shouldApplyInitialZoom =
-          initializedPaginatedPageWidth.isNaN() ||
-            abs(initializedPaginatedPageWidth - layoutSpec.pageWidth) >= ZoomEpsilon
-        if (shouldApplyInitialZoom) {
-          initializedPaginatedPageWidth = layoutSpec.pageWidth
-          setZoomInternal(
-            zoom =
-              computeInitialPaginatedZoom(
-                pageWidth = layoutSpec.pageWidth,
-                viewportWidth = viewportWidth,
-              ),
-            layoutSpec = layoutSpec,
-            viewportWidth = viewportWidth,
-            commitRender = true,
-          )
-          return
-        }
-
-        setZoomInternal(
-          zoom = displayZoom,
-          layoutSpec = layoutSpec,
-          viewportWidth = viewportWidth,
-          commitRender = true,
-        )
-      }
+    if (initializedLayoutKey != key) {
+      initializedLayoutKey = key
+      setZoomInternal(
+        zoom = computeInitialDocumentZoom(layoutSpec, viewportWidth),
+        layoutSpec = layoutSpec,
+        viewportWidth = viewportWidth,
+        commitRender = true,
+      )
+      return
     }
+
+    setZoomInternal(
+      zoom = displayZoom,
+      layoutSpec = layoutSpec,
+      viewportWidth = viewportWidth,
+      commitRender = true,
+    )
   }
 
   fun setDisplayZoom(
@@ -109,12 +92,12 @@ internal class EditorZoomController(
   }
 
   fun resolveSnapKey(zoom: Float = displayZoom): EditorZoomSnapKey? {
-    val layout = currentLayoutSpec as? EditorDocumentLayoutSpec.Paginated ?: return null
-    val viewportWidth = resolveViewportWidthFallback(layout.pageWidth)
+    if (!isZoomEnabled) return null
+    val layout = currentLayoutSpec
+    val viewportWidth = resolveViewportWidthFallback(layout.documentZoomWidth())
     val fitWidthZoom =
-      computePaginatedFitWidthZoom(pageWidth = layout.pageWidth, viewportWidth = viewportWidth)
-    val unitZoom =
-      clampDocumentZoom(zoom = 1f, bounds = computePaginatedZoomBounds(layout.pageWidth))
+      computeDocumentFitWidthZoom(layoutSpec = layout, viewportWidth = viewportWidth)
+    val unitZoom = clampDocumentZoom(zoom = 1f, bounds = computeDocumentZoomBounds(layout))
 
     return when {
       zoomEquals(zoom, fitWidthZoom) -> EditorZoomSnapKey.FitWidth
@@ -127,16 +110,7 @@ internal class EditorZoomController(
     zoom: Float,
     layoutSpec: EditorDocumentLayoutSpec,
     viewportWidth: Float,
-  ): Float =
-    when (layoutSpec) {
-      is EditorDocumentLayoutSpec.Continuous -> 1f
-      is EditorDocumentLayoutSpec.Paginated ->
-        clampPaginatedZoom(
-          zoom = zoom,
-          pageWidth = layoutSpec.pageWidth,
-          viewportWidth = viewportWidth,
-        )
-    }
+  ): Float = clampDocumentLayoutZoom(zoom, layoutSpec, viewportWidth)
 
   private fun setZoomInternal(
     zoom: Float,
@@ -170,11 +144,7 @@ internal class EditorZoomController(
   }
 
   private fun syncRenderZoomNow() {
-    val nextRenderZoom =
-      when (currentLayoutSpec) {
-        is EditorDocumentLayoutSpec.Continuous -> 1f
-        is EditorDocumentLayoutSpec.Paginated -> renderZoomForDisplay(displayZoom)
-      }
+    val nextRenderZoom = renderZoomForDisplay(displayZoom)
     if (!zoomEquals(renderZoom, nextRenderZoom)) {
       renderZoom = nextRenderZoom
     }
@@ -196,9 +166,10 @@ internal enum class EditorZoomSnapKey {
   Unit,
 }
 
-internal fun computePaginatedZoomBounds(pageWidth: Float): ClosedFloatingPointRange<Float> {
-  val safePageWidth = if (pageWidth.isFinite() && pageWidth > 0f) pageWidth else 1f
-  val minZoom = (MinDocumentDisplayWidth / safePageWidth).coerceAtLeast(0.01f)
+internal fun computeDocumentZoomBounds(
+  layoutSpec: EditorDocumentLayoutSpec
+): ClosedFloatingPointRange<Float> {
+  val minZoom = (MinDocumentDisplayWidth / layoutSpec.documentZoomWidth()).coerceAtLeast(0.01f)
   val maxZoom = MaxDocumentZoom.coerceAtLeast(minZoom)
   return minZoom..maxZoom
 }
@@ -211,27 +182,41 @@ internal fun clampDocumentZoom(zoom: Float, bounds: ClosedFloatingPointRange<Flo
   return zoom.coerceIn(bounds.start, bounds.endInclusive)
 }
 
-internal fun computePaginatedFitWidthZoom(pageWidth: Float, viewportWidth: Float): Float {
-  val bounds = computePaginatedZoomBounds(pageWidth)
-  val safePageWidth = if (pageWidth.isFinite() && pageWidth > 0f) pageWidth else 1f
+internal fun computeDocumentFitWidthZoom(
+  layoutSpec: EditorDocumentLayoutSpec,
+  viewportWidth: Float,
+): Float {
+  val bounds = computeDocumentZoomBounds(layoutSpec)
+  val width = layoutSpec.documentZoomWidth()
   val safeViewportWidth =
     if (viewportWidth.isFinite() && viewportWidth > 0f) {
       viewportWidth
     } else {
-      safePageWidth
+      width
     }
-  return (safeViewportWidth / safePageWidth).coerceIn(bounds.start, bounds.endInclusive)
+  return (safeViewportWidth / width).coerceIn(bounds.start, bounds.endInclusive)
 }
 
-internal fun computeInitialPaginatedZoom(pageWidth: Float, viewportWidth: Float): Float =
-  computePaginatedFitWidthZoom(pageWidth = pageWidth, viewportWidth = viewportWidth)
-    .coerceAtMost(1f)
+internal fun computeInitialDocumentZoom(
+  layoutSpec: EditorDocumentLayoutSpec,
+  viewportWidth: Float,
+): Float =
+  when (layoutSpec) {
+    is EditorDocumentLayoutSpec.Continuous ->
+      clampDocumentZoom(1f, computeDocumentZoomBounds(layoutSpec))
+    is EditorDocumentLayoutSpec.Paginated ->
+      computeDocumentFitWidthZoom(layoutSpec, viewportWidth).coerceAtMost(1f)
+  }
 
-internal fun clampPaginatedZoom(zoom: Float, pageWidth: Float, viewportWidth: Float): Float {
-  val bounds = computePaginatedZoomBounds(pageWidth)
+internal fun clampDocumentLayoutZoom(
+  zoom: Float,
+  layoutSpec: EditorDocumentLayoutSpec,
+  viewportWidth: Float,
+): Float {
+  val bounds = computeDocumentZoomBounds(layoutSpec)
   val clamped = clampDocumentZoom(zoom = zoom, bounds = bounds)
   val fitWidthZoom =
-    computePaginatedFitWidthZoom(pageWidth = pageWidth, viewportWidth = viewportWidth)
+    computeDocumentFitWidthZoom(layoutSpec = layoutSpec, viewportWidth = viewportWidth)
   val unitZoom = clampDocumentZoom(zoom = 1f, bounds = bounds)
 
   var snapped: Float? = null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -60,7 +60,8 @@ internal fun EditorBody(
   overlay: @Composable BoxScope.(EditorBodyGeometry, EditorState) -> Unit = { _, _ -> },
 ) {
   val density = LocalDensity.current
-  val displayZoom = LocalEditorZoomController.current.displayZoom
+  val zoomController = LocalEditorZoomController.current
+  val displayZoom = zoomController.displayZoom
   val editor = LocalEditorRuntime.current.editor
   val uiState = LocalEditorUiState.current
   val interactionScope = LocalEditorInteractionScope.current
@@ -75,6 +76,15 @@ internal fun EditorBody(
       pageSizes = pageSizes,
       displayZoom = displayZoom,
     )
+  val logicalViewportWidth =
+    when (layoutSpec) {
+      is EditorDocumentLayoutSpec.Continuous ->
+        resolveContinuousLayoutViewportWidth(
+          viewportWidth = geometry.visibleBodySize.width,
+          committedZoom = zoomController.renderZoom,
+        )
+      is EditorDocumentLayoutSpec.Paginated -> geometry.visibleBodySize.width
+    }
   val cursor = presentedState.cursor
   val extensionAreaFillSpacerHeight =
     remember(geometry.minimumBodyHeight, bodyContentHeight) {
@@ -141,7 +151,7 @@ internal fun EditorBody(
                 load = load,
                 publishedBundle = presentedBundle,
                 layoutSpec = layoutSpec,
-                viewportWidth = geometry.visibleBodySize.width,
+                viewportWidth = logicalViewportWidth,
                 viewportHeight = geometry.visibleBodySize.height,
                 modifier = Modifier.fillMaxWidth(),
                 editorInputEnabled = editorInputEnabled,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBodyGeometry.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBodyGeometry.kt
@@ -33,8 +33,8 @@ internal fun resolveEditorBodyGeometry(
       is EditorDocumentLayoutSpec.Continuous ->
         when {
           // Continuous.maxWidth caps content; engine page sizes also include its page margins.
-          maxPageWidth > 0f -> maxPageWidth
-          else -> visibleBodySize.width
+          maxPageWidth > 0f -> maxPageWidth * effectiveDisplayZoom
+          else -> visibleBodySize.width * effectiveDisplayZoom
         }
       is EditorDocumentLayoutSpec.Paginated ->
         when {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorDocumentLayoutSpec.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorDocumentLayoutSpec.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.floatOrNull
 
 internal const val PaginatedPageGap = 24f
+internal const val ContinuousPageHorizontalMargin = 20f
 
 internal sealed interface EditorDocumentLayoutSpec {
   data class Continuous(val maxWidth: Float) : EditorDocumentLayoutSpec
@@ -22,6 +23,21 @@ internal sealed interface EditorDocumentLayoutSpec {
     val pageMarginLeft: Float,
     val pageMarginRight: Float,
   ) : EditorDocumentLayoutSpec
+}
+
+internal fun EditorDocumentLayoutSpec.documentZoomWidth(): Float =
+  when (this) {
+    is EditorDocumentLayoutSpec.Continuous -> maxWidth + ContinuousPageHorizontalMargin * 2f
+    is EditorDocumentLayoutSpec.Paginated -> pageWidth
+  }.takeIf { it.isFinite() && it > 0f } ?: 1f
+
+internal fun resolveContinuousLayoutViewportWidth(
+  viewportWidth: Float,
+  committedZoom: Float,
+): Float {
+  val safeWidth = viewportWidth.takeIf { it.isFinite() && it > 0f } ?: 1f
+  val safeZoom = committedZoom.takeIf { it.isFinite() && it > 0f } ?: 1f
+  return safeWidth / minOf(safeZoom, 1f)
 }
 
 internal fun LayoutMode.toEditorDocumentLayoutSpec(): EditorDocumentLayoutSpec =
@@ -40,8 +56,9 @@ internal fun LayoutMode.toEditorDocumentLayoutSpec(): EditorDocumentLayoutSpec =
 
 internal fun EditorDocumentLayoutSpec.resolveBaseBottomSpace(displayZoom: Float = 1f): Float =
   when (this) {
-    is EditorDocumentLayoutSpec.Continuous -> 20f
-    is EditorDocumentLayoutSpec.Paginated -> pageMarginBottom * displayZoom
+    is EditorDocumentLayoutSpec.Continuous ->
+      ContinuousPageHorizontalMargin * normalizeDisplayZoom(displayZoom)
+    is EditorDocumentLayoutSpec.Paginated -> pageMarginBottom * normalizeDisplayZoom(displayZoom)
   }
 
 internal fun resolvePaginatedPageGap(displayZoom: Float = 1f): Float =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
@@ -5,8 +5,9 @@ import co.typie.editor.EditorViewportAnchor
 import co.typie.editor.EditorZoomController
 import co.typie.editor.EditorZoomSnapKey
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.body.documentZoomWidth
 import co.typie.editor.clampDocumentZoom
-import co.typie.editor.computePaginatedZoomBounds
+import co.typie.editor.computeDocumentZoomBounds
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.interaction.EditorPinchSample
 import co.typie.editor.runtime.EditorUiState
@@ -17,7 +18,7 @@ import kotlin.math.exp
 private const val PointerSignalZoomDivisor = 240f
 
 internal data class EditorViewportZoomSemanticConfig(
-  val layoutSpec: EditorDocumentLayoutSpec.Paginated,
+  val layoutSpec: EditorDocumentLayoutSpec,
   val zoomController: EditorZoomController,
   val viewportState: EditorViewportState,
   val uiState: EditorUiState,
@@ -25,6 +26,10 @@ internal data class EditorViewportZoomSemanticConfig(
   val viewportWidth: Float,
   val density: Float,
   val onZoomSnap: () -> Unit,
+  val onAttachViewportAnchor:
+    (anchor: EditorViewportAnchor, displayPosition: Offset, scrollOffset: Offset) -> Unit =
+    { _, _, _ ->
+    },
 )
 
 internal class EditorViewportZoomSemantic {
@@ -60,15 +65,21 @@ internal class EditorViewportZoomSemantic {
         startScrollOffset = currentConfig.viewportState.scrollOffset,
         startDisplayZoom = startZoom,
         startAnchorDisplayPosition = startAnchorDisplayPosition,
+        pageSizes = currentConfig.pageSizes,
+        lastSample = sample,
       )
     return true
   }
 
   fun updatePinch(sample: EditorPinchSample): Boolean {
     val currentConfig = config?.takeIf { it.isUsable } ?: return false
-    val session = pinchSession ?: return false
+    var session = pinchSession ?: return false
     if (!sample.isUsable) {
       return false
+    }
+    if (currentConfig.pageSizes !== session.pageSizes) {
+      session = currentConfig.rebasePinchSession(session) ?: return false
+      pinchSession = session
     }
 
     val previousZoom = currentConfig.zoomController.displayZoom
@@ -82,12 +93,19 @@ internal class EditorViewportZoomSemantic {
         ?: return false
     val focalDelta =
       (sample.focalInRootPx - session.startSample.focalInRootPx) / currentConfig.density
+    val targetScrollOffset =
+      session.startScrollOffset + (nextAnchorDisplayPosition - session.startAnchorDisplayPosition) -
+        focalDelta
     currentConfig.viewportState.scrollToTransformTarget(
-      offset =
-        session.startScrollOffset +
-          (nextAnchorDisplayPosition - session.startAnchorDisplayPosition) - focalDelta,
+      offset = targetScrollOffset,
       retainUntilMeasuredBounds = previousZoom != nextZoom,
     )
+    currentConfig.onAttachViewportAnchor(
+      session.anchor,
+      nextAnchorDisplayPosition,
+      targetScrollOffset,
+    )
+    pinchSession = session.copy(lastSample = sample)
     return true
   }
 
@@ -136,7 +154,7 @@ internal class EditorViewportZoomSemantic {
     val nextRawZoom =
       clampDocumentZoom(
         zoom = baseZoom * scaleFactor,
-        bounds = computePaginatedZoomBounds(currentConfig.layoutSpec.pageWidth),
+        bounds = computeDocumentZoomBounds(currentConfig.layoutSpec),
       )
     indirectRawZoom = nextRawZoom
 
@@ -144,10 +162,13 @@ internal class EditorViewportZoomSemantic {
     val nextAnchorDisplayPosition =
       currentConfig.resolveAnchorDisplayPosition(anchor = anchor, displayZoom = nextZoom)
         ?: return false
+    val targetScrollOffset =
+      effectiveScrollTarget + (nextAnchorDisplayPosition - previousAnchorDisplayPosition)
     viewportState.scrollToTransformTarget(
-      offset = effectiveScrollTarget + (nextAnchorDisplayPosition - previousAnchorDisplayPosition),
+      offset = targetScrollOffset,
       retainUntilMeasuredBounds = previousZoom != nextZoom,
     )
+    currentConfig.onAttachViewportAnchor(anchor, nextAnchorDisplayPosition, targetScrollOffset)
     return true
   }
 
@@ -206,10 +227,34 @@ private data class PinchSession(
   val startScrollOffset: Offset,
   val startDisplayZoom: Float,
   val startAnchorDisplayPosition: Offset,
+  val pageSizes: List<PageSize>,
+  val lastSample: EditorPinchSample,
 )
 
+private fun EditorViewportZoomSemanticConfig.rebasePinchSession(
+  session: PinchSession
+): PinchSession? {
+  val anchor = resolveAnchor(session.lastSample.focalInRootPx) ?: return null
+  val displayZoom = zoomController.displayZoom
+  val anchorDisplayPosition =
+    resolveAnchorDisplayPosition(anchor = anchor, displayZoom = displayZoom) ?: return null
+  return PinchSession(
+    anchor = anchor,
+    startSample = session.lastSample,
+    startScrollOffset = viewportState.scrollOffset,
+    startDisplayZoom = displayZoom,
+    startAnchorDisplayPosition = anchorDisplayPosition,
+    pageSizes = pageSizes,
+    lastSample = session.lastSample,
+  )
+}
+
 private val EditorViewportZoomSemanticConfig.isUsable: Boolean
-  get() = density > 0f && viewportWidth > 0f && layoutSpec.pageWidth > 0f && pageSizes.isNotEmpty()
+  get() =
+    density > 0f &&
+      viewportWidth > 0f &&
+      layoutSpec.documentZoomWidth() > 0f &&
+      pageSizes.isNotEmpty()
 
 private val EditorPinchSample.isUsable: Boolean
   get() =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewport.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewport.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.typie.editor.EditorViewportAnchor
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.body.resolveEditorPageWidth
 import co.typie.editor.body.resolveMeasuredPageLength
 import co.typie.editor.body.resolvePageContentTop
 import co.typie.editor.ffi.Size as PageSize
@@ -167,10 +168,24 @@ internal class EditorViewportState(initialScrollOffset: Offset = Offset.Zero) {
     )
   }
 
-  fun scrollTo(offset: Offset, isAutoScroll: Boolean = false) {
+  fun scrollTo(offset: Offset, isAutoScroll: Boolean = false, maximumScrollOffset: Offset? = null) {
     invalidateRetainedTransformScrollTargetAfterTransform()
     pendingRestoredScrollOffset = null
-    val resolvedScrollOffset = offset.coerceToBounds()
+    val resolvedScrollOffset =
+      if (
+        maximumScrollOffset != null &&
+          maximumScrollOffset.x.isFinite() &&
+          maximumScrollOffset.y.isFinite() &&
+          maximumScrollOffset.x >= 0f &&
+          maximumScrollOffset.y >= 0f
+      ) {
+        Offset(
+          x = offset.x.coerceIn(0f, maximumScrollOffset.x),
+          y = offset.y.coerceIn(0f, maximumScrollOffset.y),
+        )
+      } else {
+        offset.coerceToBounds()
+      }
     if (scrollOffset == resolvedScrollOffset) {
       return
     }
@@ -377,7 +392,7 @@ private fun Offset.consumeCrossAxisDelta(requested: Offset): Offset =
 private fun Offset.isDominantRightPan(): Boolean = x > 0f && abs(x) > abs(y)
 
 internal fun resolveZoomAnchorDisplayPosition(
-  layoutSpec: EditorDocumentLayoutSpec.Paginated,
+  layoutSpec: EditorDocumentLayoutSpec,
   anchor: EditorViewportAnchor,
   displayZoom: Float,
   viewportWidth: Float,
@@ -396,7 +411,12 @@ internal fun resolveZoomAnchorDisplayPosition(
     }
   val pageTrackWidth =
     resolveMeasuredPageLength(
-      length = layoutSpec.pageWidth,
+      length =
+        when (layoutSpec) {
+          is EditorDocumentLayoutSpec.Continuous ->
+            resolveEditorPageWidth(pageSizes) ?: pageSizes[anchor.page].width
+          is EditorDocumentLayoutSpec.Paginated -> layoutSpec.pageWidth
+        },
       displayZoom = effectiveDisplayZoom,
       density = density,
     )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorGeometry.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorGeometry.kt
@@ -14,6 +14,15 @@ internal fun ResolvedViewportAnchor.toEditorViewportAnchorGeometry(
 ): EditorViewportAnchorGeometry? {
   if (!contentOriginY.isFinite()) return null
   val zoom = frame.displayZoom.takeIf { it.isFinite() && it > 0f } ?: 1f
+  val bodyGeometry =
+    resolveEditorBodyGeometry(
+      visibleArea = frame.visibleArea,
+      layoutSpec = frame.layoutSpec,
+      pageSizes = frame.state.pageSizes,
+      displayZoom = zoom,
+    )
+  val contentWidth = maxOf(frame.visibleArea.viewport.width, bodyGeometry.pageColumnWidth)
+  val pageColumnLeft = (contentWidth - bodyGeometry.pageColumnWidth) / 2f
 
   fun contentY(page: Int, y: Float): Float? {
     val pageTop =
@@ -27,11 +36,13 @@ internal fun ResolvedViewportAnchor.toEditorViewportAnchorGeometry(
   }
 
   val pointY = contentY(point.pageIdx, point.y) ?: return null
+  val pointX = pageColumnLeft + point.x * zoom
+  if (!pointX.isFinite()) return null
   val rectSpan = rect?.let { pageRect ->
     val top = contentY(pageRect.pageIdx, pageRect.rect.y) ?: return@let null
     VerticalSpan(top = top, bottom = top + pageRect.rect.height * zoom)
   }
-  return EditorViewportAnchorGeometry(pointY = pointY, rect = rectSpan)
+  return EditorViewportAnchorGeometry(pointY = pointY, pointX = pointX, rect = rectSpan)
 }
 
 internal fun resolveViewportAnchorContentOriginY(frame: EditorScrollFrame): Float {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorState.kt
@@ -1,14 +1,21 @@
 package co.typie.editor.viewport
 
+import androidx.compose.ui.geometry.Offset
+import co.typie.editor.Editor
 import co.typie.editor.VerticalSpan
 import co.typie.editor.ffi.ViewportAnchor
+import co.typie.editor.ffi.ViewportAnchorPoint
 import co.typie.editor.scroll.EditorBringIntoViewPolicy
 import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.scroll.resolveKeepVisibleRange
 import co.typie.editor.scroll.resolveKeepVisibleScrollOffset
 
-internal data class EditorViewportAnchorGeometry(val pointY: Float, val rect: VerticalSpan? = null)
+internal data class EditorViewportAnchorGeometry(
+  val pointY: Float,
+  val pointX: Float = 0f,
+  val rect: VerticalSpan? = null,
+)
 
 internal data class EditorViewportAnchorRevealOrigin(
   val scrollY: Float,
@@ -19,13 +26,22 @@ internal data class EditorViewportAnchorRevealOrigin(
 internal class EditorViewportAnchorState {
   private data class Active(
     val identity: ViewportAnchor,
+    val pointAttachmentX: Float,
     val pointAttachmentY: Float,
     val rect: VerticalSpan?,
     val revealOrigin: EditorViewportAnchorRevealOrigin?,
   )
 
+  private data class CapturedViewportIdentity(
+    val editor: Editor,
+    val revision: Long,
+    val point: ViewportAnchorPoint,
+    val identity: ViewportAnchor,
+  )
+
   private var active: Active? = null
   private var preferredSelection: ViewportAnchor? = null
+  private var capturedViewportIdentity: CapturedViewportIdentity? = null
   private var observedScrollRevision: Int? = null
   private var observedVisibleTop: Float? = null
   private var observedVisibleBottom: Float? = null
@@ -36,12 +52,37 @@ internal class EditorViewportAnchorState {
   val pointAttachmentY: Float?
     get() = active?.pointAttachmentY
 
+  val pointAttachmentX: Float?
+    get() = active?.pointAttachmentX
+
   val preferredSelectionIdentity: ViewportAnchor?
     get() = preferredSelection
 
   fun clear() {
     active = null
     preferredSelection = null
+    capturedViewportIdentity = null
+  }
+
+  fun captureViewportIdentity(
+    editor: Editor,
+    revision: Long,
+    point: ViewportAnchorPoint,
+  ): ViewportAnchor? {
+    capturedViewportIdentity?.let { captured ->
+      if (captured.editor === editor && captured.revision == revision && captured.point == point) {
+        return captured.identity
+      }
+    }
+    val identity = editor.captureViewportAnchorAt(revision, point)?.identity ?: return null
+    capturedViewportIdentity =
+      CapturedViewportIdentity(
+        editor = editor,
+        revision = revision,
+        point = point,
+        identity = identity,
+      )
+    return identity
   }
 
   fun needsSelectionAdoption(identity: ViewportAnchor): Boolean = preferredSelection != identity
@@ -62,41 +103,45 @@ internal class EditorViewportAnchorState {
     return changed
   }
 
-  fun attach(identity: ViewportAnchor, geometry: EditorViewportAnchorGeometry, scrollY: Float) {
-    attachActive(identity, geometry, scrollY)
+  fun attach(
+    identity: ViewportAnchor,
+    geometry: EditorViewportAnchorGeometry,
+    scrollOffset: Offset,
+  ) {
+    attachActive(identity, geometry, scrollOffset)
   }
 
   fun attachSelection(
     identity: ViewportAnchor,
     geometry: EditorViewportAnchorGeometry,
-    scrollY: Float,
+    scrollOffset: Offset,
     revealOrigin: EditorViewportAnchorRevealOrigin? = null,
   ) {
     preferredSelection = identity
-    attachActive(identity, geometry, scrollY, revealOrigin)
+    attachActive(identity, geometry, scrollOffset, revealOrigin)
   }
 
   fun attachViewport(
     identity: ViewportAnchor,
     geometry: EditorViewportAnchorGeometry,
-    scrollY: Float,
+    scrollOffset: Offset,
   ) {
-    attachActive(identity, geometry, scrollY)
+    attachActive(identity, geometry, scrollOffset)
   }
 
   fun adoptSelection(
     identity: ViewportAnchor,
     geometry: EditorViewportAnchorGeometry,
-    scrollY: Float,
+    scrollOffset: Offset,
     visibleArea: EditorVisibleArea,
     preserveActiveAnchor: Boolean,
   ) {
     if (!needsSelectionAdoption(identity)) return
     val activate =
       !preserveActiveAnchor &&
-        (active != null || canRetainAfterDirectScroll(geometry, scrollY, visibleArea))
+        (active != null || canRetainAfterDirectScroll(geometry, scrollOffset.y, visibleArea))
     preferredSelection = identity
-    if (activate) attachActive(identity, geometry, scrollY)
+    if (activate) attachActive(identity, geometry, scrollOffset)
   }
 
   fun clearPreferredSelection() {
@@ -105,37 +150,33 @@ internal class EditorViewportAnchorState {
 
   fun tryReactivatePreferredSelection(
     geometry: EditorViewportAnchorGeometry,
-    scrollY: Float,
+    scrollOffset: Offset,
     visibleArea: EditorVisibleArea,
   ): Boolean {
     val identity = preferredSelection ?: return false
     val rect = geometry.rect ?: return false
     val guard = resolveKeepVisibleRange(visibleArea)
-    if (
-      !guard.isValid ||
-        !rect.top.isFinite() ||
-        !rect.bottom.isFinite() ||
-        rect.bottom < rect.top ||
-        rect.top - scrollY < guard.top ||
-        rect.bottom - scrollY > guard.bottom
-    ) {
+    if (!guard.isValid) return false
+    if (!rect.top.isFinite() || !rect.bottom.isFinite() || rect.bottom < rect.top) return false
+    if (rect.top - scrollOffset.y < guard.top || rect.bottom - scrollOffset.y > guard.bottom)
       return false
-    }
-    attachActive(identity, geometry, scrollY)
+    attachActive(identity, geometry, scrollOffset)
     return true
   }
 
   private fun attachActive(
     identity: ViewportAnchor,
     geometry: EditorViewportAnchorGeometry,
-    scrollY: Float,
+    scrollOffset: Offset,
     revealOrigin: EditorViewportAnchorRevealOrigin? = null,
   ) {
-    if (!geometry.pointY.isFinite() || !scrollY.isFinite()) return
+    if (!geometry.pointX.isFinite() || !geometry.pointY.isFinite()) return
+    if (!scrollOffset.x.isFinite() || !scrollOffset.y.isFinite()) return
     active =
       Active(
         identity = identity,
-        pointAttachmentY = geometry.pointY - scrollY,
+        pointAttachmentX = geometry.pointX - scrollOffset.x,
+        pointAttachmentY = geometry.pointY - scrollOffset.y,
         rect = geometry.rect,
         revealOrigin = revealOrigin,
       )
@@ -143,39 +184,44 @@ internal class EditorViewportAnchorState {
 
   fun publicationScroll(
     geometry: EditorViewportAnchorGeometry,
-    currentScrollY: Float,
-    maximumScrollY: Float,
-  ): Float {
-    val attachment = active?.pointAttachmentY ?: return currentScrollY
-    if (!geometry.pointY.isFinite() || !maximumScrollY.isFinite() || maximumScrollY < 0f) {
-      return currentScrollY
+    currentScrollOffset: Offset,
+    maximumScrollOffset: Offset,
+  ): Offset {
+    val current = active ?: return currentScrollOffset
+    if (!geometry.pointX.isFinite() || !geometry.pointY.isFinite()) return currentScrollOffset
+    if (!maximumScrollOffset.x.isFinite() || !maximumScrollOffset.y.isFinite()) {
+      return currentScrollOffset
     }
-    return (geometry.pointY - attachment).coerceIn(0f, maximumScrollY)
+    if (maximumScrollOffset.x < 0f || maximumScrollOffset.y < 0f) return currentScrollOffset
+    return Offset(
+      x = (geometry.pointX - current.pointAttachmentX).coerceIn(0f, maximumScrollOffset.x),
+      y = (geometry.pointY - current.pointAttachmentY).coerceIn(0f, maximumScrollOffset.y),
+    )
   }
 
   fun publicationRevealScroll(
     geometry: EditorViewportAnchorGeometry,
-    currentScrollY: Float,
-    maximumScrollY: Float,
+    currentScrollOffset: Offset,
+    maximumScrollOffset: Offset,
     visibleArea: EditorVisibleArea,
     resolveReveal: ((EditorViewportAnchorRevealOrigin) -> Float?)? = null,
-  ): Float {
-    val exact = publicationScroll(geometry, currentScrollY, maximumScrollY)
+  ): Offset {
+    val exact = publicationScroll(geometry, currentScrollOffset, maximumScrollOffset)
     if (!rectHeightChanged(active?.rect, geometry.rect)) return exact
     active?.revealOrigin?.let { origin ->
       resolveReveal?.invoke(origin)?.let {
-        return it.coerceIn(0f, maximumScrollY)
+        return exact.copy(y = it.coerceIn(0f, maximumScrollOffset.y))
       }
     }
-    return resizeScroll(geometry, exact, maximumScrollY, visibleArea)
+    return exact.copy(y = resizeScroll(geometry, exact.y, maximumScrollOffset.y, visibleArea))
   }
 
-  fun acceptGeometry(geometry: EditorViewportAnchorGeometry, scrollY: Float) {
+  fun acceptGeometry(geometry: EditorViewportAnchorGeometry, scrollOffset: Offset) {
     val current = active ?: return
     attachActive(
       identity = current.identity,
       geometry = geometry,
-      scrollY = scrollY,
+      scrollOffset = scrollOffset,
       revealOrigin = current.revealOrigin,
     )
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorLoadingSkeleton.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorLoadingSkeleton.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import co.typie.editor.body.EditorDocumentLayoutSpec
-import co.typie.editor.computeInitialPaginatedZoom
+import co.typie.editor.computeInitialDocumentZoom
 import co.typie.editor.ffi.Size
 import co.typie.screen.editor.editor.header.EditorHeader
 import co.typie.screen.editor.editor.header.EditorHeaderFrame
@@ -62,14 +62,7 @@ internal fun EditorLoadingSkeleton(
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
       val availableWidth = maxWidth.value
       val displayZoom =
-        when (layoutSpec) {
-          is EditorDocumentLayoutSpec.Continuous -> 1f
-          is EditorDocumentLayoutSpec.Paginated ->
-            computeInitialPaginatedZoom(
-              pageWidth = layoutSpec.pageWidth,
-              viewportWidth = availableWidth,
-            )
-        }
+        computeInitialDocumentZoom(layoutSpec = layoutSpec, viewportWidth = availableWidth)
       val bodyTrackWidth =
         when (layoutSpec) {
           is EditorDocumentLayoutSpec.Continuous ->

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -59,6 +59,7 @@ import co.typie.editor.body.EditorBody
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.decodeDocumentLayoutSpec
 import co.typie.editor.body.resolveBaseBottomSpace
+import co.typie.editor.body.resolveContinuousLayoutViewportWidth
 import co.typie.editor.body.resolveEditorBodyGeometry
 import co.typie.editor.body.toEditorDocumentLayoutSpec
 import co.typie.editor.external.EditorExternalElementState
@@ -116,7 +117,9 @@ import co.typie.editor.sync.ws.SyncWs
 import co.typie.editor.sync.ws.SyncWsException
 import co.typie.editor.sync.ws.WsSyncTransport
 import co.typie.editor.sync.ws.replacementSnapshotInFlight
+import co.typie.editor.viewport.EditorViewportAnchorState
 import co.typie.editor.viewport.consumeEditorViewportTouchPan
+import co.typie.editor.viewport.resolveViewportAnchorContentOriginY
 import co.typie.ext.LocalScrollGestureLockState
 import co.typie.ext.ime
 import co.typie.ext.rememberTextInputState
@@ -151,6 +154,7 @@ import co.typie.screen.editor.editor.header.EditorHeaderFrame
 import co.typie.screen.editor.editor.header.resolveEditorHeaderGeometry
 import co.typie.screen.editor.editor.layout.EditorScreenLayout
 import co.typie.screen.editor.editor.layout.EditorViewportScrollReconcileMode
+import co.typie.screen.editor.editor.layout.attachViewportZoomAnchor
 import co.typie.screen.editor.editor.overlay.EditorCharacterCountOverlay
 import co.typie.screen.editor.editor.overlay.EditorRepasteAsTextOverlay
 import co.typie.screen.editor.editor.overlay.EditorScreenOverlayHost
@@ -277,6 +281,7 @@ fun EditorScreen(entityId: String) {
     }
   var assetQueryGeneration by remember(entityId) { mutableStateOf(0L) }
   val zoomController = rememberEditorZoomController(key = entityId)
+  val viewportAnchorState = remember(entityId) { EditorViewportAnchorState() }
   val screenState = rememberEditorScreenState(key = entityId)
   val subPaneState = remember(entityId) { EditorSubPaneState() }
   val toolbarSessionState = rememberEditorToolbarSessionState(key = entityId)
@@ -1616,7 +1621,7 @@ fun EditorScreen(entityId: String) {
         layoutSpec = layoutSpec,
         viewportWidth = visibleArea.visibleBodySize.width,
         bodyTrackWidth = bodyTrackWidth,
-        displayZoom = if (layoutSpec is EditorDocumentLayoutSpec.Paginated) displayZoom else 1f,
+        displayZoom = displayZoom,
       )
     val publishedRevision = editor?.publishedRevision
     val editorGeometryValid =
@@ -1694,18 +1699,30 @@ fun EditorScreen(entityId: String) {
         popoverOverlayState.entry == null
     SideEffect {
       val viewportZoomConfig =
-        (layoutSpec as? EditorDocumentLayoutSpec.Paginated)?.let { paginatedLayoutSpec ->
-          EditorViewportZoomSemanticConfig(
-            layoutSpec = paginatedLayoutSpec,
-            zoomController = zoomController,
-            viewportState = screenState.viewportState,
-            uiState = uiState,
-            pageSizes = layoutPageSizes,
-            viewportWidth = visibleArea.visibleBodySize.width,
-            density = density,
-            onZoomSnap = { haptic.performHapticFeedback(HapticFeedbackType.SegmentTick) },
-          )
-        }
+        EditorViewportZoomSemanticConfig(
+          layoutSpec = layoutSpec,
+          zoomController = zoomController,
+          viewportState = screenState.viewportState,
+          uiState = uiState,
+          pageSizes = layoutPageSizes,
+          viewportWidth = visibleArea.visibleBodySize.width,
+          density = density,
+          onZoomSnap = { haptic.performHapticFeedback(HapticFeedbackType.SegmentTick) },
+          onAttachViewportAnchor = attach@{ anchor, displayPosition, scrollOffset ->
+              val activeEditor = editor ?: return@attach
+              val bundle = publishedBundle ?: return@attach
+              val frame = scrollFrame.withState(bundle.snapshot)
+              attachViewportZoomAnchor(
+                editor = activeEditor,
+                anchorState = viewportAnchorState,
+                revision = bundle.snapshot.version,
+                anchor = anchor,
+                displayPosition = displayPosition,
+                scrollOffset = scrollOffset,
+                contentOriginY = resolveViewportAnchorContentOriginY(frame),
+              )
+            },
+        )
       interactionScope.update(
         editor = editor,
         bringIntoViewRequests = bringIntoViewRequests,
@@ -1792,6 +1809,7 @@ fun EditorScreen(entityId: String) {
         editorInteractionEnabled = editorInteractionEnabled,
         platformIndirectScaleEnabled = platformIndirectScaleEnabled,
         viewportContentWidth = bodyTrackWidth,
+        viewportAnchorState = viewportAnchorState,
         viewportScrollReconcileMode = viewportScrollReconcileMode,
         onViewportIndirectInput = { uiState.contextMenu.hide() },
         onRequestEditing =
@@ -1817,7 +1835,15 @@ fun EditorScreen(entityId: String) {
                 enqueue(
                   Message.System(
                     SystemEvent.Resize(
-                      width = viewport.width,
+                      width =
+                        when (layoutSpec) {
+                          is EditorDocumentLayoutSpec.Continuous ->
+                            resolveContinuousLayoutViewportWidth(
+                              viewportWidth = viewport.width,
+                              committedZoom = zoomController.renderZoom,
+                            )
+                          is EditorDocumentLayoutSpec.Paginated -> viewport.width
+                        },
                       height = viewport.height,
                       scaleFactor = density.toDouble(),
                     )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -210,6 +210,7 @@ internal fun EditorScreenLayout(
   magnifierFocalPositionInRoot: Offset? = null,
   viewportScrollableState: Scrollable2DState,
   viewportContentWidth: Float,
+  viewportAnchorState: EditorViewportAnchorState? = null,
   isCurrentNavigationRoute: Boolean = true,
   editorInteractionEnabled: Boolean = true,
   platformIndirectScaleEnabled: Boolean = editorInteractionEnabled,
@@ -245,14 +246,15 @@ internal fun EditorScreenLayout(
   val bringIntoViewRequest = appliedState?.let {
     bringIntoViewRequests.activateForVersion(it.version)
   }
-  val viewportAnchorState = remember { EditorViewportAnchorState() }
+  val ownedViewportAnchorState = remember { EditorViewportAnchorState() }
+  val activeViewportAnchorState = viewportAnchorState ?: ownedViewportAnchorState
   val surfacePreparation = editor?.let {
     resolveAnchoredEditorSurfacePreparation(
       editor = it,
       scrollFrame = scrollFrame.withState(it.appliedState),
       currentScrollOffset = state.viewportState.scrollOffset,
       bringIntoViewRequest = bringIntoViewRequest,
-      anchorState = viewportAnchorState,
+      anchorState = activeViewportAnchorState,
       publishedBundle = it.publishedBundle,
       smoothScrollEnabled = smoothScrollEnabled,
       smoothRevealActive = smoothScrollSession.active,
@@ -386,7 +388,7 @@ internal fun EditorScreenLayout(
             scrollFrame = measuredScrollFrame.withState(currentAppliedState),
             currentScrollOffset = state.viewportState.scrollOffset,
             bringIntoViewRequest = currentRequest,
-            anchorState = viewportAnchorState,
+            anchorState = activeViewportAnchorState,
             publishedBundle = publishedBundle,
             smoothScrollEnabled = smoothScrollEnabled,
             smoothRevealActive = smoothScrollSession.active,
@@ -410,7 +412,7 @@ internal fun EditorScreenLayout(
                 scrollFrame = measuredScrollFrame.withState(latestState),
                 currentScrollOffset = state.viewportState.scrollOffset,
                 bringIntoViewRequest = latestRequest,
-                anchorState = viewportAnchorState,
+                anchorState = activeViewportAnchorState,
                 publishedBundle = publishedBundle,
                 smoothScrollEnabled = smoothScrollEnabled,
                 smoothRevealActive = smoothScrollSession.active,
@@ -422,15 +424,19 @@ internal fun EditorScreenLayout(
           return@let null
         }
 
-        val previousScrollY = state.viewportState.scrollOffset.y
-        state.viewportState.scrollToY(
-          targetY = anchorPublication.scrollY,
+        val previousScrollOffset = state.viewportState.scrollOffset
+        state.viewportState.scrollTo(
+          offset = anchorPublication.scrollOffset,
           isAutoScroll = true,
-          maximumScrollY = currentPreparation.maximumScrollY,
+          maximumScrollOffset =
+            Offset(
+              x = resolveMaximumScrollX(measuredScrollFrame.withState(candidate.snapshot)),
+              y = currentPreparation.maximumScrollY,
+            ),
         )
-        smoothScrollSession.translate(state.viewportState.scrollOffset.y - previousScrollY)
+        smoothScrollSession.translate(state.viewportState.scrollOffset.y - previousScrollOffset.y)
         anchorPublication.geometry?.let { geometry ->
-          viewportAnchorState.acceptGeometry(geometry, state.viewportState.scrollOffset.y)
+          activeViewportAnchorState.acceptGeometry(geometry, state.viewportState.scrollOffset)
         }
         candidate
       }
@@ -608,10 +614,10 @@ internal fun EditorScreenLayout(
                                 ) {
                                   attachSelectionViewportAnchor(
                                     editor = activePresentation.editor,
-                                    anchorState = viewportAnchorState,
+                                    anchorState = activeViewportAnchorState,
                                     revision = activePresentation.bundle.snapshot.version,
                                     frame = activePresentation.frame,
-                                    scrollY = state.viewportState.scrollOffset.y,
+                                    scrollOffset = state.viewportState.scrollOffset,
                                     visibleArea = activePresentation.visibleArea,
                                     requireGuard =
                                       completedRequest.target !=
@@ -626,7 +632,7 @@ internal fun EditorScreenLayout(
                             editor?.let { activeEditor ->
                               attachViewportCenterAnchor(
                                 editor = activeEditor,
-                                anchorState = viewportAnchorState,
+                                anchorState = activeViewportAnchorState,
                                 revision = scrollFrameVersion,
                                 frame = presentationScrollFrame,
                                 scrollOffset = state.viewportState.scrollOffset,
@@ -649,7 +655,7 @@ internal fun EditorScreenLayout(
 
               reconcileViewportAnchorObservation(
                 editor = editor,
-                anchorState = viewportAnchorState,
+                anchorState = activeViewportAnchorState,
                 bundle = placedBundle,
                 frame = presentationScrollFrame,
                 viewportState = state.viewportState,
@@ -688,10 +694,10 @@ internal fun EditorScreenLayout(
       }
     }
 
-    NavigationForeground(sharePointerInputWithSiblings = true, matchHostBounds = true) {
+    NavigationForeground(sharePointerInputWithSiblings = true) {
       EditorViewportOverlayLayout(viewportOverlay)
     }
-    NavigationForeground(matchHostBounds = true) {
+    NavigationForeground {
       EditorScreenForegroundLayout(
         overlay = overlay,
         toolbar = toolbar,
@@ -730,21 +736,33 @@ internal fun resolveAnchoredEditorSurfacePreparation(
       measuredScrollFrame = scrollFrame,
       currentScrollOffset = currentScrollOffset,
       maximumScrollY = initial.maximumScrollY,
+      maximumScrollX = resolveMaximumScrollX(scrollFrame),
       contentOriginY = initial.contentOriginY,
       smoothRevealActive = smoothRevealActive,
     )
       as? EditorViewportAnchorPublication.Ready ?: return null
-  if (anchorPublication.scrollY == currentScrollOffset.y) {
+  if (anchorPublication.scrollOffset == currentScrollOffset) {
     return initial.copy(anchorPublication = anchorPublication)
   }
   return resolveEditorSurfacePreparation(
       editor = editor,
       scrollFrame = scrollFrame,
-      currentScroll = anchorPublication.scrollY,
+      currentScroll = anchorPublication.scrollOffset.y,
       bringIntoViewRequest = bringIntoViewRequest,
       smoothScrollEnabled = smoothScrollEnabled,
     )
     ?.copy(anchorPublication = anchorPublication)
+}
+
+private fun resolveMaximumScrollX(frame: EditorScrollFrame): Float {
+  val bodyGeometry =
+    resolveEditorBodyGeometry(
+      visibleArea = frame.visibleArea,
+      layoutSpec = frame.layoutSpec,
+      pageSizes = frame.state.pageSizes,
+      displayZoom = frame.displayZoom,
+    )
+  return (bodyGeometry.pageColumnWidth - frame.visibleArea.viewport.width).coerceAtLeast(0f)
 }
 
 internal fun resolveEditorSurfacePreparation(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
@@ -3,6 +3,7 @@ package co.typie.screen.editor.editor.layout
 import androidx.compose.ui.geometry.Offset
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.EditorViewportAnchor
 import co.typie.editor.PublishedBundle
 import co.typie.editor.ffi.ViewportAnchorResolution
 import co.typie.editor.scroll.EditorBringIntoViewTarget
@@ -21,7 +22,7 @@ import co.typie.editor.viewport.viewportCenterAnchorPoint
 internal sealed interface EditorViewportAnchorPublication {
   data object Withhold : EditorViewportAnchorPublication
 
-  data class Ready(val scrollY: Float, val geometry: EditorViewportAnchorGeometry?) :
+  data class Ready(val scrollOffset: Offset, val geometry: EditorViewportAnchorGeometry?) :
     EditorViewportAnchorPublication
 }
 
@@ -33,6 +34,7 @@ internal fun reconcileViewportAnchorPublication(
   measuredScrollFrame: EditorScrollFrame,
   currentScrollOffset: Offset,
   maximumScrollY: Float,
+  maximumScrollX: Float = 0f,
   contentOriginY: Float,
   smoothRevealActive: Boolean = false,
 ): EditorViewportAnchorPublication {
@@ -48,7 +50,7 @@ internal fun reconcileViewportAnchorPublication(
     anchorState.adoptSelection(
       identity = selectionCapture.identity,
       geometry = geometry,
-      scrollY = currentScrollY,
+      scrollOffset = currentScrollOffset,
       visibleArea = candidateFrame.visibleArea,
       preserveActiveAnchor = smoothRevealActive,
     )
@@ -69,7 +71,11 @@ internal fun reconcileViewportAnchorPublication(
   }
   val unanchoredPublication =
     EditorViewportAnchorPublication.Ready(
-      scrollY = currentScrollY.coerceIn(0f, maximumScrollY),
+      scrollOffset =
+        Offset(
+          x = currentScrollOffset.x.coerceIn(0f, maximumScrollX),
+          y = currentScrollY.coerceIn(0f, maximumScrollY),
+        ),
       geometry = null,
     )
   if (publishedBundle == null || publishedBundle.snapshot.version == candidateState.version) {
@@ -98,11 +104,11 @@ internal fun reconcileViewportAnchorPublication(
           contentOriginY = contentOriginY,
         ) ?: return EditorViewportAnchorPublication.Withhold
       EditorViewportAnchorPublication.Ready(
-        scrollY =
+        scrollOffset =
           anchorState.publicationRevealScroll(
             geometry = geometry,
-            currentScrollY = currentScrollY,
-            maximumScrollY = maximumScrollY,
+            currentScrollOffset = currentScrollOffset,
+            maximumScrollOffset = Offset(x = maximumScrollX, y = maximumScrollY),
             visibleArea = measuredScrollFrame.visibleArea,
             resolveReveal = { origin ->
               when (
@@ -162,7 +168,7 @@ private fun resolveCandidateViewportAnchor(
     anchorState.clear()
     return null
   }
-  anchorState.attach(fallback.identity, oldGeometry, currentScrollOffset.y)
+  anchorState.attach(fallback.identity, oldGeometry, currentScrollOffset)
   return editor.resolveViewportAnchor(candidateFrame.state.version, fallback.identity)
 }
 
@@ -183,7 +189,10 @@ internal fun reconcileViewportAnchorObservation(
     anchorState.clear()
     return
   }
-  if (viewportState.isTransforming) return
+  if (viewportState.isTransforming) {
+    anchorState.consumeScrollChange(viewportState.lastScrollRevision)
+    return
+  }
   val scrollChanged = anchorState.consumeScrollChange(viewportState.lastScrollRevision)
   val visibleAreaChanged = anchorState.consumeVisibleAreaChange(visibleArea)
 
@@ -196,7 +205,7 @@ internal fun reconcileViewportAnchorObservation(
         anchorState = anchorState,
         revision = revision,
         frame = presentationFrame,
-        scrollY = viewportState.scrollOffset.y,
+        scrollOffset = viewportState.scrollOffset,
         visibleArea = visibleArea,
         requireGuard = handoffTarget != EditorBringIntoViewTarget.CurrentSelectionHead,
         revealOrigin = selectionRevealOrigin,
@@ -208,7 +217,7 @@ internal fun reconcileViewportAnchorObservation(
         anchorState = anchorState,
         revision = revision,
         frame = presentationFrame,
-        scrollY = viewportState.scrollOffset.y,
+        scrollOffset = viewportState.scrollOffset,
         visibleArea = visibleArea,
         requireGuard = true,
         contentOriginY = contentOriginY,
@@ -258,7 +267,7 @@ internal fun reconcileViewportAnchorObservation(
         contentOriginY,
       )
   if (scrollChanged && handoffTarget != null) {
-    geometry?.let { anchorState.acceptGeometry(it, viewportState.scrollOffset.y) }
+    geometry?.let { anchorState.acceptGeometry(it, viewportState.scrollOffset) }
   } else if (scrollChanged) {
     val preferredSelectionGeometry =
       if (!viewportState.lastScrollWasAuto) {
@@ -274,11 +283,11 @@ internal fun reconcileViewportAnchorObservation(
       }
     when {
       viewportState.lastScrollWasAuto ->
-        geometry?.let { anchorState.acceptGeometry(it, viewportState.scrollOffset.y) }
+        geometry?.let { anchorState.acceptGeometry(it, viewportState.scrollOffset) }
       preferredSelectionGeometry != null &&
         anchorState.tryReactivatePreferredSelection(
           geometry = preferredSelectionGeometry,
-          scrollY = viewportState.scrollOffset.y,
+          scrollOffset = viewportState.scrollOffset,
           visibleArea = visibleArea,
         ) -> geometry = preferredSelectionGeometry
       geometry != null &&
@@ -286,7 +295,7 @@ internal fun reconcileViewportAnchorObservation(
           geometry = geometry,
           scrollY = viewportState.scrollOffset.y,
           visibleArea = visibleArea,
-        ) -> anchorState.acceptGeometry(geometry, viewportState.scrollOffset.y)
+        ) -> anchorState.acceptGeometry(geometry, viewportState.scrollOffset)
       else -> {
         geometry =
           attachViewportCenterAnchor(
@@ -310,7 +319,7 @@ internal fun reconcileViewportAnchorObservation(
         visibleArea = visibleArea,
       )
     viewportState.scrollToY(targetY = targetY, isAutoScroll = true)
-    anchorState.acceptGeometry(geometry, viewportState.scrollOffset.y)
+    anchorState.acceptGeometry(geometry, viewportState.scrollOffset)
   }
 }
 
@@ -319,7 +328,7 @@ internal fun attachSelectionViewportAnchor(
   anchorState: EditorViewportAnchorState,
   revision: Long,
   frame: EditorScrollFrame,
-  scrollY: Float,
+  scrollOffset: Offset,
   visibleArea: EditorVisibleArea,
   requireGuard: Boolean,
   revealOrigin: EditorViewportAnchorRevealOrigin? = null,
@@ -329,10 +338,12 @@ internal fun attachSelectionViewportAnchor(
   val geometry =
     capture.geometry.toEditorViewportAnchorGeometry(frame = frame, contentOriginY = contentOriginY)
       ?: return null
-  if (requireGuard && !anchorState.canRetainAfterDirectScroll(geometry, scrollY, visibleArea)) {
+  if (
+    requireGuard && !anchorState.canRetainAfterDirectScroll(geometry, scrollOffset.y, visibleArea)
+  ) {
     return null
   }
-  anchorState.attachSelection(capture.identity, geometry, scrollY, revealOrigin)
+  anchorState.attachSelection(capture.identity, geometry, scrollOffset, revealOrigin)
   return geometry
 }
 
@@ -349,8 +360,40 @@ internal fun attachViewportCenterAnchor(
   val geometry =
     capture.geometry.toEditorViewportAnchorGeometry(frame = frame, contentOriginY = contentOriginY)
       ?: return null
-  anchorState.attachViewport(capture.identity, geometry, scrollOffset.y)
+  anchorState.attachViewport(capture.identity, geometry, scrollOffset)
   return geometry
+}
+
+internal fun attachViewportZoomAnchor(
+  editor: Editor,
+  anchorState: EditorViewportAnchorState,
+  revision: Long,
+  anchor: EditorViewportAnchor,
+  displayPosition: Offset,
+  scrollOffset: Offset,
+  contentOriginY: Float,
+) {
+  if (
+    !displayPosition.x.isFinite() || !displayPosition.y.isFinite() || !contentOriginY.isFinite()
+  ) {
+    return
+  }
+  val identity =
+    anchorState.captureViewportIdentity(
+      editor = editor,
+      revision = revision,
+      point =
+        co.typie.editor.ffi.ViewportAnchorPoint(pageIdx = anchor.page, x = anchor.x, y = anchor.y),
+    ) ?: return
+  anchorState.attachViewport(
+    identity = identity,
+    geometry =
+      EditorViewportAnchorGeometry(
+        pointX = displayPosition.x,
+        pointY = contentOriginY + displayPosition.y,
+      ),
+    scrollOffset = scrollOffset,
+  )
 }
 
 private fun resolvePreferredSelectionViewportAnchorGeometry(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomOverlay.kt
@@ -36,24 +36,24 @@ private val ZoomOverlayShape = AppShapes.rounded(8.dp)
 @Composable
 internal fun EditorZoomOverlay(modifier: Modifier = Modifier) {
   val zoomController = LocalEditorZoomController.current
-  val isPaginated = zoomController.isPaginated
+  val enabled = zoomController.isZoomEnabled
   val displayZoom = zoomController.displayZoom
 
   var visible by remember { mutableStateOf(false) }
   var lastZoom by remember { mutableStateOf<Float?>(null) }
-  var wasPaginated by remember { mutableStateOf(false) }
+  var wasEnabled by remember { mutableStateOf(false) }
   var showRequest by remember { mutableIntStateOf(0) }
 
-  LaunchedEffect(isPaginated, displayZoom) {
-    val enteredPaginated = isPaginated && !wasPaginated
-    wasPaginated = isPaginated
+  LaunchedEffect(enabled, displayZoom) {
+    val entered = enabled && !wasEnabled
+    wasEnabled = enabled
     val previousZoom = lastZoom
     lastZoom = displayZoom
     val shouldShow = previousZoom == null || zoomDiffers(previousZoom, displayZoom)
 
-    if (isPaginated && (enteredPaginated || shouldShow)) {
+    if (enabled && (entered || shouldShow)) {
       showRequest += 1
-    } else if (!isPaginated) {
+    } else if (!enabled) {
       visible = false
     }
   }
@@ -68,7 +68,7 @@ internal fun EditorZoomOverlay(modifier: Modifier = Modifier) {
     visible = false
   }
 
-  if (!isPaginated) {
+  if (!enabled) {
     return
   }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomStateTest.kt
@@ -1,6 +1,8 @@
 package co.typie.editor
 
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.body.resolveBaseBottomSpace
+import co.typie.editor.body.resolveContinuousLayoutViewportWidth
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,6 +12,26 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorZoomControllerTest {
+  @Test
+  fun `continuous policy mirrors web bounds fit snap and logical viewport`() {
+    val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+
+    assertEquals(0.15625f, computeDocumentZoomBounds(layout).start, 0.0001f)
+    assertEquals(2f, computeDocumentZoomBounds(layout).endInclusive, 0.0001f)
+    assertEquals(0.78125f, computeDocumentFitWidthZoom(layout, 500f), 0.0001f)
+    assertEquals(0.78125f, clampDocumentLayoutZoom(0.79f, layout, 500f), 0.0001f)
+    assertEquals(500f, resolveContinuousLayoutViewportWidth(500f, 1.5f), 0.0001f)
+    assertEquals(625f, resolveContinuousLayoutViewportWidth(500f, 0.8f), 0.0001f)
+  }
+
+  @Test
+  fun `continuous engine margin follows visual zoom`() {
+    val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+
+    assertEquals(30f, layout.resolveBaseBottomSpace(displayZoom = 1.5f), 0.0001f)
+    assertEquals(10f, layout.resolveBaseBottomSpace(displayZoom = 0.5f), 0.0001f)
+  }
+
   @Test
   fun `paginated sync applies fit-width initial zoom`() {
     val state = EditorZoomController()
@@ -120,6 +142,24 @@ class EditorZoomControllerTest {
     advanceTimeBy(1)
     runCurrent()
     assertEquals(1.4f, state.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `continuous render zoom follows display zoom at the same debounce boundary`() = runTest {
+    val state = EditorZoomController(scope = backgroundScope)
+    val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+    state.setDisplayZoom(zoom = 0.75f, layoutSpec = layout, viewportWidth = 500f)
+
+    assertEquals(0.75f, state.displayZoom, 0.0001f)
+    assertEquals(1f, state.renderZoom, 0.0001f)
+    advanceTimeBy(119)
+    runCurrent()
+    assertEquals(1f, state.renderZoom, 0.0001f)
+    advanceTimeBy(1)
+    runCurrent()
+    assertEquals(0.75f, state.renderZoom, 0.0001f)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/body/EditorBodyGeometryTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/body/EditorBodyGeometryTest.kt
@@ -47,6 +47,24 @@ class EditorBodyGeometryTest {
   }
 
   @Test
+  fun `continuous geometry scales the committed engine page width for display`() {
+    val geometry =
+      resolveEditorBodyGeometry(
+        visibleArea =
+          EditorVisibleArea(
+            viewport = Size(width = 500f, height = 900f),
+            headerHeight = 120f,
+            topInset = 120f,
+          ),
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        pageSizes = listOf(PageSize(width = 500f, height = 800f)),
+        displayZoom = 1.5f,
+      )
+
+    assertEquals(750f, geometry.pageColumnWidth)
+  }
+
+  @Test
   fun `geometry falls back to the visible width before page metrics arrive`() {
     val geometry =
       resolveEditorBodyGeometry(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
@@ -33,6 +33,51 @@ class EditorViewportZoomSemanticTest {
   }
 
   @Test
+  fun `continuous pinch shares optical update anchor attachment and gesture-end commit`() {
+    val fixture =
+      Fixture(
+        documentLayoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        pageSizes = listOf(PageSize(width = 500f, height = 960f)),
+        viewportWidth = 500f,
+      )
+    val start = EditorPinchSample(focalInRootPx = Offset(100f, 200f), distancePx = 100f)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(fixture.semantic.updatePinch(start.copy(distancePx = 75f)))
+
+    assertEquals(0.75f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(1f, fixture.zoomController.renderZoom, 0.0001f)
+    assertTrue(fixture.attachedAnchors.isNotEmpty())
+
+    fixture.semantic.end()
+    assertEquals(0.75f, fixture.zoomController.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `continuous pinch rebases its page local anchor after reflow is published`() {
+    val fixture =
+      Fixture(
+        documentLayoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+        pageSizes = listOf(PageSize(width = 500f, height = 960f)),
+        viewportWidth = 500f,
+      )
+    val start = EditorPinchSample(focalInRootPx = Offset(100f, 200f), distancePx = 100f)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(fixture.semantic.updatePinch(start.copy(distancePx = 75f)))
+    fixture.updatePresentation(
+      pageSizes = listOf(PageSize(width = 600f, height = 960f)),
+      pageOffsets = mapOf(0 to Offset(x = 40f, y = 0f)),
+      displayZoom = 0.75f,
+    )
+
+    assertTrue(fixture.semantic.updatePinch(start.copy(distancePx = 60f)))
+
+    assertEquals(0.6f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(80f, fixture.attachedAnchors.last().first.x, 0.0001f)
+  }
+
+  @Test
   fun `pinch samples resolve an absolute target from a root-stable focal`() {
     val fixture =
       Fixture(
@@ -227,8 +272,7 @@ class EditorViewportZoomSemanticTest {
     editorBoundsInRoot: Rect = Rect(left = 0f, top = 0f, right = 720f, bottom = 2000f),
     measuredViewportSize: Size = Size(width = 100f, height = 120f),
     contentSize: Size = Size(width = 2000f, height = 2000f),
-  ) {
-    val layoutSpec =
+    documentLayoutSpec: EditorDocumentLayoutSpec =
       EditorDocumentLayoutSpec.Paginated(
         pageWidth = 720f,
         pageHeight = 960f,
@@ -236,7 +280,11 @@ class EditorViewportZoomSemanticTest {
         pageMarginBottom = 0f,
         pageMarginLeft = 0f,
         pageMarginRight = 0f,
-      )
+      ),
+  ) {
+    val layoutSpec = documentLayoutSpec
+    val attachedAnchors =
+      mutableListOf<Triple<co.typie.editor.EditorViewportAnchor, Offset, Offset>>()
     val zoomController = EditorZoomController()
     val viewportState =
       EditorViewportState().apply {
@@ -249,30 +297,47 @@ class EditorViewportZoomSemanticTest {
         pageOffsets.forEach { (page, offset) -> updatePageOffset(page = page, offset = offset) }
         updateEditorBounds(boundsInRoot = editorBoundsInRoot, density = 1f)
       }
-    val semantic =
-      EditorViewportZoomSemantic().apply {
-        configure(
-          EditorViewportZoomSemanticConfig(
-            layoutSpec = layoutSpec,
-            zoomController = zoomController,
-            viewportState = viewportState,
-            uiState = uiState,
-            pageSizes = pageSizes,
-            viewportWidth = viewportWidth,
-            density = 1f,
-            onZoomSnap = {},
-          )
-        )
-      }
+    val semantic = EditorViewportZoomSemantic()
 
     init {
       zoomController.syncLayout(layoutSpec = layoutSpec, viewportWidth = viewportWidth)
+      configure(pageSizes)
     }
 
     fun updateEditorRootOffset(offset: Offset) {
       uiState.updateEditorBounds(
         boundsInRoot = Rect(offset = offset, size = Size(width = viewportWidth, height = 1000f)),
         density = 1f,
+      )
+    }
+
+    fun updatePresentation(
+      pageSizes: List<PageSize>,
+      pageOffsets: Map<Int, Offset>,
+      displayZoom: Float,
+    ) {
+      uiState.updateDisplayZoom(displayZoom)
+      pageOffsets.forEach { (page, offset) ->
+        uiState.updatePageOffset(page = page, offset = offset)
+      }
+      configure(pageSizes)
+    }
+
+    private fun configure(pageSizes: List<PageSize>) {
+      semantic.configure(
+        EditorViewportZoomSemanticConfig(
+          layoutSpec = layoutSpec,
+          zoomController = zoomController,
+          viewportState = viewportState,
+          uiState = uiState,
+          pageSizes = pageSizes,
+          viewportWidth = viewportWidth,
+          density = 1f,
+          onZoomSnap = {},
+          onAttachViewportAnchor = { anchor, displayPosition, scrollOffset ->
+            attachedAnchors += Triple(anchor, displayPosition, scrollOffset)
+          },
+        )
       )
     }
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorGeometryTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorGeometryTest.kt
@@ -4,7 +4,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import co.typie.editor.EditorState
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.ResolvedViewportAnchor
 import co.typie.editor.ffi.Size as PageSize
+import co.typie.editor.ffi.ViewportAnchorPoint
 import co.typie.editor.runtime.EditorBoundsInContainer
 import co.typie.editor.scroll.EditorScrollFrame
 import co.typie.editor.scroll.EditorVisibleArea
@@ -32,6 +34,19 @@ class EditorViewportAnchorGeometryTest {
   @Test
   fun `continuous viewport anchor origin includes the body top spacer`() {
     assertEquals(40f, resolveViewportAnchorContentOriginY(frame()))
+  }
+
+  @Test
+  fun `resolved anchor geometry includes displayed horizontal page position`() {
+    val geometry =
+      ResolvedViewportAnchor(
+          point = ViewportAnchorPoint(pageIdx = 0, x = 40f, y = 50f),
+          rect = null,
+        )
+        .toEditorViewportAnchorGeometry(frame = frame(), contentOriginY = 40f)
+
+    assertEquals(40f, geometry?.pointX)
+    assertEquals(90f, geometry?.pointY)
   }
 
   private fun frame(): EditorScrollFrame {

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorStateTest.kt
@@ -1,5 +1,6 @@
 package co.typie.editor.viewport
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import co.typie.editor.VerticalSpan
 import co.typie.editor.ffi.ViewportAnchor
@@ -18,14 +19,33 @@ class EditorViewportAnchorStateTest {
   @Test
   fun `publication keeps the anchor at the exact attached viewport point`() {
     val state = EditorViewportAnchorState()
-    state.attach(identity, geometry(pointY = 200f), scrollY = 100f)
+    state.attach(identity, geometry(pointY = 200f), scrollOffset = Offset(x = 0f, y = 100f))
 
     assertEquals(
-      220f,
+      Offset(x = 0f, y = 220f),
       state.publicationScroll(
         geometry = geometry(pointY = 320f),
-        currentScrollY = 100f,
-        maximumScrollY = 500f,
+        currentScrollOffset = Offset(x = 0f, y = 100f),
+        maximumScrollOffset = Offset(x = 0f, y = 500f),
+      ),
+    )
+  }
+
+  @Test
+  fun `publication keeps the anchor attachment on both axes`() {
+    val state = EditorViewportAnchorState()
+    state.attach(
+      identity = identity,
+      geometry = geometry(pointX = 100f, pointY = 200f),
+      scrollOffset = Offset(x = 20f, y = 100f),
+    )
+
+    assertEquals(
+      Offset(x = 180f, y = 220f),
+      state.publicationScroll(
+        geometry = geometry(pointX = 260f, pointY = 320f),
+        currentScrollOffset = Offset(x = 20f, y = 100f),
+        maximumScrollOffset = Offset(x = 500f, y = 500f),
       ),
     )
   }
@@ -33,14 +53,14 @@ class EditorViewportAnchorStateTest {
   @Test
   fun `geometry change below the anchor does not move the viewport`() {
     val state = EditorViewportAnchorState()
-    state.attach(identity, geometry(pointY = 200f), scrollY = 100f)
+    state.attach(identity, geometry(pointY = 200f), scrollOffset = Offset(x = 0f, y = 100f))
 
     assertEquals(
-      100f,
+      Offset(x = 0f, y = 100f),
       state.publicationScroll(
         geometry = geometry(pointY = 200f),
-        currentScrollY = 100f,
-        maximumScrollY = 500f,
+        currentScrollOffset = Offset(x = 0f, y = 100f),
+        maximumScrollOffset = Offset(x = 0f, y = 500f),
       ),
     )
   }
@@ -49,7 +69,11 @@ class EditorViewportAnchorStateTest {
   fun `direct scroll retains identity inside cursor guard and replaces it outside`() {
     val state = EditorViewportAnchorState()
     val visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 300f))
-    state.attach(identity, geometry(pointY = 200f, top = 190f, bottom = 210f), scrollY = 100f)
+    state.attach(
+      identity,
+      geometry(pointY = 200f, top = 190f, bottom = 210f),
+      scrollOffset = Offset(x = 0f, y = 100f),
+    )
 
     assertTrue(
       state.canRetainAfterDirectScroll(
@@ -71,7 +95,11 @@ class EditorViewportAnchorStateTest {
   fun `oversized rect uses its point instead of trying to fit the whole rect`() {
     val state = EditorViewportAnchorState()
     val visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 300f))
-    state.attach(identity, geometry(pointY = 150f, top = 0f, bottom = 1_000f), scrollY = 0f)
+    state.attach(
+      identity,
+      geometry(pointY = 150f, top = 0f, bottom = 1_000f),
+      scrollOffset = Offset.Zero,
+    )
 
     assertTrue(
       state.canRetainAfterDirectScroll(
@@ -94,7 +122,11 @@ class EditorViewportAnchorStateTest {
   @Test
   fun `resize moves minimally only after the anchor leaves cursor guard`() {
     val state = EditorViewportAnchorState()
-    state.attach(identity, geometry(pointY = 260f, top = 250f, bottom = 270f), scrollY = 100f)
+    state.attach(
+      identity,
+      geometry(pointY = 260f, top = 250f, bottom = 270f),
+      scrollOffset = Offset(x = 0f, y = 100f),
+    )
     val shrunken =
       EditorVisibleArea(viewport = Size(width = 300f, height = 300f), bottomOcclusionInset = 100f)
 
@@ -112,12 +144,16 @@ class EditorViewportAnchorStateTest {
   @Test
   fun `clamped publication records the achieved attachment`() {
     val state = EditorViewportAnchorState()
-    state.attach(identity, geometry(pointY = 200f), scrollY = 100f)
+    state.attach(identity, geometry(pointY = 200f), scrollOffset = Offset(x = 0f, y = 100f))
     val candidate = geometry(pointY = 800f)
 
     val clamped =
-      state.publicationScroll(geometry = candidate, currentScrollY = 100f, maximumScrollY = 500f)
-    state.acceptGeometry(candidate, scrollY = clamped)
+      state.publicationScroll(
+        geometry = candidate,
+        currentScrollOffset = Offset(x = 0f, y = 100f),
+        maximumScrollOffset = Offset(x = 0f, y = 500f),
+      )
+    state.acceptGeometry(candidate, scrollOffset = clamped)
 
     assertEquals(300f, state.pointAttachmentY)
   }
@@ -135,16 +171,16 @@ class EditorViewportAnchorStateTest {
     state.attachSelection(
       identity,
       geometry(pointY = 500.5f, top = 500f, bottom = 501f),
-      scrollY = 161f,
+      scrollOffset = Offset(x = 0f, y = 161f),
       revealOrigin = revealOrigin,
     )
 
     assertEquals(
-      240f,
+      Offset(x = 0f, y = 240f),
       state.publicationRevealScroll(
         geometry = geometry(pointY = 600f, top = 500f, bottom = 700f),
-        currentScrollY = 161f,
-        maximumScrollY = 600f,
+        currentScrollOffset = Offset(x = 0f, y = 161f),
+        maximumScrollOffset = Offset(x = 0f, y = 600f),
         visibleArea = visibleArea,
         resolveReveal = { origin ->
           assertEquals(revealOrigin, origin)
@@ -155,22 +191,35 @@ class EditorViewportAnchorStateTest {
   }
 
   @Test
-  fun `preferred selection rect becomes active again after direct scroll returns it inside guard`() {
+  fun `preferred selection rect becomes active again at the current two dimensional scroll`() {
     val state = EditorViewportAnchorState()
     val visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 300f))
-    val selectionGeometry = geometry(pointY = 200f, top = 190f, bottom = 210f)
-    state.attachSelection(identity, selectionGeometry, scrollY = 100f)
-    state.attachViewport(viewportIdentity, geometry(pointY = 500f), scrollY = 350f)
+    val selectionGeometry = geometry(pointX = 100f, pointY = 200f, top = 190f, bottom = 210f)
+    state.attachSelection(identity, selectionGeometry, scrollOffset = Offset(x = 20f, y = 100f))
+    state.attachViewport(
+      viewportIdentity,
+      geometry(pointX = 300f, pointY = 500f),
+      scrollOffset = Offset(x = 80f, y = 350f),
+    )
 
     assertTrue(
       state.tryReactivatePreferredSelection(
         geometry = selectionGeometry,
-        scrollY = 120f,
+        scrollOffset = Offset(x = 120f, y = 120f),
         visibleArea = visibleArea,
       )
     )
     assertEquals(identity, state.identity)
+    assertEquals(-20f, state.pointAttachmentX)
     assertEquals(80f, state.pointAttachmentY)
+    assertEquals(
+      Offset(x = 160f, y = 120f),
+      state.publicationScroll(
+        geometry = selectionGeometry.copy(pointX = 140f),
+        currentScrollOffset = Offset(x = 120f, y = 120f),
+        maximumScrollOffset = Offset(x = 500f, y = 500f),
+      ),
+    )
   }
 
   @Test
@@ -180,21 +229,25 @@ class EditorViewportAnchorStateTest {
     state.attachSelection(
       identity,
       geometry(pointY = 200f, top = 0f, bottom = 1_000f),
-      scrollY = 100f,
+      scrollOffset = Offset(x = 0f, y = 100f),
     )
-    state.attachViewport(viewportIdentity, geometry(pointY = 500f), scrollY = 350f)
+    state.attachViewport(
+      viewportIdentity,
+      geometry(pointY = 500f),
+      scrollOffset = Offset(x = 0f, y = 350f),
+    )
 
     assertFalse(
       state.tryReactivatePreferredSelection(
         geometry = geometry(pointY = 200f, top = 0f, bottom = 1_000f),
-        scrollY = 100f,
+        scrollOffset = Offset(x = 0f, y = 100f),
         visibleArea = visibleArea,
       )
     )
     assertFalse(
       state.tryReactivatePreferredSelection(
         geometry = geometry(pointY = 200f),
-        scrollY = 100f,
+        scrollOffset = Offset(x = 0f, y = 100f),
         visibleArea = visibleArea,
       )
     )
@@ -204,7 +257,11 @@ class EditorViewportAnchorStateTest {
   @Test
   fun `selection adoption compares stable anchor identity`() {
     val state = EditorViewportAnchorState()
-    state.attachSelection(identity, geometry(pointY = 200f), scrollY = 100f)
+    state.attachSelection(
+      identity,
+      geometry(pointY = 200f),
+      scrollOffset = Offset(x = 0f, y = 100f),
+    )
 
     assertFalse(state.needsSelectionAdoption(identity))
     assertTrue(state.needsSelectionAdoption(viewportIdentity))
@@ -214,12 +271,16 @@ class EditorViewportAnchorStateTest {
   fun `preferred selection can change without replacing the active viewport anchor`() {
     val state = EditorViewportAnchorState()
     val visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 300f))
-    state.attachViewport(viewportIdentity, geometry(pointY = 500f), scrollY = 350f)
+    state.attachViewport(
+      viewportIdentity,
+      geometry(pointY = 500f),
+      scrollOffset = Offset(x = 0f, y = 350f),
+    )
 
     state.adoptSelection(
       identity = identity,
       geometry = geometry(pointY = 200f),
-      scrollY = 350f,
+      scrollOffset = Offset(x = 0f, y = 350f),
       visibleArea = visibleArea,
       preserveActiveAnchor = true,
     )
@@ -229,12 +290,14 @@ class EditorViewportAnchorStateTest {
   }
 
   private fun geometry(
+    pointX: Float = 0f,
     pointY: Float,
     top: Float? = null,
     bottom: Float? = null,
   ): EditorViewportAnchorGeometry =
     EditorViewportAnchorGeometry(
       pointY = pointY,
+      pointX = pointX,
       rect = if (top != null && bottom != null) VerticalSpan(top, bottom) else null,
     )
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
@@ -111,7 +111,7 @@ class EditorSurfacePreparationTest {
           identity = identity,
           geometry =
             EditorViewportAnchorGeometry(pointY = 2_100.5f, rect = VerticalSpan(2_100f, 2_101f)),
-          scrollY = provisionalScroll,
+          scrollOffset = Offset(x = 0f, y = provisionalScroll),
           revealOrigin =
             EditorViewportAnchorRevealOrigin(scrollY = 0f, target = target, policy = policy),
         )
@@ -136,7 +136,7 @@ class EditorSurfacePreparationTest {
         publishedBundle = PublishedBundle(snapshot = provisionalFrame.state, frames = emptyMap()),
       )
 
-    assertEquals(expectedScroll, preparation?.anchorPublication?.scrollY)
+    assertEquals(expectedScroll, preparation?.anchorPublication?.scrollOffset?.y)
     assertEquals(
       preparation!!.contentOriginY + 2_100f,
       preparation.anchorPublication?.geometry?.rect?.top,
@@ -182,7 +182,7 @@ class EditorSurfacePreparationTest {
         attach(
           identity = identity,
           geometry = EditorViewportAnchorGeometry(pointY = 200f, rect = VerticalSpan(190f, 210f)),
-          scrollY = 100f,
+          scrollOffset = Offset(x = 0f, y = 100f),
         )
       }
     val corrected =
@@ -270,7 +270,10 @@ class EditorSurfacePreparationTest {
       val resolved = requireNotNull(preparation)
       assertEquals(setOf(0), resolved.requiredPages)
       assertEquals(
-        EditorViewportAnchorPublication.Ready(scrollY = resolved.maximumScrollY, geometry = null),
+        EditorViewportAnchorPublication.Ready(
+          scrollOffset = Offset(x = 0f, y = resolved.maximumScrollY),
+          geometry = null,
+        ),
         resolved.anchorPublication,
       )
     }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.EditorViewportAnchor
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.PublishedBundle
 import co.typie.editor.VerticalSpan
@@ -133,7 +134,11 @@ class EditorViewportAnchorReconcilerTest {
       val candidateFrame = initialFrame.copy(state = initialFrame.state.copy(version = 2L))
       val anchorState =
         EditorViewportAnchorState().apply {
-          attachSelection(selectionAnchor, anchorGeometry(240f), scrollY = 100f)
+          attachSelection(
+            selectionAnchor,
+            anchorGeometry(240f),
+            scrollOffset = Offset(x = 0f, y = 100f),
+          )
         }
       val viewportState = viewportState(scrollY = 350f)
       val editor = editor(selectionY = 200f)
@@ -177,11 +182,11 @@ class EditorViewportAnchorReconcilerTest {
         )
           as EditorViewportAnchorPublication.Ready
 
-      assertEquals(349.75f, publication.scrollY)
+      assertEquals(349.75f, publication.scrollOffset.y)
     }
 
   @Test
-  fun `scroll observed during transform is reconciled after the transform ends`() = runTest {
+  fun `transform-owned scroll does not reactivate a visible preferred selection`() = runTest {
     val visibleArea = visibleArea()
     val frame = frame(visibleArea)
     val anchorState = EditorViewportAnchorState()
@@ -193,15 +198,87 @@ class EditorViewportAnchorReconcilerTest {
 
     viewportState.beginTransform()
     viewportState.scrollToTransformTarget(
-      offset = Offset(x = 0f, y = 350f),
+      offset = Offset(x = 0f, y = 120f),
       retainUntilMeasuredBounds = false,
     )
+    attachViewportZoomAnchor(
+      editor = editor,
+      anchorState = anchorState,
+      revision = frame.state.version,
+      anchor = EditorViewportAnchor(page = 0, x = 0f, y = 500f),
+      displayPosition = Offset(x = 0f, y = 500f),
+      scrollOffset = viewportState.scrollOffset,
+      contentOriginY = 0f,
+    )
+    assertEquals(viewportAnchor, anchorState.identity)
     reconcile(editor, anchorState, frame, viewportState, visibleArea)
     viewportState.endTransform()
     reconcile(editor, anchorState, frame, viewportState, visibleArea)
 
     assertEquals(viewportAnchor, anchorState.identity)
   }
+
+  @Test
+  fun `repeated zoom attachments reuse the captured identity until their stable input changes`() =
+    runTest {
+      val anchorState = EditorViewportAnchorState()
+      var firstEditorCaptures = 0
+      val firstEditor =
+        Editor(
+          FakeFfiEditor(
+            captureViewportAnchorAtProvider = { _, _ ->
+              firstEditorCaptures += 1
+              CapturedViewportAnchor(identity = viewportAnchor, geometry = selectionGeometry(500f))
+            }
+          ),
+          this,
+          StandardTestDispatcher(testScheduler),
+        )
+      var secondEditorCaptures = 0
+      val secondEditor =
+        Editor(
+          FakeFfiEditor(
+            captureViewportAnchorAtProvider = { _, _ ->
+              secondEditorCaptures += 1
+              CapturedViewportAnchor(identity = viewportAnchor, geometry = selectionGeometry(500f))
+            }
+          ),
+          this,
+          StandardTestDispatcher(testScheduler),
+        )
+      val anchor = EditorViewportAnchor(page = 0, x = 10f, y = 20f)
+
+      fun attach(
+        editor: Editor = firstEditor,
+        revision: Long = 1L,
+        point: EditorViewportAnchor = anchor,
+        displayPosition: Offset = Offset(x = 100f, y = 200f),
+        scrollOffset: Offset = Offset.Zero,
+      ) {
+        attachViewportZoomAnchor(
+          editor = editor,
+          anchorState = anchorState,
+          revision = revision,
+          anchor = point,
+          displayPosition = displayPosition,
+          scrollOffset = scrollOffset,
+          contentOriginY = 0f,
+        )
+      }
+
+      attach()
+      attach(displayPosition = Offset(x = 120f, y = 230f), scrollOffset = Offset(x = 10f, y = 20f))
+      assertEquals(1, firstEditorCaptures)
+      assertEquals(110f, anchorState.pointAttachmentX)
+      assertEquals(210f, anchorState.pointAttachmentY)
+
+      attach(revision = 2L)
+      attach(revision = 2L, point = anchor.copy(x = 11f))
+      attach(editor = secondEditor, revision = 2L, point = anchor.copy(x = 11f))
+
+      assertEquals(3, firstEditorCaptures)
+      assertEquals(1, secondEditorCaptures)
+    }
 
   @Test
   fun `publication proceeds when a live anchor has no candidate geometry`() = runTest {
@@ -212,7 +289,7 @@ class EditorViewportAnchorReconcilerTest {
         attach(
           identity = selectionAnchor,
           geometry = co.typie.editor.viewport.EditorViewportAnchorGeometry(pointY = 200f),
-          scrollY = 100f,
+          scrollOffset = Offset(x = 0f, y = 100f),
         )
       }
     val captured =
@@ -248,7 +325,10 @@ class EditorViewportAnchorReconcilerTest {
       )
 
     assertEquals(
-      EditorViewportAnchorPublication.Ready(scrollY = 100f, geometry = null),
+      EditorViewportAnchorPublication.Ready(
+        scrollOffset = Offset(x = 0f, y = 100f),
+        geometry = null,
+      ),
       publication,
     )
   }
@@ -392,7 +472,7 @@ class EditorViewportAnchorReconcilerTest {
       assertEquals(Offset(x = 0f, y = 100f), viewportState.scrollOffset)
 
       (publication as EditorViewportAnchorPublication.Ready).geometry?.let { geometry ->
-        anchorState.acceptGeometry(geometry, viewportState.scrollOffset.y)
+        anchorState.acceptGeometry(geometry, viewportState.scrollOffset)
       }
       reconcile(editor, anchorState, movedFrame, viewportState, visibleArea)
 
@@ -465,7 +545,11 @@ class EditorViewportAnchorReconcilerTest {
       initialFrame.copy(state = initialFrame.state.copy(version = 2L, selection = null))
     val anchorState =
       EditorViewportAnchorState().apply {
-        attachSelection(selectionAnchor, anchorGeometry(200f), scrollY = 100f)
+        attachSelection(
+          selectionAnchor,
+          anchorGeometry(200f),
+          scrollOffset = Offset(x = 0f, y = 100f),
+        )
       }
     val editor =
       Editor(
@@ -499,7 +583,7 @@ class EditorViewportAnchorReconcilerTest {
 
     assertEquals(viewportAnchor, anchorState.identity)
     assertEquals(null, anchorState.preferredSelectionIdentity)
-    assertEquals(100f, (publication as EditorViewportAnchorPublication.Ready).scrollY)
+    assertEquals(100f, (publication as EditorViewportAnchorPublication.Ready).scrollOffset.y)
   }
 
   @Test
@@ -521,7 +605,11 @@ class EditorViewportAnchorReconcilerTest {
     val candidateFrame = initialFrame.copy(state = initialFrame.state.copy(version = 2L))
     val anchorState =
       EditorViewportAnchorState().apply {
-        attachSelection(selectionAnchor, anchorGeometry(200f), scrollY = 100f)
+        attachSelection(
+          selectionAnchor,
+          anchorGeometry(200f),
+          scrollOffset = Offset(x = 0f, y = 100f),
+        )
       }
     val editor =
       Editor(

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopFixture.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopFixture.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 @OptIn(ExperimentalTestApi::class)
 internal class FrameSyncFixture(
   continuous: Boolean = false,
+  continuousMaxWidth: Int = PageWidth.toInt(),
   initialDoc: PlainDoc? = null,
   viewportHeight: Float = ViewportHeight,
 ) {
@@ -54,7 +55,7 @@ internal class FrameSyncFixture(
   val scope = CoroutineScope(SupervisorJob() + continuationDispatcher)
   val layoutSpec: EditorDocumentLayoutSpec =
     if (continuous) {
-      EditorDocumentLayoutSpec.Continuous(maxWidth = PageWidth)
+      EditorDocumentLayoutSpec.Continuous(maxWidth = continuousMaxWidth.toFloat())
     } else {
       EditorDocumentLayoutSpec.Paginated(
         pageWidth = PageWidth,
@@ -69,6 +70,7 @@ internal class FrameSyncFixture(
   val autoScrollPolicy =
     resolveEditorAutoScrollPolicy(visibleArea = visibleArea, baseBottomSpace = PageMargin)
   val viewportState = EditorViewportState()
+  val zoomController = EditorZoomController()
   val uiState = EditorUiState()
   val bringIntoViewRequests = EditorBringIntoViewRequests()
   private var drawSequence = 0L
@@ -86,7 +88,12 @@ internal class FrameSyncFixture(
       kotlinx.coroutines.runBlocking {
         Editor.createFromDoc(
           doc =
-            initialDoc ?: if (continuous) emptyContinuousDocument() else emptyPaginatedDocument(),
+            initialDoc
+              ?: if (continuous) {
+                emptyContinuousDocument(maxWidth = continuousMaxWidth)
+              } else {
+                emptyPaginatedDocument()
+              },
           viewport = Viewport(ViewportWidth, viewportHeight, 1.0),
           scope = scope,
           dispatcher = Dispatchers.Default.limitedParallelism(1),
@@ -362,8 +369,8 @@ private fun emptyPaginatedDocument(): PlainDoc =
     )
   )
 
-private fun emptyContinuousDocument(): PlainDoc =
-  emptyDocument(LayoutMode.Continuous(maxWidth = PageWidth.toInt()))
+private fun emptyContinuousDocument(maxWidth: Int = PageWidth.toInt()): PlainDoc =
+  emptyDocument(LayoutMode.Continuous(maxWidth = maxWidth))
 
 internal fun continuousDocumentWithOffscreenTable(): PlainDoc {
   val document = emptyContinuousDocument()

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
@@ -262,6 +262,43 @@ class EditorFrameSyncDesktopTest {
   }
 
   @Test
+  fun continuousZoomOutReflowsAtTheCommittedLogicalViewportWidth() = runComposeUiTest {
+    val fixture = FrameSyncFixture(continuous = true, continuousMaxWidth = 600)
+    fixture.zoomController.syncLayout(
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = ViewportWidth,
+    )
+
+    try {
+      setFrameSyncContent(fixture)
+      waitUntil(timeoutMillis = 10_000) {
+        fixture.editor.publishedBundle?.frames?.isNotEmpty() == true
+      }
+      assertEquals(ViewportWidth, fixture.editor.appliedState.pageSizes.single().width, 0.01f)
+
+      runOnIdle {
+        fixture.zoomController.setDisplayZoom(
+          zoom = 0.75f,
+          layoutSpec = fixture.layoutSpec,
+          viewportWidth = ViewportWidth,
+        )
+        fixture.zoomController.commitRenderZoom()
+      }
+
+      waitUntil(timeoutMillis = 1_000) {
+        fixture.editor.appliedState.pageSizes.single().width > ViewportWidth
+      }
+      assertEquals(
+        ViewportWidth / 0.75f,
+        fixture.editor.appliedState.pageSizes.single().width,
+        0.01f,
+      )
+    } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
   fun firstVisibleContinuousSelectionDrawsHandlesWithoutVirtualizationReset() = runComposeUiTest {
     val fixture =
       FrameSyncFixture(continuous = true, initialDoc = continuousDocumentWithOffscreenTable())
@@ -1382,7 +1419,7 @@ class EditorFrameSyncDesktopTest {
       ) {
         val interactionScope = remember { EditorInteractionScope(fixture.scope) }
         val scrollGestureLockState = remember { ScrollGestureLockState() }
-        val zoomController = remember { EditorZoomController() }
+        val zoomController = fixture.zoomController
         val publishedBundle = fixture.editor.publishedBundle
         val publishedState = publishedBundle?.snapshot ?: EditorState.Initial
         val geometry =

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/navigation/NavigationStackDesktopTest.kt
@@ -78,12 +78,19 @@ class NavigationStackDesktopTest {
       ) { route ->
         Box(Modifier.fillMaxSize().padding(horizontal = 12.dp)) {
           Box(Modifier.fillMaxSize().testTag("surface-$route"))
+          NavigationForeground(sharePointerInputWithSiblings = true) {
+            Box(Modifier.fillMaxSize().testTag("shared-foreground-$route"))
+          }
           NavigationForeground { Box(Modifier.fillMaxSize().testTag("foreground-$route")) }
         }
       }
     }
     waitForIdle()
 
+    assertEquals(
+      onNodeWithTag("surface-${Route.Home}").fetchSemanticsNode().boundsInRoot,
+      onNodeWithTag("shared-foreground-${Route.Home}").fetchSemanticsNode().boundsInRoot,
+    )
     assertEquals(
       onNodeWithTag("surface-${Route.Home}").fetchSemanticsNode().boundsInRoot,
       onNodeWithTag("foreground-${Route.Home}").fetchSemanticsNode().boundsInRoot,

--- a/apps/website/src/lib/drag-scroll.test.ts
+++ b/apps/website/src/lib/drag-scroll.test.ts
@@ -21,6 +21,7 @@ const createViewport = (rect: ViewportRect = DEFAULT_VIEWPORT_RECT) => {
     getRect: () => rect,
     getScrollTop: () => scrollTop,
     getScrollLeft: () => scrollLeft,
+    getScrollWidth: () => 1000,
     getScrollHeight: () => 1000,
     scrollBy: (x, y) => {
       scrollLeft += x;

--- a/apps/website/src/lib/editor-ffi/components/DocumentEmbeds.svelte
+++ b/apps/website/src/lib/editor-ffi/components/DocumentEmbeds.svelte
@@ -17,7 +17,7 @@
   const mountedNodes = new SvelteSet<string>();
   const layoutMode = $derived(editor.rootAttrs?.layout_mode);
   const isPaginated = $derived(layoutMode?.type === 'paginated');
-  const displayZoom = $derived(isPaginated ? editor.displayZoom : 1);
+  const displayZoom = $derived(editor.safeDisplayZoom());
   const pageSpans = $derived(
     resolvePageSpans(editor.pageSizes, {
       displayZoom,
@@ -72,8 +72,8 @@
         <div
           style:width={`${cssWidth}px`}
           style:height={`${cssHeight}px`}
-          style:transform={isPaginated && displayZoom !== 1 ? `scale(${displayZoom})` : undefined}
-          style:transform-origin={isPaginated && displayZoom !== 1 ? 'top left' : undefined}
+          style:transform={displayZoom === 1 ? undefined : `scale(${displayZoom})`}
+          style:transform-origin={displayZoom === 1 ? undefined : 'top left'}
           class={css({ position: 'relative' })}
         >
           <ExternalElement {element} />

--- a/apps/website/src/lib/editor-ffi/components/DocumentOverlayLayer.svelte
+++ b/apps/website/src/lib/editor-ffi/components/DocumentOverlayLayer.svelte
@@ -6,18 +6,23 @@
 
   type PageAnchor = {
     top: number;
-    width: number;
-    height: number;
+    slotWidth: number;
+    slotHeight: number;
+    logicalWidth: number;
+    logicalHeight: number;
   };
 
   const ctx = getEditorContext();
   const scaleFactor = $derived(ctx.editor?.scaleFactor ?? 1);
+  const displayZoom = $derived(ctx.editor?.safeDisplayZoom() ?? 1);
   const pageAnchors = $derived.by(() => {
     const pageSizes = ctx.editor?.pageSizes ?? [];
-    return resolvePageSpans(pageSizes, { scaleFactor }).map<PageAnchor>(({ page, top, bottom }) => ({
+    return resolvePageSpans(pageSizes, { scaleFactor, displayZoom }).map<PageAnchor>(({ page, top, bottom }) => ({
       top,
-      width: roundToScale(pageSizes[page].width, scaleFactor),
-      height: bottom - top,
+      slotWidth: roundToScale(pageSizes[page].width * displayZoom, scaleFactor),
+      slotHeight: bottom - top,
+      logicalWidth: roundToScale(pageSizes[page].width, scaleFactor),
+      logicalHeight: roundToScale(pageSizes[page].height, scaleFactor),
     }));
   });
   const tableOverlays = $derived.by(() => {
@@ -40,11 +45,19 @@
       {#if anchor}
         <div
           style:top={`${anchor.top}px`}
-          style:width={`${anchor.width}px`}
-          style:height={`${anchor.height}px`}
+          style:width={`${anchor.slotWidth}px`}
+          style:height={`${anchor.slotHeight}px`}
           class={css({ position: 'absolute', left: '0', right: '0', marginX: 'auto', overflow: 'visible', pointerEvents: 'none' })}
         >
-          <TableOverlay {overlay} readOnly={ctx.editor.readOnly} />
+          <div
+            style:width={`${anchor.logicalWidth}px`}
+            style:height={`${anchor.logicalHeight}px`}
+            style:transform={displayZoom === 1 ? undefined : `scale(${displayZoom})`}
+            style:transform-origin={displayZoom === 1 ? undefined : 'top left'}
+            class={css({ position: 'relative' })}
+          >
+            <TableOverlay {overlay} readOnly={ctx.editor.readOnly} />
+          </div>
         </div>
       {/if}
     {/each}

--- a/apps/website/src/lib/editor-ffi/components/LineHighlight.svelte
+++ b/apps/website/src/lib/editor-ffi/components/LineHighlight.svelte
@@ -2,7 +2,7 @@
   import { css } from '@typie/styled-system/css';
   import { getAppContext } from '@typie/ui/context';
   import { getEditorContext } from '../editor.svelte';
-  import { presentedPageElement } from '../geometry';
+  import { presentedPageElement, resolvePageSpans } from '../geometry';
 
   const { editor } = getEditorContext();
   const app = getAppContext();
@@ -16,12 +16,22 @@
   const lineHighlightEnabled = $derived(app?.preference.current.lineHighlightEnabled ?? false);
 
   const isPaginated = $derived(editor?.rootAttrs?.layout_mode.type === 'paginated');
+  const displayZoom = $derived(editor?.safeDisplayZoom() ?? 1);
 
-  const container = $derived(cursor && editor ? presentedPageElement(editor, cursor.page_idx) : undefined);
+  const container = $derived.by(() => {
+    if (!cursor || !editor) return;
+    if (isPaginated) return presentedPageElement(editor, cursor.page_idx);
+    return editor.extensionAreaEl;
+  });
 
-  const top = $derived(cursor?.line.y ?? 0);
+  const top = $derived.by(() => {
+    if (!cursor || !editor) return 0;
+    if (isPaginated) return cursor.line.y;
+    const pageTop = resolvePageSpans(editor.pageSizes, { displayZoom })[cursor.page_idx]?.top ?? 0;
+    return pageTop + cursor.line.y * displayZoom;
+  });
 
-  const height = $derived(cursor?.line.height ?? 0);
+  const height = $derived((cursor?.line.height ?? 0) * (isPaginated ? 1 : displayZoom));
 
   let element = $state<HTMLDivElement>();
 
@@ -38,11 +48,8 @@
     style:display={show ? 'block' : 'none'}
     style:top={`${top}px`}
     style:height={`${height}px`}
-    style:box-shadow={isPaginated ? undefined : '0 0 0 100vmax currentColor'}
-    style:clip-path={isPaginated ? undefined : 'inset(0 -100vmax)'}
     class={css({
       position: 'absolute',
-      color: { base: 'text.default/4', _dark: 'text.default/10' },
       backgroundColor: { base: 'text.default/4', _dark: 'text.default/10' },
       insetX: '0',
       zIndex: '[-1]',

--- a/apps/website/src/lib/editor-ffi/components/Page.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Page.svelte
@@ -23,7 +23,7 @@
   const cssHeight = $derived(roundToScale(height, scaleFactor));
   const layoutMode = $derived(editor.rootAttrs?.layout_mode);
   const isPaginated = $derived(layoutMode?.type === 'paginated');
-  const displayZoom = $derived(isPaginated ? editor.displayZoom : 1);
+  const displayZoom = $derived(editor.safeDisplayZoom());
   const slotWidth = $derived(roundToScale(width * displayZoom, scaleFactor));
   const slotHeight = $derived(roundToScale(height * displayZoom, scaleFactor));
   const showCropMarker = $derived(layoutMode?.type === 'paginated' && !editor.readOnly);
@@ -46,9 +46,9 @@
   <div
     style:width={`${cssWidth}px`}
     style:height={`${cssHeight}px`}
-    style:transform={isPaginated && displayZoom !== 1 ? `scale(${displayZoom})` : undefined}
-    style:transform-origin={isPaginated && displayZoom !== 1 ? 'top left' : undefined}
-    style:will-change={isPaginated && displayZoom !== 1 ? 'transform' : undefined}
+    style:transform={displayZoom === 1 ? undefined : `scale(${displayZoom})`}
+    style:transform-origin={displayZoom === 1 ? undefined : 'top left'}
+    style:will-change={displayZoom === 1 ? undefined : 'transform'}
     class={css({
       position: 'relative',
       isolation: 'isolate',

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -26,6 +26,7 @@
   } from '../handlers/pointer';
   import { setupEditorScroll } from '../scroll.svelte';
   import { touchPanLock } from '../touch-pan-lock';
+  import { resolveContinuousLayoutViewportWidth, zoomDiffers } from '../zoom';
   import Caret from './Caret.svelte';
   import ContextMenu from './ContextMenu.svelte';
   import DocumentOverlayLayer from './DocumentOverlayLayer.svelte';
@@ -43,6 +44,7 @@
   import type { SystemStyleObject } from '@typie/styled-system/types';
   import type { Snippet } from 'svelte';
   import type { Editor_document$key } from '$mearie';
+  import type { DocumentZoomLayout } from '../zoom';
 
   type Props = {
     document$key: Editor_document$key;
@@ -172,7 +174,16 @@
   const isPaginated = $derived(layoutMode?.type === 'paginated');
   const layoutBackground = $derived(token(isPaginated ? 'colors.surface.subtle' : 'colors.surface.default'));
   const pageWidth = $derived(ctx.editor?.pageSizes[0]?.width ?? 0);
-  const displayZoom = $derived(isPaginated ? (ctx.editor?.displayZoom ?? 1) : 1);
+  const zoomLayout: DocumentZoomLayout | null = $derived.by(() => {
+    if (layoutMode?.type === 'continuous' && layoutMode.max_width > 0) {
+      return { type: 'continuous', maxWidth: layoutMode.max_width };
+    }
+    if (layoutMode?.type === 'paginated' && pageWidth > 0) {
+      return { type: 'paginated', pageWidth };
+    }
+    return null;
+  });
+  const displayZoom = $derived(zoomLayout ? (ctx.editor?.displayZoom ?? 1) : 1);
   const pageGap = $derived(PAGE_GAP * displayZoom);
   const editorMinWidth = $derived(isPaginated ? 'max-content' : `${CONTINUOUS_MIN_WIDTH}px`);
   const continuousMaxFrameWidth = $derived(
@@ -217,18 +228,29 @@
 
   let readyFired = false;
   let viewportEditor: (typeof ctx)['editor'];
+  let viewportRenderZoom = 1;
+  let viewportLayoutType: 'continuous' | 'paginated' | undefined;
 
   $effect(() => {
     const editor = ctx.editor;
     const width = clientWidth;
     const height = useWindowScroll ? windowViewportHeight : clientHeight;
     const viewportScaleFactor = scaleFactor;
-    const isContinuous = !isPaginated;
+    const isContinuous = layoutMode?.type === 'continuous';
+    const renderZoom = editor?.renderZoom ?? 1;
     if (!editor || !width || !height) return;
-    const effectiveWidth = isContinuous ? Math.max(CONTINUOUS_MIN_WIDTH, width) : width;
+    const physicalWidth = isContinuous ? Math.max(CONTINUOUS_MIN_WIDTH, width) : width;
+    const effectiveWidth = isContinuous
+      ? resolveContinuousLayoutViewportWidth({ viewportWidth: physicalWidth, committedZoom: renderZoom })
+      : physicalWidth;
 
     untrack(() => {
-      if (viewportEditor === editor) {
+      const committedLayoutChanged =
+        viewportEditor === editor &&
+        (viewportLayoutType !== layoutMode?.type || (isContinuous && zoomDiffers(viewportRenderZoom, renderZoom)));
+      viewportRenderZoom = renderZoom;
+      viewportLayoutType = layoutMode?.type;
+      if (viewportEditor === editor && !committedLayoutChanged) {
         editor.resizeViewport(effectiveWidth, height, viewportScaleFactor);
       } else {
         viewportEditor = editor;
@@ -366,12 +388,18 @@
     {/if}
 
     {#if ctx.editor}
-      <EditorZoom {active} editor={ctx.editor} {isPaginated} {pageWidth} viewportWidth={clientWidth ?? 0}>
+      <EditorZoom
+        {active}
+        attachViewportAnchor={(point) => ctx.scroll?.attachViewportAnchorAt(point)}
+        editor={ctx.editor}
+        layout={zoomLayout}
+        viewportWidth={clientWidth ?? 0}
+      >
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
           bind:this={ctx.editor.extensionAreaEl}
           style:cursor
-          style:min-width={editorMinWidth}
+          style:min-width="max-content"
           style:padding-left={`${contentInsetLeft}px`}
           style:padding-right={`${contentInsetRight}px`}
           style:padding-bottom={viewer ? '0px' : `${ctx.scroll?.bottomPadding ?? 0}px`}
@@ -382,6 +410,7 @@
               flexDirection: 'column',
               alignItems: 'center',
               flexGrow: '1',
+              isolation: 'isolate',
               width: 'full',
               userSelect: 'none',
             },
@@ -437,6 +466,7 @@
                 rowGap: 'var(--page-gap)',
               }),
             })}
+            data-editor-document-track
           >
             <EditorPages editor={ctx.editor} {surfaceHost} />
 

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
@@ -1,9 +1,9 @@
 import { tick } from 'svelte';
 import {
+  clampDocumentLayoutZoom,
   clampDocumentZoom,
-  clampPaginatedZoom,
-  computeInitialPaginatedZoom,
-  computePaginatedZoomBounds,
+  computeDocumentZoomBounds,
+  computeInitialDocumentZoom,
   RENDER_ZOOM_DEBOUNCE_MS,
   renderZoomForDisplay,
   zoomDiffers,
@@ -11,6 +11,7 @@ import {
 } from '$lib/editor-ffi/zoom';
 import type { ScrollViewport } from '@typie/ui/utils';
 import type { Editor } from '$lib/editor-ffi/editor.svelte';
+import type { DocumentZoomLayout } from '$lib/editor-ffi/zoom';
 
 type ZoomAnchor = {
   page: number;
@@ -22,17 +23,17 @@ type ZoomAnchor = {
 
 type EditorZoomControllerOptions = {
   editor: Editor;
-  isPaginated: () => boolean;
-  pageWidth: () => number;
+  layout: () => DocumentZoomLayout | null;
   viewportWidth: () => number;
   getScrollViewport: () => ScrollViewport | null | undefined;
+  attachViewportAnchor?: (point: Pick<ZoomAnchor, 'page' | 'x' | 'y'>) => void;
 };
 
 export class EditorZoomController {
   static readonly WHEEL_RAW_ZOOM_RESET_MS = 150;
   static readonly KEYBOARD_ZOOM_STEP = 0.1;
 
-  #initializedPaginatedPageWidth: number | null = null;
+  #initializedLayoutKey: string | null = null;
   #renderZoomTimer: ReturnType<typeof setTimeout> | null = null;
   #wheelRawZoomResetTimer: ReturnType<typeof setTimeout> | null = null;
   #wheelRawZoom: number | null = null;
@@ -46,11 +47,7 @@ export class EditorZoomController {
   }
 
   async #stepZoomByKeyboard(delta: number): Promise<void> {
-    const isPaginated = this.#options.isPaginated();
-    const pageWidth = this.#options.pageWidth();
-    if (!isPaginated || pageWidth <= 0) {
-      return;
-    }
+    if (!this.#options.layout()) return;
     const anchor = this.#createZoomAnchorFromViewportCenter();
     const nextZoom = this.displayZoom + delta;
     await this.#setZoomWithAnchor(nextZoom, anchor);
@@ -143,6 +140,7 @@ export class EditorZoomController {
     if (Math.abs(deltaX) > 0.5 || Math.abs(deltaY) > 0.5) {
       viewport.scrollBy(deltaX, deltaY);
     }
+    this.#options.attachViewportAnchor?.(anchor);
   }
 
   destroy(): void {
@@ -158,9 +156,13 @@ export class EditorZoomController {
       this.#resetWheelRawZoom();
     }
 
-    const isPaginated = this.#options.isPaginated();
-    const pageWidth = this.#options.pageWidth();
-    if (!isPaginated || pageWidth <= 0) {
+    if (this.#renderZoomTimer) {
+      clearTimeout(this.#renderZoomTimer);
+      this.#renderZoomTimer = null;
+    }
+
+    const layout = this.#options.layout();
+    if (!layout) {
       if (zoomDiffers(this.displayZoom, 1)) {
         this.displayZoom = 1;
       }
@@ -170,21 +172,16 @@ export class EditorZoomController {
       return;
     }
 
-    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : pageWidth;
-    const clamped = clampPaginatedZoom({
+    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
+    const clamped = clampDocumentLayoutZoom({
       zoom: nextZoom,
-      pageWidth,
+      layout,
       viewportWidth,
     });
     const nextRenderZoom = renderZoomForDisplay(clamped);
 
     if (zoomDiffers(this.displayZoom, clamped)) {
       this.displayZoom = clamped;
-    }
-
-    if (this.#renderZoomTimer) {
-      clearTimeout(this.#renderZoomTimer);
-      this.#renderZoomTimer = null;
     }
 
     if (commitRender) {
@@ -196,7 +193,7 @@ export class EditorZoomController {
 
     this.#renderZoomTimer = setTimeout(() => {
       this.#renderZoomTimer = null;
-      if (!this.#options.isPaginated()) {
+      if (!this.#options.layout()) {
         if (zoomDiffers(this.renderZoom, 1)) {
           this.renderZoom = 1;
         }
@@ -210,42 +207,34 @@ export class EditorZoomController {
   }
 
   syncInitialZoom(): void {
-    const isPaginated = this.#options.isPaginated();
-    const pageWidth = this.#options.pageWidth();
+    const layout = this.#options.layout();
     const viewportWidth = this.#options.viewportWidth();
 
-    if (!isPaginated) {
-      this.#initializedPaginatedPageWidth = null;
+    if (!layout) {
+      this.#initializedLayoutKey = null;
       this.setZoom(1, { commitRender: true });
       return;
     }
 
-    if (pageWidth <= 0 || viewportWidth <= 0) {
-      return;
-    }
+    if (viewportWidth <= 0) return;
 
-    const shouldApplyInitialZoom =
-      this.#initializedPaginatedPageWidth === null || zoomDiffers(this.#initializedPaginatedPageWidth, pageWidth);
-    if (!shouldApplyInitialZoom) {
-      return;
-    }
+    const width = layout.type === 'continuous' ? layout.maxWidth : layout.pageWidth;
+    const key = `${layout.type}:${width}`;
+    if (this.#initializedLayoutKey === key) return;
 
-    this.#initializedPaginatedPageWidth = pageWidth;
-    const initialZoom = computeInitialPaginatedZoom(pageWidth, viewportWidth);
+    this.#initializedLayoutKey = key;
+    const initialZoom = computeInitialDocumentZoom(layout, viewportWidth);
     this.setZoom(initialZoom, { commitRender: true });
   }
 
   clampCurrentZoomToBounds(): void {
-    const isPaginated = this.#options.isPaginated();
-    const pageWidth = this.#options.pageWidth();
-    if (!isPaginated || pageWidth <= 0) {
-      return;
-    }
+    const layout = this.#options.layout();
+    if (!layout) return;
 
-    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : pageWidth;
-    const clamped = clampPaginatedZoom({
+    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
+    const clamped = clampDocumentLayoutZoom({
       zoom: this.displayZoom,
-      pageWidth,
+      layout,
       viewportWidth,
     });
     if (zoomDiffers(clamped, this.displayZoom)) {
@@ -254,11 +243,8 @@ export class EditorZoomController {
   }
 
   async handleWheel(event: WheelEvent): Promise<void> {
-    const isPaginated = this.#options.isPaginated();
-    const pageWidth = this.#options.pageWidth();
-    if (!isPaginated || pageWidth <= 0) {
-      return;
-    }
+    const layout = this.#options.layout();
+    if (!layout) return;
 
     const zoomDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ? event.deltaY : event.deltaX;
     if (zoomDelta === 0) {
@@ -274,15 +260,15 @@ export class EditorZoomController {
     }
     this.#scheduleWheelRawZoomReset();
 
-    const bounds = computePaginatedZoomBounds(pageWidth);
+    const bounds = computeDocumentZoomBounds(layout);
     const wheelBaseZoom = this.#wheelRawZoom ?? this.displayZoom;
     const nextRawZoom = clampDocumentZoom(wheelBaseZoom * Math.exp(-zoomDelta / 240), bounds);
     this.#wheelRawZoom = nextRawZoom;
 
-    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : pageWidth;
-    const nextZoom = clampPaginatedZoom({
+    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
+    const nextZoom = clampDocumentLayoutZoom({
       zoom: nextRawZoom,
-      pageWidth,
+      layout,
       viewportWidth,
     });
     if (zoomEquals(nextZoom, this.displayZoom)) {
@@ -302,23 +288,19 @@ export class EditorZoomController {
   }
 
   async resetByKeyboard(): Promise<void> {
-    const isPaginated = this.#options.isPaginated();
-    const pageWidth = this.#options.pageWidth();
-    if (!isPaginated || pageWidth <= 0) {
-      return;
-    }
+    if (!this.#options.layout()) return;
     const anchor = this.#createZoomAnchorFromViewportCenter();
     await this.#setZoomWithAnchor(1, anchor);
   }
 
   async zoomToClientPoint(nextZoom: number, clientX: number, clientY: number): Promise<void> {
-    const isPaginated = this.#options.isPaginated();
-    const pageWidth = this.#options.pageWidth();
-    if (!isPaginated || pageWidth <= 0) {
-      return;
-    }
+    if (!this.#options.layout()) return;
 
     const anchor = this.#createZoomAnchorFromClient(clientX, clientY);
     await this.#setZoomWithAnchor(nextZoom, anchor);
+  }
+
+  commitRenderZoom(): void {
+    this.setZoom(this.displayZoom, { commitRender: true });
   }
 }

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EditorZoomController } from './editor-zoom.svelte';
 import type { Editor } from '$lib/editor-ffi/editor.svelte';
+import type { DocumentZoomLayout } from '$lib/editor-ffi/zoom';
 
 type WheelEventDouble = WheelEvent & {
   preventDefault: ReturnType<typeof vi.fn>;
 };
 
 const controllers: EditorZoomController[] = [];
+const defaultLayout: DocumentZoomLayout = { type: 'paginated', pageWidth: 1000 };
 
-const createController = (): EditorZoomController => {
+const createController = (layout: DocumentZoomLayout = defaultLayout): EditorZoomController => {
   const editor = {
     clientToLocal: vi.fn(() => null),
     pageSizes: [],
@@ -16,14 +18,50 @@ const createController = (): EditorZoomController => {
   } as unknown as Editor;
   const controller = new EditorZoomController({
     editor,
-    isPaginated: () => true,
-    pageWidth: () => 1000,
+    layout: () => layout,
     viewportWidth: () => 1000,
     getScrollViewport: () => null,
   });
   controllers.push(controller);
   return controller;
 };
+
+describe('EditorZoomController continuous timing', () => {
+  it('starts continuous layout at unit zoom', () => {
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+
+    controller.syncInitialZoom();
+
+    expect(controller.displayZoom).toBe(1);
+    expect(controller.renderZoom).toBe(1);
+  });
+
+  it('commits continuous render zoom only at the existing debounce boundary', () => {
+    vi.useFakeTimers();
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+
+    controller.setZoom(0.8);
+    expect(controller.displayZoom).toBe(0.8);
+    expect(controller.renderZoom).toBe(1);
+
+    vi.advanceTimersByTime(119);
+    expect(controller.renderZoom).toBe(1);
+
+    vi.advanceTimersByTime(1);
+    expect(controller.renderZoom).toBe(0.8);
+  });
+
+  it('commits continuous render zoom immediately at gesture end', () => {
+    vi.useFakeTimers();
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+
+    controller.setZoom(0.8);
+    controller.commitRenderZoom();
+
+    expect(controller.renderZoom).toBe(0.8);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
 
 const wheelEvent = ({
   metaKey = false,
@@ -193,6 +231,16 @@ describe('EditorZoomController.handleWheel', () => {
     await controller.handleWheel(event);
 
     expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(controller.displayZoom).toBeGreaterThan(1);
+  });
+
+  it('admits modified wheel zoom in continuous layout', async () => {
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+    const event = wheelEvent({ ctrlKey: true });
+
+    await controller.handleWheel(event);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
     expect(controller.displayZoom).toBeGreaterThan(1);
   });
 });

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
@@ -5,13 +5,14 @@
   import ZoomOverlay from './ZoomOverlay.svelte';
   import type { Snippet } from 'svelte';
   import type { Editor } from '$lib/editor-ffi/editor.svelte';
+  import type { DocumentZoomLayout } from '$lib/editor-ffi/zoom';
 
   type Props = {
     editor: Editor;
     active?: boolean;
-    isPaginated: boolean;
-    pageWidth: number;
+    layout: DocumentZoomLayout | null;
     viewportWidth: number;
+    attachViewportAnchor?: (point: { page: number; x: number; y: number }) => void;
     children?: Snippet;
   };
 
@@ -26,23 +27,24 @@
     clientY: number;
   };
 
-  let { editor, active = true, isPaginated, pageWidth, viewportWidth, children }: Props = $props();
+  let { editor, active = true, layout, viewportWidth, attachViewportAnchor, children }: Props = $props();
 
   let pinchSession = $state<PinchSession | null>(null);
-  let pinchUpdateInFlight = $state(false);
   let pinchQueuedUpdate = $state<PinchUpdate | null>(null);
+  let pinchFlushPromise: Promise<void> | null = null;
   const scrollContainer = $derived(editor.scrollContainerEl);
 
   const zoom = new EditorZoomController({
     editor,
-    isPaginated: () => isPaginated,
-    pageWidth: () => pageWidth,
+    layout: () => layout,
     viewportWidth: () => viewportWidth,
     getScrollViewport: () => editor.scrollViewport,
+    attachViewportAnchor: (point) => attachViewportAnchor?.(point),
   });
 
-  const displayZoom = $derived(isPaginated ? zoom.displayZoom : 1);
-  const renderZoom = $derived(isPaginated ? zoom.renderZoom : 1);
+  const zoomEnabled = $derived(layout !== null);
+  const displayZoom = $derived(zoomEnabled ? zoom.displayZoom : 1);
+  const renderZoom = $derived(zoomEnabled ? zoom.renderZoom : 1);
 
   $effect(() => {
     editor.displayZoom = displayZoom;
@@ -50,15 +52,13 @@
   });
 
   $effect(() => {
-    void isPaginated;
-    void pageWidth;
+    void layout;
     void viewportWidth;
     zoom.syncInitialZoom();
   });
 
   $effect(() => {
-    void isPaginated;
-    void pageWidth;
+    void layout;
     void viewportWidth;
     void zoom.displayZoom;
     zoom.clampCurrentZoomToBounds();
@@ -85,7 +85,7 @@
   };
 
   const handleBrowserZoomShortcut = (event: KeyboardEvent): void => {
-    if (!active || !isPaginated) {
+    if (!active || !zoomEnabled) {
       return;
     }
 
@@ -122,28 +122,26 @@
 
   function queuePinchUpdate(update: PinchUpdate): void {
     pinchQueuedUpdate = update;
-    void flushPinchUpdates();
+    pinchFlushPromise ??= flushPinchUpdates().finally(() => {
+      pinchFlushPromise = null;
+    });
   }
 
   async function flushPinchUpdates(): Promise<void> {
-    if (pinchUpdateInFlight) {
-      return;
-    }
-
-    pinchUpdateInFlight = true;
-    try {
-      while (pinchQueuedUpdate) {
-        const next = pinchQueuedUpdate;
-        pinchQueuedUpdate = null;
-        await zoom.zoomToClientPoint(next.zoom, next.clientX, next.clientY);
-      }
-    } finally {
-      pinchUpdateInFlight = false;
+    while (pinchQueuedUpdate) {
+      const next = pinchQueuedUpdate;
+      pinchQueuedUpdate = null;
+      await zoom.zoomToClientPoint(next.zoom, next.clientX, next.clientY);
     }
   }
 
+  async function commitPinchZoom(): Promise<void> {
+    await pinchFlushPromise;
+    zoom.commitRenderZoom();
+  }
+
   function tryStartPinch(touches: TouchList): boolean {
-    if (!isPaginated || touches.length !== 2) {
+    if (!zoomEnabled || touches.length !== 2) {
       return false;
     }
 
@@ -171,7 +169,7 @@
   }
 
   function handleTouchStartForPinch(event: TouchEvent): void {
-    if (pinchSession || !isPaginated || event.touches.length !== 2) {
+    if (pinchSession || !zoomEnabled || event.touches.length !== 2) {
       return;
     }
 
@@ -179,7 +177,7 @@
   }
 
   function handleTouchMoveForPinch(event: TouchEvent): void {
-    if (!isPaginated || event.touches.length !== 2) {
+    if (!zoomEnabled || event.touches.length !== 2) {
       return;
     }
 
@@ -212,6 +210,7 @@
   function handleTouchEndForPinch(event: TouchEvent): void {
     if (event.touches.length < 2) {
       pinchSession = null;
+      void commitPinchZoom();
       return;
     }
 
@@ -223,6 +222,7 @@
 
   function handleTouchCancelForPinch(): void {
     pinchSession = null;
+    void commitPinchZoom();
   }
 
   $effect(() => {
@@ -266,7 +266,7 @@
   });
 
   $effect(() => {
-    if (active && isPaginated) {
+    if (active && zoomEnabled) {
       return;
     }
 
@@ -281,4 +281,4 @@
   {@render children?.()}
 </div>
 
-<ZoomOverlay {displayZoom} {isPaginated} {scrollContainer} />
+<ZoomOverlay {displayZoom} enabled={zoomEnabled} {scrollContainer} />

--- a/apps/website/src/lib/editor-ffi/components/ui/ZoomOverlay.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/ZoomOverlay.svelte
@@ -3,7 +3,7 @@
   import { zoomDiffers } from '$lib/editor-ffi/zoom';
 
   type Props = {
-    isPaginated: boolean;
+    enabled: boolean;
     displayZoom: number;
     scrollContainer?: HTMLElement;
   };
@@ -11,12 +11,12 @@
   const ZOOM_OVERLAY_VISIBLE_MS = 1000;
   const ZOOM_OVERLAY_FADE_MS = 180;
 
-  let { isPaginated, displayZoom, scrollContainer }: Props = $props();
+  let { enabled, displayZoom, scrollContainer }: Props = $props();
 
   let visible = $state(false);
   let hideTimer: ReturnType<typeof setTimeout> | null = null;
   let lastZoom: number | null = null;
-  let wasPaginated = $state(false);
+  let wasEnabled = $state(false);
   let overlayLeft = $state(20);
   let overlayBottom = $state(20);
 
@@ -32,15 +32,15 @@
   }
 
   $effect(() => {
-    const enteredPaginated = isPaginated && !wasPaginated;
-    wasPaginated = isPaginated;
+    const entered = enabled && !wasEnabled;
+    wasEnabled = enabled;
     const prev = lastZoom;
     lastZoom = displayZoom;
     const shouldShow = prev === null || zoomDiffers(prev, displayZoom);
-    if (isPaginated && (enteredPaginated || shouldShow)) {
+    if (enabled && (entered || shouldShow)) {
       showTemporarily();
     }
-    if (!isPaginated) {
+    if (!enabled) {
       visible = false;
     }
   });
@@ -91,7 +91,7 @@
   const zoomPercent = $derived(Math.round(displayZoom * 100));
 </script>
 
-{#if isPaginated}
+{#if enabled}
   <div
     style:left={`${overlayLeft}px`}
     style:bottom={`${overlayBottom}px`}

--- a/apps/website/src/lib/editor-ffi/edge-auto-scroll.test.ts
+++ b/apps/website/src/lib/editor-ffi/edge-auto-scroll.test.ts
@@ -46,6 +46,7 @@ const setup = () => {
     getRect: () => VIEWPORT_RECT,
     getScrollTop: () => scrollTop,
     getScrollLeft: () => 0,
+    getScrollWidth: () => 10_000,
     getScrollHeight: () => 10_000,
     scrollBy: (_x, y) => {
       scrollTop += y;

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
@@ -14,6 +14,7 @@
   import EditorPages from './components/EditorPages.svelte';
   import Input from './components/Input.svelte';
   import LineHighlight from './components/LineHighlight.svelte';
+  import Scrollbar from './components/Scrollbar.svelte';
   import SelectionHandles from './components/SelectionHandles.svelte';
   import EditorZoom from './components/ui/EditorZoom.svelte';
   import ViewportOverlay from './components/ViewportOverlay.svelte';
@@ -22,8 +23,10 @@
   import { setupEditorPublication } from './editor-publication.svelte';
   import { EditorSurfaceHost } from './editor-surface-host.svelte';
   import { setupEditorScroll } from './scroll.svelte';
+  import { resolveContinuousLayoutViewportWidth } from './zoom';
   import type { MouseEventHandler } from 'svelte/elements';
   import type { Editor } from './editor.svelte';
+  import type { DocumentZoomLayout } from './zoom';
 
   type Props = {
     editor: Editor;
@@ -36,6 +39,8 @@
     userId: string;
     withZoom?: boolean;
     headerHeight?: number;
+    contentInsetLeft?: number;
+    contentInsetRight?: number;
   };
 
   let {
@@ -49,6 +54,8 @@
     userId,
     withZoom = false,
     headerHeight = 0,
+    contentInsetLeft = 0,
+    contentInsetRight = 0,
   }: Props = $props();
 
   const app = setupAppContext(userId);
@@ -70,9 +77,31 @@
   let publishedReady = false;
   const isPaginated = $derived(editor.rootAttrs?.layout_mode.type === 'paginated');
   const pageWidth = $derived(editor.pageSizes[0]?.width ?? 0);
+  const zoomLayout: DocumentZoomLayout | null = $derived.by(() => {
+    const layout = editor.rootAttrs?.layout_mode;
+    if (layout?.type === 'continuous' && layout.max_width > 0) return { type: 'continuous', maxWidth: layout.max_width };
+    if (layout?.type === 'paginated' && pageWidth > 0) return { type: 'paginated', pageWidth };
+    return null;
+  });
 
   $effect(() => {
     editor.readOnly = readOnly;
+  });
+
+  $effect(() => {
+    const layout = zoomLayout;
+    const width = viewportWidth;
+    const renderZoom = editor.renderZoom;
+    if (!withZoom || layout?.type !== 'continuous' || width <= 0) return;
+    untrack(() => {
+      const height = editor.viewport.height;
+      if (height <= 0) return;
+      editor.resizeViewportNow(
+        resolveContinuousLayoutViewportWidth({ viewportWidth: width, committedZoom: renderZoom }),
+        height,
+        editor.scaleFactor,
+      );
+    });
   });
 
   $effect(() => {
@@ -123,20 +152,28 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     bind:this={extensionArea}
+    style:min-width="max-content"
+    style:padding-left={`${contentInsetLeft}px`}
+    style:padding-right={`${contentInsetRight}px`}
     style:padding-bottom={`${ctx.scroll?.bottomPadding ?? 0}px`}
-    style:row-gap={`${isPaginated ? PAGE_GAP * editor.displayZoom : 0}px`}
-    style="position: relative; display: flex; flex-direction: column; align-items: center; min-width: max-content;"
+    style="position: relative; display: flex; flex-direction: column; align-items: center; isolation: isolate; width: 100%;"
     {@attach (el) => {
       editor.extensionAreaEl = el;
     }}
     data-editor-extension-area
     {onclick}
   >
-    <EditorPages {editor} {surfaceHost} />
+    <div
+      style:row-gap={`${isPaginated ? PAGE_GAP * editor.displayZoom : 0}px`}
+      style="position: relative; display: flex; flex-direction: column; align-items: center; flex: 1 0 auto; width: 100%;"
+      data-editor-document-track
+    >
+      <EditorPages {editor} {surfaceHost} />
 
-    <DocumentOverlayLayer />
-    <Caret />
-    <LineHighlight />
+      <DocumentOverlayLayer />
+      <Caret />
+      <LineHighlight />
+    </div>
 
     <ViewportOverlay>
       <Input />
@@ -168,10 +205,20 @@
     <div style:height={`${headerHeight}px`} data-editor-test-header></div>
   {/if}
   {#if withZoom}
-    <EditorZoom active {editor} {isPaginated} {pageWidth} {viewportWidth}>
+    <EditorZoom
+      active
+      attachViewportAnchor={(point) => ctx.scroll?.attachViewportAnchorAt(point)}
+      {editor}
+      layout={zoomLayout}
+      {viewportWidth}
+    >
       {@render editorContent()}
     </EditorZoom>
   {:else}
     {@render editorContent()}
   {/if}
 </div>
+
+{#if withZoom}
+  <Scrollbar />
+{/if}

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -69,7 +69,7 @@ type WebFrameSample = {
   expectedHighlightY: number;
   actualHighlightY: number | null;
   caretOnCursorPage: boolean;
-  highlightOnCursorPage: boolean;
+  highlightOnExpectedContainer: boolean;
   selectionHeadVisible: boolean;
 };
 
@@ -91,7 +91,7 @@ function matchingWebFrameSample(overrides: Partial<WebFrameSample> = {}): WebFra
     expectedHighlightY: 8,
     actualHighlightY: 8,
     caretOnCursorPage: true,
-    highlightOnCursorPage: true,
+    highlightOnExpectedContainer: true,
     selectionHeadVisible: true,
     ...overrides,
   };
@@ -135,6 +135,17 @@ function doc(text = '', href?: string): PlainDoc {
         line_height: { type: 'line_height', value: 160 },
       } as never,
     ),
+  };
+}
+
+function continuousDoc(text = ''): PlainDoc {
+  const document = doc(text);
+  return {
+    ...document,
+    root: {
+      ...document.root,
+      node: { type: 'root', layout_mode: { type: 'continuous', max_width: 600 } },
+    },
   };
 }
 
@@ -256,7 +267,14 @@ function paginatedDocWithLinkedPage(pageCount: number, linkedPage: number, text:
 
 async function mountEditor(
   plain: PlainDoc,
-  options: { readOnly?: boolean; typewriterEnabled?: boolean; withZoom?: boolean; displayZoom?: number } = {},
+  options: {
+    readOnly?: boolean;
+    typewriterEnabled?: boolean;
+    withZoom?: boolean;
+    displayZoom?: number;
+    contentInsetLeft?: number;
+    contentInsetRight?: number;
+  } = {},
 ) {
   editor = await Editor.createFromDoc(plain, { width: 360, height: 180, scale_factor: 1 });
   if (options.displayZoom !== undefined) {
@@ -275,6 +293,8 @@ async function mountEditor(
       typewriterEnabled: options.typewriterEnabled,
       userId: `frame-sync-${crypto.randomUUID()}`,
       withZoom: options.withZoom,
+      contentInsetLeft: options.contentInsetLeft,
+      contentInsetRight: options.contentInsetRight,
     },
   });
   const result = await harness.promise;
@@ -344,7 +364,7 @@ function readWebFrameSample(
   if (!published || !cursor) throw new Error('Expected a published cursor');
 
   const paginated = published.snapshot.rootAttrs?.layout_mode.type === 'paginated';
-  const zoom = paginated ? editor.displayZoom : 1;
+  const zoom = editor.safeDisplayZoom();
   const pageGap = paginated ? PAGE_GAP * zoom : 0;
   const pageTop = published.snapshot.pageSizes
     .slice(0, cursor.page_idx)
@@ -356,6 +376,7 @@ function readWebFrameSample(
   const caret = document.querySelector<HTMLElement>('[data-editor-caret]');
   const lineHighlight = document.querySelector<HTMLElement>('[data-editor-line-highlight]');
   const cursorPage = editor.pageEls[cursor.page_idx];
+  const expectedHighlightContainer = paginated ? cursorPage : editor.extensionAreaEl;
   const cursorTop = caret?.getBoundingClientRect().top ?? null;
   const cursorBottom = cursorTop === null ? null : cursorTop + cursor.caret.height * zoom;
   const viewportBottom = rootTop + scrollRoot.clientHeight;
@@ -377,7 +398,7 @@ function readWebFrameSample(
     expectedHighlightY: rootTop + highlightDocumentY - scrollTop,
     actualHighlightY: lineHighlight?.getBoundingClientRect().top ?? null,
     caretOnCursorPage: caret?.parentElement === cursorPage,
-    highlightOnCursorPage: lineHighlight?.parentElement === cursorPage,
+    highlightOnExpectedContainer: lineHighlight?.parentElement === expectedHighlightContainer,
     selectionHeadVisible:
       cursorTop !== null &&
       cursorBottom !== null &&
@@ -397,7 +418,7 @@ function delayUntil(deadline: number): Promise<void> {
 }
 
 function describeWebFrameMismatch(sample: WebFrameSample, previous?: WebFrameSample): string | undefined {
-  const nativePresentationMismatch = !sample.hasNativeFrame || !sample.caretOnCursorPage || !sample.highlightOnCursorPage;
+  const nativePresentationMismatch = !sample.hasNativeFrame || !sample.caretOnCursorPage || !sample.highlightOnExpectedContainer;
   const cursorMismatch = sample.actualCursorY === null || Math.abs(sample.actualCursorY - sample.expectedCursorY) > COORDINATE_TOLERANCE_PX;
   const highlightMismatch =
     sample.actualHighlightY === null || Math.abs(sample.actualHighlightY - sample.expectedHighlightY) > COORDINATE_TOLERANCE_PX;
@@ -418,7 +439,7 @@ function describeWebFrameMismatch(sample: WebFrameSample, previous?: WebFrameSam
   return [
     `phase=${sample.phaseMs}ms frame=${sample.frame} direction=${sample.direction} revision=${sample.revision}`,
     `scrollTop=${sample.scrollTop} cursorPage=${sample.cursorPage} hasNativeFrame=${sample.hasNativeFrame}`,
-    `caretOnCursorPage=${sample.caretOnCursorPage} highlightOnCursorPage=${sample.highlightOnCursorPage}`,
+    `caretOnCursorPage=${sample.caretOnCursorPage} highlightOnExpectedContainer=${sample.highlightOnExpectedContainer}`,
     `selectionHeadVisible=${sample.selectionHeadVisible}`,
     `cursor expected=${sample.expectedCursorY} actual=${sample.actualCursorY}`,
     `highlight expected=${sample.expectedHighlightY} actual=${sample.actualHighlightY}`,
@@ -1289,6 +1310,175 @@ describe('web editor frame synchronization', () => {
     expect(attachSurfaceSpy.mock.calls.filter(([page]) => page === 0)).toHaveLength(1);
     expect(editor.published?.frames.get(0)?.canvas.isConnected).toBe(true);
     expectActualCanvas(editor, 0);
+  });
+
+  it('delays continuous reflow until the render commit and replaces it coherently', async () => {
+    const { editor, scrollRoot } = await mountEditor(continuousDoc('continuous zoom '.repeat(40)), { withZoom: true });
+    await waitForPresentation(editor);
+    const initialPageWidth = editor.appliedSnapshot.pageSizes[0]?.width;
+    const initialCanvas = editor.published?.frames.get(0)?.canvas;
+    expect(initialPageWidth).toBeCloseTo(360);
+    expect(initialCanvas).toBeDefined();
+    expectActualCanvas(editor, 0, false);
+
+    const viewportRect = scrollRoot.getBoundingClientRect();
+    scrollRoot.dispatchEvent(
+      new WheelEvent('wheel', {
+        deltaY: 69,
+        metaKey: navigator.platform.toUpperCase().includes('MAC'),
+        ctrlKey: !navigator.platform.toUpperCase().includes('MAC'),
+        clientX: viewportRect.left + viewportRect.width / 2,
+        clientY: viewportRect.top + viewportRect.height / 2,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await nextAnimationFrame();
+
+    expect(editor.displayZoom).toBeLessThan(1);
+    expect(editor.renderZoom).toBe(1);
+    expect(editor.viewport.width).toBeCloseTo(360);
+    expect(editor.appliedSnapshot.pageSizes[0]?.width).toBeCloseTo(initialPageWidth ?? 0);
+    expect(editor.published?.frames.get(0)?.canvas).toBe(initialCanvas);
+
+    await expect.poll(() => editor.renderZoom).toBeCloseTo(editor.displayZoom);
+    await expect.poll(() => editor.viewport.width).toBeGreaterThan(360);
+    await waitForPresentation(editor);
+
+    expect(editor.appliedSnapshot.pageSizes[0]?.width).toBeGreaterThan(initialPageWidth ?? Infinity);
+    expect(editor.published?.frames.get(0)?.canvas).not.toBe(initialCanvas);
+    expect(editor.pageEls[0]?.getBoundingClientRect().width).toBeCloseTo(360, 0);
+    expect(editor.published?.frames.get(0)?.canvas.width).toBeGreaterThan(0);
+    expect(editor.published?.frames.get(0)?.canvas.height).toBeGreaterThan(0);
+    expectActualCanvas(editor, 0, false);
+  });
+
+  it('makes the entire zoomed continuous track horizontally reachable without oversized line highlight paint', async () => {
+    const { editor, extensionArea, scrollRoot } = await mountEditor(continuousDoc('continuous zoom'), { withZoom: true });
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    editor.focus();
+    await tick();
+
+    const viewportRect = scrollRoot.getBoundingClientRect();
+    scrollRoot.dispatchEvent(
+      new WheelEvent('wheel', {
+        deltaY: -98,
+        metaKey: navigator.platform.toUpperCase().includes('MAC'),
+        ctrlKey: !navigator.platform.toUpperCase().includes('MAC'),
+        clientX: viewportRect.left + viewportRect.width / 2,
+        clientY: viewportRect.top + viewportRect.height / 2,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await nextAnimationFrame();
+    expect(editor.displayZoom).toBeGreaterThan(1);
+
+    scrollRoot.scrollLeft = 0;
+    scrollRoot.dispatchEvent(new Event('scroll'));
+    await nextAnimationFrame();
+
+    const pageElement = editor.pageEls[0];
+    const documentTrack = document.querySelector<HTMLElement>('[data-editor-document-track]');
+    const lineHighlight = document.querySelector<HTMLElement>('[data-editor-line-highlight]');
+    expect(pageElement).toBeDefined();
+    expect(documentTrack).not.toBeNull();
+    expect(lineHighlight?.parentElement).toBe(extensionArea);
+    if (!pageElement || !documentTrack || !lineHighlight) throw new Error('Expected continuous zoom geometry');
+
+    const pageRectAtStart = pageElement.parentElement?.getBoundingClientRect();
+    const trackRectAtStart = documentTrack.getBoundingClientRect();
+    expect(pageRectAtStart?.left).toBeCloseTo(viewportRect.left, 0);
+    expect(trackRectAtStart.left).toBeCloseTo(viewportRect.left, 0);
+    expect(trackRectAtStart.width).toBeCloseTo(pageRectAtStart?.width ?? 0, 0);
+    expect(scrollRoot.scrollWidth).toBeCloseTo(trackRectAtStart.width, 0);
+    expect(lineHighlight.getBoundingClientRect().width).toBeCloseTo(extensionArea.getBoundingClientRect().width, 0);
+    expect(getComputedStyle(lineHighlight).boxShadow).toBe('none');
+
+    const maximumScrollLeft = scrollRoot.scrollWidth - scrollRoot.clientWidth;
+    expect(maximumScrollLeft).toBeGreaterThan(0);
+    const horizontalScrollbarThumb = document.querySelector<HTMLElement>(
+      '[role="scrollbar"][aria-orientation="horizontal"] [role="slider"]',
+    );
+    expect(horizontalScrollbarThumb).not.toBeNull();
+    if (!horizontalScrollbarThumb) throw new Error('Expected the horizontal scrollbar thumb');
+    const thumbRect = horizontalScrollbarThumb.getBoundingClientRect();
+    const pointerId = 1;
+    horizontalScrollbarThumb.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        pointerId,
+        pointerType: 'mouse',
+        isPrimary: true,
+        button: 0,
+        buttons: 1,
+        clientX: thumbRect.left + thumbRect.width / 2,
+        clientY: thumbRect.top + thumbRect.height / 2,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    horizontalScrollbarThumb.dispatchEvent(
+      new PointerEvent('pointermove', {
+        pointerId,
+        pointerType: 'mouse',
+        isPrimary: true,
+        buttons: 1,
+        clientX: thumbRect.left + thumbRect.width / 2 + 40,
+        clientY: thumbRect.top + thumbRect.height / 2,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    horizontalScrollbarThumb.dispatchEvent(
+      new PointerEvent('pointerup', {
+        pointerId,
+        pointerType: 'mouse',
+        isPrimary: true,
+        button: 0,
+        clientX: thumbRect.left + thumbRect.width / 2 + 40,
+        clientY: thumbRect.top + thumbRect.height / 2,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await nextAnimationFrame();
+    expect(scrollRoot.scrollLeft).toBeGreaterThan(0);
+    const draggedScrollLeft = scrollRoot.scrollLeft;
+    scrollRoot.dispatchEvent(new Event('scroll'));
+    await tick();
+    await nextAnimationFrame();
+    await nextAnimationFrame();
+    expect(scrollRoot.scrollLeft).toBeCloseTo(draggedScrollLeft, 0);
+
+    scrollRoot.scrollLeft = maximumScrollLeft;
+    scrollRoot.dispatchEvent(new Event('scroll'));
+    await nextAnimationFrame();
+
+    expect(scrollRoot.scrollLeft).toBeCloseTo(maximumScrollLeft, 0);
+    expect(documentTrack.getBoundingClientRect().right).toBeCloseTo(viewportRect.right, 0);
+  });
+
+  it('fills the continuous editor surface behind reserved review-column insets', async () => {
+    const { editor, extensionArea } = await mountEditor(continuousDoc('continuous review column'), {
+      contentInsetLeft: 100,
+      contentInsetRight: 396,
+    });
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    editor.focus();
+    await tick();
+
+    const lineHighlight = document.querySelector<HTMLElement>('[data-editor-line-highlight]');
+    expect(lineHighlight).not.toBeNull();
+    if (!lineHighlight) throw new Error('Expected continuous line highlight');
+
+    const surfaceRect = extensionArea.getBoundingClientRect();
+    const highlightRect = lineHighlight.getBoundingClientRect();
+    expect(lineHighlight.parentElement).toBe(extensionArea);
+    expect(highlightRect.left).toBeCloseTo(surfaceRect.left, 0);
+    expect(highlightRect.right).toBeCloseTo(surfaceRect.right, 0);
+    expect(getComputedStyle(lineHighlight).boxShadow).toBe('none');
   });
 
   it('prepares an appended page without mounting candidate geometry before publication', async () => {

--- a/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
@@ -44,12 +44,15 @@ describe('editor publication preparation', () => {
       scaleFactor: 1,
       displayZoom: 1,
       activeSurfacePages: new Set<number>(),
+      pageEls: {},
       extensionAreaEl: {
         getBoundingClientRect: () => new DOMRect(0, 0, 600, 1000),
       },
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => 0,
+        getScrollLeft: () => 0,
+        getScrollWidth: () => 600,
         getScrollHeight: () => 1000,
         scrollTo: vi.fn(),
       },
@@ -105,6 +108,8 @@ describe('editor publication preparation', () => {
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => scrollTop,
+        getScrollLeft: () => 0,
+        getScrollWidth: () => 600,
         getScrollHeight: () => 4000,
         scrollTo: vi.fn((options: ScrollToOptions) => {
           scrollTop = options.top ?? scrollTop;
@@ -156,6 +161,8 @@ describe('editor publication preparation', () => {
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => 0,
+        getScrollLeft: () => 0,
+        getScrollWidth: () => 600,
         getScrollHeight: () => 1000,
         scrollTo: vi.fn(),
       },
@@ -205,6 +212,8 @@ describe('editor publication preparation', () => {
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => 0,
+        getScrollLeft: () => 0,
+        getScrollWidth: () => 600,
         getScrollHeight: () => 3040,
         scrollTo: vi.fn(),
       },
@@ -249,6 +258,8 @@ describe('editor publication preparation', () => {
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => scrollTop,
+        getScrollLeft: () => 0,
+        getScrollWidth: () => 600,
         getScrollHeight: () => 100_000,
         scrollTo: vi.fn(),
       },
@@ -285,6 +296,8 @@ describe('editor publication preparation', () => {
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => scrollTop,
+        getScrollLeft: () => 0,
+        getScrollWidth: () => 600,
         getScrollHeight: () => 4000,
         scrollTo: vi.fn(),
       },
@@ -320,6 +333,8 @@ describe('editor publication preparation', () => {
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => 0,
+        getScrollLeft: () => 0,
+        getScrollWidth: () => 600,
         getScrollHeight: () => 2000,
         scrollTo: vi.fn(),
       },
@@ -356,6 +371,8 @@ describe('editor publication preparation', () => {
       scrollViewport: {
         getRect: () => new DOMRect(0, 0, 600, 400),
         getScrollTop: () => 0,
+        getScrollLeft: () => 0,
+        getScrollWidth: () => 600,
         getScrollHeight: () => 2000,
         scrollTo: vi.fn(),
       },

--- a/apps/website/src/lib/editor-ffi/editor-publication.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication.svelte.ts
@@ -26,6 +26,7 @@ export function setupEditorPublication(ctx: EditorContext, getSurfaceHost: () =>
 
     void editor.publicationVersion;
     void editor.appliedSnapshot;
+    void editor.viewport.width;
     void editor.viewport.height;
     void editor.viewport.scale_factor;
     const displayZoom = editor.displayZoom;
@@ -227,5 +228,5 @@ function samePages(a: ReadonlySet<number>, b: ReadonlySet<number>): boolean {
 }
 
 function displayZoom(snapshot: EditorSnapshot, zoom: number): number {
-  return snapshot.rootAttrs?.layout_mode.type === 'paginated' && Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+  return snapshot.rootAttrs?.layout_mode && Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
 }

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -1543,7 +1543,7 @@ export class Editor {
   }
 
   safeDisplayZoom(): number {
-    const zoom = this.rootAttrs?.layout_mode.type === 'paginated' ? this.displayZoom : 1;
+    const zoom = this.rootAttrs?.layout_mode ? this.displayZoom : 1;
     return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
   }
 

--- a/apps/website/src/lib/editor-ffi/gesture.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/gesture.svelte.ts
@@ -272,7 +272,7 @@ export class TouchGestureController {
       height: visualViewport?.height ?? (typeof window === 'undefined' ? 0 : window.innerHeight),
     };
 
-    const displayZoom = snapshot.rootAttrs?.layout_mode.type === 'paginated' ? this.#editor.displayZoom : 1;
+    const displayZoom = snapshot.rootAttrs?.layout_mode ? this.#editor.displayZoom : 1;
     const zoom = Number.isFinite(displayZoom) && displayZoom > 0 ? displayZoom : 1;
     const position = computeTouchContextMenuPosition({ endpoints, pageRects, zoom, viewport });
     if (!position) {

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -70,7 +70,7 @@ describe('EditorRequest', () => {
   });
 });
 
-function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; position: number | undefined }) {
+function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; position: number | undefined }, displayZoom = 1) {
   const typewriterPreferences = typewriter ?? { enabled: false, position: undefined };
   let animationTime = 0;
   let nextAnimationFrameId = 1;
@@ -82,8 +82,10 @@ function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; positi
   });
   vi.stubGlobal('cancelAnimationFrame', (id: number) => animationFrames.delete(id));
   let scrollTop = 0;
+  let scrollLeft = 0;
   const scrollTo = vi.fn((options: ScrollToOptions) => {
     if (options.behavior === 'instant' && options.top !== undefined) scrollTop = options.top;
+    if (options.behavior === 'instant' && options.left !== undefined) scrollLeft = options.left;
   });
   const requestPublication = vi.fn();
   const editor = {
@@ -108,10 +110,12 @@ function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; positi
     scrollViewport: {
       getRect: () => new DOMRect(0, 0, 600, 400),
       getScrollTop: () => scrollTop,
+      getScrollLeft: () => scrollLeft,
+      getScrollWidth: () => 600,
       getScrollHeight: () => 1200,
       scrollTo,
     },
-    safeDisplayZoom: () => 1,
+    safeDisplayZoom: () => displayZoom,
     clientToLocal: vi.fn(() => null),
     captureSelectionViewportAnchor: vi.fn(() => void 0),
     captureViewportAnchorAt: vi.fn(() => void 0),
@@ -127,8 +131,12 @@ function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; positi
     },
     animationFrameCount: () => animationFrames.size,
     editor,
+    getScrollLeft: () => scrollLeft,
     getScrollTop: () => scrollTop,
     requestPublication,
+    setScrollLeft: (value: number) => {
+      scrollLeft = value;
+    },
     setScrollTop: (value: number) => {
       scrollTop = value;
     },
@@ -195,6 +203,17 @@ describe('EditorScrollScope', () => {
     expect(scope.resolveScrollTop(request, candidateMetrics, candidateSnapshot)).toBe(320);
     expect(scope.resolvePreparationViewports(request, candidateMetrics, candidateSnapshot)).toEqual([{ top: 320, bottom: 720 }]);
     expect(scope.bottomPaddingFor(candidateSnapshot)).toBe(160);
+  });
+
+  it('scales the continuous trailing engine margin in typewriter padding', () => {
+    const rect = { page_idx: 0, rect: { x: 0, y: 500, width: 1, height: 40 } };
+    const snapshot = {
+      ...selectionSnapshot(false, rect),
+      rootAttrs: { layout_mode: { type: 'continuous', max_width: 600 } },
+    } as EditorSnapshot;
+    const { scope } = setup(snapshot, { enabled: true, position: 0.5 }, 2);
+
+    expect(scope.bottomPaddingFor(snapshot)).toBe(120);
   });
 
   it('uses typewriter reveal at the endpoint matching a keyboard-extended range head', () => {
@@ -758,8 +777,116 @@ describe('EditorScrollScope', () => {
 
     expect(publication).toMatchObject({ type: 'ready', targetScrollTop: 220 });
     scope.applyViewportAnchorPublication(publication);
-    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 220, behavior: 'instant' });
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 0, top: 220, behavior: 'instant' });
     expect(scrollTop).toBe(220);
+  });
+
+  it('settles a retained zoom focal on both axes with one scroll operation', () => {
+    const current = selectionSnapshot(false, { page_idx: 0, rect: { x: 0, y: 0, width: 1, height: 1 } });
+    const candidate = { ...current, revision: 2 };
+    const { editor, scope } = setup(current);
+    const anchor = { type: 'node' as const, node: 'zoom', offset_x: 0, offset_y: 0 };
+    let scrollLeft = 100;
+    let scrollTop = 100;
+    const scrollTo = vi.fn((options: ScrollToOptions) => {
+      scrollLeft = options.left ?? scrollLeft;
+      scrollTop = options.top ?? scrollTop;
+    });
+    editor.scrollViewport = {
+      ...editor.scrollViewport,
+      getScrollLeft: () => scrollLeft,
+      getScrollTop: () => scrollTop,
+      getScrollWidth: () => 1200,
+      getScrollHeight: () => 1200,
+      scrollTo,
+    } as NonNullable<Editor['scrollViewport']>;
+    editor.captureViewportAnchorAt = vi.fn(() => ({
+      identity: anchor,
+      geometry: { point: { page_idx: 0, x: 200, y: 200 }, rect: undefined },
+    }));
+    editor.resolveViewportAnchor = vi.fn(() => ({
+      type: 'resolved' as const,
+      geometry: { point: { page_idx: 0, x: 400, y: 320 }, rect: undefined },
+    }));
+
+    scope.attachViewportAnchorAt({ page: 0, x: 200, y: 200 });
+    const publication = scope.prepareViewportAnchorPublication(candidate);
+
+    expect(publication).toMatchObject({ type: 'ready', targetScrollLeft: 300, targetScrollTop: 220 });
+    scope.applyViewportAnchorPublication(publication);
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 300, top: 220, behavior: 'instant' });
+  });
+
+  it('derives a wider candidate page x position from candidate geometry', () => {
+    const current = {
+      ...trackedSnapshot('unused', { page_idx: 0, rect: { x: 0, y: 0, width: 1, height: 1 } }),
+      pageSizes: [{ width: 400, height: 1200 }],
+    } as EditorSnapshot;
+    const candidate = { ...current, revision: 2, pageSizes: [{ width: 800, height: 1200 }] } as EditorSnapshot;
+    const { editor, scope } = setup(current);
+    const anchor = { type: 'node' as const, node: 'zoom', offset_x: 0, offset_y: 0 };
+    editor.pageEls = {
+      0: { getBoundingClientRect: () => new DOMRect(100, 0, 400, 1200) },
+    } as unknown as Editor['pageEls'];
+    editor.extensionAreaEl = {
+      getBoundingClientRect: () => new DOMRect(0, 0, 600, 1200),
+      style: { paddingLeft: '20px', paddingRight: '20px' },
+    } as unknown as HTMLDivElement;
+    editor.scrollRootEl = {} as HTMLElement;
+    editor.captureViewportAnchorAt = vi.fn(() => ({
+      identity: anchor,
+      geometry: { point: { page_idx: 0, x: 200, y: 200 }, rect: undefined },
+    }));
+    editor.resolveViewportAnchor = vi.fn(() => ({
+      type: 'resolved' as const,
+      geometry: { point: { page_idx: 0, x: 400, y: 200 }, rect: undefined },
+    }));
+
+    scope.attachViewportAnchorAt({ page: 0, x: 200, y: 200 });
+
+    expect(scope.prepareViewportAnchorPublication(candidate)).toMatchObject({
+      type: 'ready',
+      targetScrollLeft: 120,
+    });
+  });
+
+  it('does not treat a zoom-owned scroll as a direct scroll that reactivates a visible selection', () => {
+    const current = selectionSnapshot(true, {
+      page_idx: 0,
+      rect: { x: 150, y: 90, width: 1, height: 20 },
+    });
+    const candidate = { ...current, revision: 2 } as EditorSnapshot;
+    const { editor, scope, setScrollLeft } = setup(current);
+    const selection = { type: 'node' as const, node: 'selection', offset_x: 0, offset_y: 0 };
+    const zoom = { type: 'node' as const, node: 'zoom', offset_x: 0, offset_y: 0 };
+    const selectionGeometry = {
+      point: { page_idx: 0, x: 150, y: 100 },
+      rect: { page_idx: 0, rect: { x: 150, y: 90, width: 1, height: 20 } },
+    };
+    editor.scrollViewport = {
+      ...editor.scrollViewport,
+      getScrollWidth: () => 1200,
+    } as NonNullable<Editor['scrollViewport']>;
+    editor.captureSelectionViewportAnchor = vi.fn(() => ({ identity: selection, geometry: selectionGeometry }));
+    editor.captureViewportAnchorAt = vi.fn(() => ({
+      identity: zoom,
+      geometry: { point: { page_idx: 0, x: 200, y: 200 }, rect: undefined },
+    }));
+    editor.resolveViewportAnchor = vi.fn((_revision, identity) => ({
+      type: 'resolved' as const,
+      geometry: identity.node === zoom.node ? { point: { page_idx: 0, x: 400, y: 200 }, rect: undefined } : selectionGeometry,
+    }));
+
+    expect(scope.prepareViewportAnchorPublication(current).type).toBe('ready');
+    setScrollLeft(100);
+    scope.attachViewportAnchorAt({ page: 0, x: 200, y: 200 });
+    scope.observeViewportScroll();
+
+    expect(scope.prepareViewportAnchorPublication(candidate)).toMatchObject({
+      type: 'ready',
+      targetScrollLeft: 300,
+    });
+    expect(editor.resolveViewportAnchor).toHaveBeenLastCalledWith(candidate.revision, zoom);
   });
 
   it('attaches a changed selection without scrolling then guards it after the viewport shrinks', () => {
@@ -839,7 +966,8 @@ describe('EditorScrollScope', () => {
 
     expect(scope.prepareViewportAnchorPublication(initial)).toEqual({
       type: 'ready',
-      geometry: { pointY: 200 },
+      geometry: { pointX: 0, pointY: 200 },
+      targetScrollLeft: null,
       targetScrollTop: 0,
     });
   });
@@ -880,7 +1008,8 @@ describe('EditorScrollScope', () => {
 
     expect(scope.prepareViewportAnchorPublication(candidate)).toEqual({
       type: 'ready',
-      geometry: { pointY: 500 },
+      geometry: { pointX: 0, pointY: 500 },
+      targetScrollLeft: null,
       targetScrollTop: 0,
     });
     expect(scrollTo).not.toHaveBeenCalled();
@@ -909,7 +1038,7 @@ describe('EditorScrollScope', () => {
     capture = { identity: { ...selection }, geometry };
     expect(scope.prepareViewportAnchorPublication(initial)).toMatchObject({
       type: 'ready',
-      geometry: { pointY: 100 },
+      geometry: { pointX: 0, pointY: 100 },
     });
   });
 
@@ -936,6 +1065,7 @@ describe('EditorScrollScope', () => {
     expect(scope.prepareViewportAnchorPublication(candidate)).toEqual({
       type: 'ready',
       geometry: null,
+      targetScrollLeft: null,
       targetScrollTop: null,
     });
   });
@@ -956,9 +1086,9 @@ describe('EditorScrollScope', () => {
 
     const publication = scope.prepareViewportAnchorPublication(candidate);
 
-    expect(publication).toEqual({ type: 'ready', geometry: null, targetScrollTop: 0 });
+    expect(publication).toEqual({ type: 'ready', geometry: null, targetScrollLeft: null, targetScrollTop: 0 });
     scope.applyViewportAnchorPublication(publication);
-    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 0, behavior: 'instant' });
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 0, top: 0, behavior: 'instant' });
     expect(getScrollTop()).toBe(0);
   });
 
@@ -979,6 +1109,7 @@ describe('EditorScrollScope', () => {
     expect(scope.prepareViewportAnchorPublication(candidate)).toEqual({
       type: 'ready',
       geometry: null,
+      targetScrollLeft: null,
       targetScrollTop: null,
     });
   });
@@ -998,12 +1129,13 @@ describe('EditorScrollScope', () => {
     advanceAnimation();
     scope.applyViewportAnchorPublication({
       type: 'ready',
-      geometry: { pointY: 320 },
+      geometry: { pointX: 0, pointY: 320 },
+      targetScrollLeft: null,
       targetScrollTop: 220,
     });
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
 
-    expect(scrollTo).toHaveBeenCalledWith({ top: 220, behavior: 'instant' });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0, top: 220, behavior: 'instant' });
     for (let frame = 0; frame < 100 && animationFrameCount() > 0; frame++) advanceAnimation();
     expect(scrollTo).toHaveBeenLastCalledWith({ top: 580, behavior: 'instant' });
     expect(scope.pendingRequest).toBeNull();
@@ -1055,12 +1187,13 @@ describe('EditorScrollScope', () => {
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
     scope.applyViewportAnchorPublication({
       type: 'ready',
-      geometry: { pointY: 320 },
+      geometry: { pointX: 0, pointY: 320 },
+      targetScrollLeft: null,
       targetScrollTop: 220,
     });
     expect(scope.applyPending(request, snapshot, { type: 'no_scroll' })).toBe(true);
 
-    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ top: 220, behavior: 'instant' });
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 0, top: 220, behavior: 'instant' });
     expect(scope.pendingRequest).toBeNull();
   });
 

--- a/apps/website/src/lib/editor-ffi/scroll-viewport.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-viewport.test.ts
@@ -2,24 +2,31 @@ import { elementScrollViewport, windowScrollViewport } from '@typie/ui/utils';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('elementScrollViewport', () => {
-  it('scrollTo와 getScrollHeight를 요소에 위임한다', () => {
+  it('scrollTo와 scroll extent를 요소에 위임한다', () => {
     const el = document.createElement('div');
     el.scrollTo = vi.fn();
-    Object.defineProperty(el, 'scrollHeight', { value: 1234 });
+    Object.defineProperties(el, {
+      scrollHeight: { value: 1234 },
+      scrollWidth: { value: 2345 },
+    });
 
     const viewport = elementScrollViewport(el);
     viewport.scrollTo({ top: 100, behavior: 'smooth' });
 
     expect(el.scrollTo).toHaveBeenCalledWith({ top: 100, behavior: 'smooth' });
     expect(viewport.getScrollHeight()).toBe(1234);
+    expect(viewport.getScrollWidth()).toBe(2345);
   });
 });
 
 describe('windowScrollViewport', () => {
-  it('scrollTo는 window에, getScrollHeight는 scrollingElement에 위임한다', () => {
+  it('scrollTo는 window에, scroll extent는 scrollingElement에 위임한다', () => {
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(vi.fn());
     const scrollingElement = document.createElement('div');
-    Object.defineProperty(scrollingElement, 'scrollHeight', { value: 5678 });
+    Object.defineProperties(scrollingElement, {
+      scrollHeight: { value: 5678 },
+      scrollWidth: { value: 6789 },
+    });
     Object.defineProperty(document, 'scrollingElement', { value: scrollingElement, configurable: true });
 
     const viewport = windowScrollViewport();
@@ -27,6 +34,7 @@ describe('windowScrollViewport', () => {
 
     expect(scrollToSpy).toHaveBeenCalledWith({ top: 50, behavior: 'instant' });
     expect(viewport.getScrollHeight()).toBe(5678);
+    expect(viewport.getScrollWidth()).toBe(6789);
 
     scrollToSpy.mockRestore();
     Reflect.deleteProperty(document, 'scrollingElement');

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -1,6 +1,6 @@
 import { getAppContext } from '@typie/ui/context';
 import { untrack } from 'svelte';
-import { CONTINUOUS_VIEW_PADDING, CURSOR_VISIBLE_MARGIN, PAGE_GAP } from './constants';
+import { CURSOR_VISIBLE_MARGIN, PAGE_GAP } from './constants';
 import { pageRectsToRevealTargetSpan, resolvePageSpans, selectionHeadRect } from './geometry';
 import {
   resolveGuardedScrollTop,
@@ -11,6 +11,7 @@ import {
 } from './scroll';
 import { SmoothScrollMotion } from './smooth-scroll-motion';
 import { EditorViewportAnchorState, resolveViewportAnchorGeometry, viewportCenterAnchorPoint } from './viewport-anchor';
+import { resolveContinuousViewPadding } from './zoom';
 import type { PageRect, ViewportAnchorResolution } from '@typie/editor-ffi/browser';
 import type { Editor, EditorContext, EditorSnapshot } from './editor.svelte';
 import type { EditorRequest } from './editor-update';
@@ -36,7 +37,13 @@ export type EditorScrollIntoViewOptions = {
 export type EditorScrollIntentResult = { type: 'unresolved' } | { type: 'no_scroll' } | { type: 'scroll_to'; y: number };
 
 export type EditorViewportAnchorPublication =
-  { type: 'ready'; geometry: EditorViewportAnchorGeometry | null; targetScrollTop: number | null } | { type: 'unavailable' };
+  | {
+      type: 'ready';
+      geometry: EditorViewportAnchorGeometry | null;
+      targetScrollLeft: number | null;
+      targetScrollTop: number | null;
+    }
+  | { type: 'unavailable' };
 
 type TypewriterPreferences = {
   enabled: boolean;
@@ -138,6 +145,7 @@ export class EditorScrollScope {
   #keepVisibleTarget = $state<EditorScrollIntoViewTarget | null>(null);
   #destroyed = false;
   #expectedScrollTop: number | null = null;
+  #expectedScrollLeft: number | null = null;
   #smoothRequest: EditorBringIntoViewRequest | null = null;
   #smoothMotion: SmoothScrollMotion | null = null;
   #smoothAnimationFrame: number | null = null;
@@ -279,7 +287,7 @@ export class EditorScrollScope {
 
   prepareViewportAnchorPublication(snapshot: EditorSnapshot): EditorViewportAnchorPublication {
     const viewport = this.#editor.scrollViewport;
-    if (!viewport) return { type: 'ready', geometry: null, targetScrollTop: null };
+    if (!viewport) return { type: 'ready', geometry: null, targetScrollLeft: null, targetScrollTop: null };
     const selectionCapture = this.#editor.captureSelectionViewportAnchor(snapshot.revision);
     if (selectionCapture && this.#viewportAnchor.needsSelectionAdoption(selectionCapture.identity)) {
       const selectionMetrics = this.#viewportMetrics(snapshot, true);
@@ -289,7 +297,7 @@ export class EditorScrollScope {
       this.#viewportAnchor.adoptSelection(
         selectionCapture.identity,
         selectionGeometry,
-        selectionMetrics.scrollTop,
+        { left: selectionMetrics.scrollLeft, top: selectionMetrics.scrollTop },
         selectionMetrics.clientHeight,
         this.visibleArea,
         this.#smoothMotion !== null,
@@ -303,10 +311,12 @@ export class EditorScrollScope {
 
     const metrics = this.#viewportMetrics(snapshot, true);
     if (!metrics) return { type: 'unavailable' };
+    const clampedScrollLeft = Math.max(0, Math.min(metrics.scrollLeft, metrics.maximumScrollLeft));
     const clampedScrollTop = Math.max(0, Math.min(metrics.scrollTop, metrics.maximumScrollTop));
     const fallbackPublication = (): EditorViewportAnchorPublication => ({
       type: 'ready',
       geometry: null,
+      targetScrollLeft: clampedScrollLeft === metrics.scrollLeft ? null : clampedScrollLeft,
       targetScrollTop: clampedScrollTop === metrics.scrollTop ? null : clampedScrollTop,
     });
 
@@ -320,7 +330,7 @@ export class EditorScrollScope {
 
     const geometry = resolveViewportAnchorGeometry(resolution.geometry, metrics.layout);
     if (!geometry) return { type: 'unavailable' };
-    const targetScrollTop = this.#viewportAnchor.publicationRevealScroll(
+    const targetScroll = this.#viewportAnchor.publicationRevealScroll(
       geometry,
       metrics.scrollTop,
       metrics.clientHeight,
@@ -343,20 +353,26 @@ export class EditorScrollScope {
           ) ?? origin.scrollTop
         );
       },
+      metrics.scrollLeft,
+      metrics.maximumScrollLeft,
     );
     return {
       type: 'ready',
       geometry,
-      targetScrollTop,
+      targetScrollLeft: targetScroll.left === metrics.scrollLeft ? null : targetScroll.left,
+      targetScrollTop: targetScroll.top,
     };
   }
 
   applyViewportAnchorPublication(publication: EditorViewportAnchorPublication): void {
     if (publication.type !== 'ready') return;
     const viewport = this.#editor.scrollViewport;
-    if (publication.targetScrollTop === null) {
+    if (publication.targetScrollLeft === null && publication.targetScrollTop === null) {
       if (viewport && publication.geometry) {
-        this.#viewportAnchor.acceptGeometry(publication.geometry, viewport.getScrollTop());
+        this.#viewportAnchor.acceptGeometry(publication.geometry, {
+          left: viewport.getScrollLeft(),
+          top: viewport.getScrollTop(),
+        });
       } else {
         this.#ensureViewportAnchor();
       }
@@ -364,13 +380,19 @@ export class EditorScrollScope {
     }
     if (!viewport) return;
     const viewportRect = viewport.getRect();
+    const clientWidth = viewportRect.right - viewportRect.left;
     const clientHeight = viewportRect.bottom - viewportRect.top;
+    const maximumScrollLeft = Math.max(0, viewport.getScrollWidth() - clientWidth);
     const maximumScrollTop = Math.max(0, viewport.getScrollHeight() - clientHeight);
-    const target = Math.max(0, Math.min(publication.targetScrollTop, maximumScrollTop));
+    const previousScrollLeft = viewport.getScrollLeft();
     const previousScrollTop = viewport.getScrollTop();
-    if (Math.abs(previousScrollTop - target) > 1) {
-      viewport.scrollTo({ top: target, behavior: 'instant' });
+    const targetLeft = Math.max(0, Math.min(publication.targetScrollLeft ?? previousScrollLeft, maximumScrollLeft));
+    const targetTop = Math.max(0, Math.min(publication.targetScrollTop ?? previousScrollTop, maximumScrollTop));
+    if (Math.abs(previousScrollLeft - targetLeft) > 1 || Math.abs(previousScrollTop - targetTop) > 1) {
+      viewport.scrollTo({ left: targetLeft, top: targetTop, behavior: 'instant' });
+      const actualScrollLeft = viewport.getScrollLeft();
       const actualScrollTop = viewport.getScrollTop();
+      this.#expectedScrollLeft = actualScrollLeft;
       this.#expectedScrollTop = actualScrollTop;
       this.#smoothMotion?.translate(actualScrollTop - previousScrollTop);
     }
@@ -378,17 +400,26 @@ export class EditorScrollScope {
       this.#ensureViewportAnchor();
       return;
     }
-    this.#viewportAnchor.acceptGeometry(publication.geometry, viewport.getScrollTop());
+    this.#viewportAnchor.acceptGeometry(publication.geometry, {
+      left: viewport.getScrollLeft(),
+      top: viewport.getScrollTop(),
+    });
   }
 
   observeViewportScroll(): void {
     const viewport = this.#editor.scrollViewport;
     if (!viewport) return;
+    const scrollLeft = viewport.getScrollLeft();
     const scrollTop = viewport.getScrollTop();
-    if (this.#expectedScrollTop !== null && Math.abs(scrollTop - this.#expectedScrollTop) <= 1) {
+    const hasExpectedScroll = this.#expectedScrollLeft !== null || this.#expectedScrollTop !== null;
+    const expectedLeftMatches = this.#expectedScrollLeft === null || Math.abs(scrollLeft - this.#expectedScrollLeft) <= 1;
+    const expectedTopMatches = this.#expectedScrollTop === null || Math.abs(scrollTop - this.#expectedScrollTop) <= 1;
+    if (hasExpectedScroll && expectedLeftMatches && expectedTopMatches) {
+      this.#expectedScrollLeft = null;
       this.#expectedScrollTop = null;
       return;
     }
+    this.#expectedScrollLeft = null;
     this.#expectedScrollTop = null;
     if (this.#smoothMotion) this.cancel();
     this.#viewportAnchor.finishRevealConvergence();
@@ -398,7 +429,12 @@ export class EditorScrollScope {
     if (
       preferred &&
       metrics &&
-      this.#viewportAnchor.tryReactivatePreferredSelection(preferred, metrics.scrollTop, metrics.clientHeight, this.visibleArea)
+      this.#viewportAnchor.tryReactivatePreferredSelection(
+        preferred,
+        { left: metrics.scrollLeft, top: metrics.scrollTop },
+        metrics.clientHeight,
+        this.visibleArea,
+      )
     ) {
       return;
     }
@@ -409,7 +445,7 @@ export class EditorScrollScope {
       metrics &&
       this.#viewportAnchor.canRetainAfterDirectScroll(current, metrics.scrollTop, metrics.clientHeight, this.visibleArea)
     ) {
-      this.#viewportAnchor.acceptGeometry(current, metrics.scrollTop);
+      this.#viewportAnchor.acceptGeometry(current, { left: metrics.scrollLeft, top: metrics.scrollTop });
     } else {
       this.#attachViewportCenter();
     }
@@ -443,7 +479,7 @@ export class EditorScrollScope {
     if (Math.abs(target - metrics.scrollTop) <= 1) return;
     this.#expectedScrollTop = target;
     this.#editor.scrollViewport?.scrollTo({ top: target, behavior: 'instant' });
-    this.#viewportAnchor.acceptGeometry(geometry, target);
+    this.#viewportAnchor.acceptGeometry(geometry, { left: metrics.scrollLeft, top: target });
   }
 
   resolveScrollTop(
@@ -532,7 +568,8 @@ export class EditorScrollScope {
     const viewportRect = viewport.getRect();
     const zoom = this.#editor.safeDisplayZoom();
     const layoutMode = snapshot?.rootAttrs?.layout_mode;
-    const trailingBottomMargin = layoutMode?.type === 'paginated' ? layoutMode.page_margin_bottom * zoom : CONTINUOUS_VIEW_PADDING;
+    const trailingBottomMargin =
+      layoutMode?.type === 'paginated' ? layoutMode.page_margin_bottom * zoom : resolveContinuousViewPadding(zoom);
     return resolveTypewriterBottomPadding({
       clientHeight: viewportRect.bottom - viewportRect.top,
       targetHeight: rect.rect.height * zoom,
@@ -575,6 +612,26 @@ export class EditorScrollScope {
     this.#editor.requestPublication();
   }
 
+  attachViewportAnchorAt(point: { page: number; x: number; y: number }): void {
+    const snapshot = this.#editor.published?.snapshot;
+    const metrics = this.#viewportMetrics(snapshot);
+    if (!snapshot || !metrics) return;
+    const capture = this.#editor.captureViewportAnchorAt(snapshot.revision, {
+      page_idx: point.page,
+      x: point.x,
+      y: point.y,
+    });
+    if (!capture) return;
+    const geometry = resolveViewportAnchorGeometry(capture.geometry, metrics.layout);
+    if (!geometry) return;
+    this.#viewportAnchor.attachViewport(capture.identity, geometry, {
+      left: metrics.scrollLeft,
+      top: metrics.scrollTop,
+    });
+    this.#expectedScrollLeft = metrics.scrollLeft;
+    this.#expectedScrollTop = metrics.scrollTop;
+  }
+
   scrollIntoView(options: EditorScrollIntoViewOptions, admission?: EditorRequest): Promise<void> | undefined {
     if (this.#destroyed) {
       return;
@@ -611,7 +668,12 @@ export class EditorScrollScope {
         (!requireGuard ||
           this.#viewportAnchor.canRetainAfterDirectScroll(geometry, metrics.scrollTop, metrics.clientHeight, this.visibleArea))
       ) {
-        this.#viewportAnchor.attachSelection(capture.identity, geometry, metrics.scrollTop, revealOrigin);
+        this.#viewportAnchor.attachSelection(
+          capture.identity,
+          geometry,
+          { left: metrics.scrollLeft, top: metrics.scrollTop },
+          revealOrigin,
+        );
         return;
       }
     }
@@ -639,7 +701,7 @@ export class EditorScrollScope {
     if (!capture) return false;
     const geometry = resolveViewportAnchorGeometry(capture.geometry, metrics.layout);
     if (!geometry) return false;
-    this.#viewportAnchor.attachViewport(capture.identity, geometry, metrics.scrollTop);
+    this.#viewportAnchor.attachViewport(capture.identity, geometry, { left: metrics.scrollLeft, top: metrics.scrollTop });
     return true;
   }
 
@@ -678,36 +740,79 @@ export class EditorScrollScope {
     candidateExtent = false,
   ): {
     layout: EditorViewportAnchorLayout;
+    scrollLeft: number;
     scrollTop: number;
+    clientWidth: number;
     clientHeight: number;
+    scrollWidth: number;
     scrollHeight: number;
+    maximumScrollLeft: number;
     maximumScrollTop: number;
   } | null {
     const viewport = this.#editor.scrollViewport;
     if (!snapshot || !viewport) return null;
     const viewportRect = viewport.getRect();
+    const clientWidth = viewportRect.right - viewportRect.left;
     const clientHeight = viewportRect.bottom - viewportRect.top;
+    const scrollLeft = viewport.getScrollLeft();
     const scrollTop = viewport.getScrollTop();
-    if (!Number.isFinite(scrollTop) || !Number.isFinite(clientHeight) || clientHeight <= 0) return null;
-    const zoom = snapshot.rootAttrs?.layout_mode.type === 'paginated' ? this.#editor.safeDisplayZoom() : 1;
-    const origin = this.#editor.extensionAreaEl
-      ? this.#editor.extensionAreaEl.getBoundingClientRect().top - viewportRect.top + scrollTop
-      : 0;
-    const pages = resolvePageSpans(snapshot.pageSizes, {
+    if (![scrollLeft, scrollTop, clientWidth, clientHeight].every(Number.isFinite) || clientWidth <= 0 || clientHeight <= 0) return null;
+    const zoom = this.#editor.safeDisplayZoom();
+    const extensionRect = this.#editor.extensionAreaEl?.getBoundingClientRect();
+    const origin = extensionRect ? extensionRect.top - viewportRect.top + scrollTop : 0;
+    const extensionLeft = extensionRect ? extensionRect.left - viewportRect.left + scrollLeft : 0;
+    const useCandidateHorizontalGeometry = candidateExtent && extensionRect !== undefined;
+    const parsedPaddingLeft = useCandidateHorizontalGeometry
+      ? Number.parseFloat(this.#editor.extensionAreaEl?.style?.paddingLeft ?? '')
+      : NaN;
+    const parsedPaddingRight = useCandidateHorizontalGeometry
+      ? Number.parseFloat(this.#editor.extensionAreaEl?.style?.paddingRight ?? '')
+      : NaN;
+    const extensionPaddingLeft = Number.isFinite(parsedPaddingLeft) ? Math.max(0, parsedPaddingLeft) : 0;
+    const extensionPaddingRight = Number.isFinite(parsedPaddingRight) ? Math.max(0, parsedPaddingRight) : 0;
+    const candidateExtensionWidth = useCandidateHorizontalGeometry
+      ? Math.max(
+          clientWidth,
+          snapshot.pageSizes.reduce((width, page) => Math.max(width, page.width * zoom), 0) + extensionPaddingLeft + extensionPaddingRight,
+        )
+      : clientWidth;
+    const candidateContentWidth = Math.max(0, candidateExtensionWidth - extensionPaddingLeft - extensionPaddingRight);
+    const pageSpans = resolvePageSpans(snapshot.pageSizes, {
       origin,
       displayZoom: zoom,
       scaleFactor: this.#editor.scaleFactor,
       pageGap: snapshot.rootAttrs?.layout_mode.type === 'paginated' ? PAGE_GAP * zoom : 0,
     });
+    const pages = pageSpans.map((span) => {
+      const pageRect = this.#editor.pageEls[span.page]?.getBoundingClientRect();
+      const displayedWidth = snapshot.pageSizes[span.page].width * zoom;
+      const left = useCandidateHorizontalGeometry
+        ? extensionLeft + extensionPaddingLeft + Math.max(0, (candidateContentWidth - displayedWidth) / 2)
+        : pageRect
+          ? pageRect.left - viewportRect.left + scrollLeft
+          : extensionLeft + Math.max(0, ((extensionRect?.width ?? clientWidth) - displayedWidth) / 2);
+      return { ...span, left };
+    });
+    const predictedRight = pages.reduce(
+      (right, page) => Math.max(right, page.left + snapshot.pageSizes[page.page].width * zoom),
+      useCandidateHorizontalGeometry ? Math.max(clientWidth, extensionLeft + candidateExtensionWidth) : clientWidth,
+    );
     const predictedExtent = pages.at(-1)?.bottom ?? origin;
+    const candidateScrollWidth = Math.max(predictedRight, clientWidth);
     const candidateScrollHeight = Math.max(predictedExtent + this.bottomPaddingFor(snapshot), clientHeight);
+    const scrollWidth =
+      candidateExtent && this.#editor.scrollRootEl ? candidateScrollWidth : Math.max(viewport.getScrollWidth(), candidateScrollWidth);
     const scrollHeight =
       candidateExtent && this.#editor.scrollRootEl ? candidateScrollHeight : Math.max(viewport.getScrollHeight(), candidateScrollHeight);
     return {
       layout: { pages, zoom },
+      scrollLeft,
       scrollTop,
+      clientWidth,
       clientHeight,
+      scrollWidth,
       scrollHeight,
+      maximumScrollLeft: Math.max(0, scrollWidth - clientWidth),
       maximumScrollTop: Math.max(0, scrollHeight - clientHeight),
     };
   }

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { EditorViewportAnchorState } from './viewport-anchor';
+import { EditorViewportAnchorState, resolveViewportAnchorGeometry } from './viewport-anchor';
 import type { ViewportAnchor } from '@typie/editor-ffi/browser';
 
 const identity: ViewportAnchor = { type: 'node', node: '1:1', offset_x: 0, offset_y: 0 };
@@ -7,24 +7,39 @@ const viewportIdentity: ViewportAnchor = { type: 'node', node: '2:1', offset_x: 
 const visibleArea = { topInset: 0, bottomInset: 0 };
 
 describe('EditorViewportAnchorState', () => {
+  it('resolves page-local points through the displayed page origin and zoom on both axes', () => {
+    const resolved = resolveViewportAnchorGeometry(
+      { point: { page_idx: 0, x: 40, y: 50 }, rect: undefined },
+      { pages: [{ page: 0, left: 120, top: 300, bottom: 900 }], zoom: 1.5 },
+    );
+
+    expect(resolved).toEqual({ pointX: 180, pointY: 375 });
+  });
+
   it('keeps the anchor at its exact attached viewport point across publication', () => {
     const state = new EditorViewportAnchorState();
-    state.attach(identity, { pointY: 200 }, 100);
+    state.attach(identity, { pointX: 100, pointY: 200 }, { left: 20, top: 100 });
 
-    expect(state.publicationScroll({ pointY: 320 }, 100, 500)).toBe(220);
+    expect(state.publicationScroll({ pointX: 260, pointY: 320 }, { left: 20, top: 100 }, { left: 500, top: 500 })).toEqual({
+      left: 180,
+      top: 220,
+    });
   });
 
   it('does not move when geometry changes below the anchor', () => {
     const state = new EditorViewportAnchorState();
-    state.attach(identity, { pointY: 200 }, 100);
+    state.attach(identity, { pointX: 0, pointY: 200 }, { left: 0, top: 100 });
 
-    expect(state.publicationScroll({ pointY: 200 }, 100, 500)).toBe(100);
+    expect(state.publicationScroll({ pointX: 0, pointY: 200 }, { left: 0, top: 100 }, { left: 0, top: 500 })).toEqual({
+      left: 0,
+      top: 100,
+    });
   });
 
   it('retains a directly scrolled anchor inside the cursor guard and rejects it outside', () => {
     const state = new EditorViewportAnchorState();
-    const geometry = { pointY: 200, rect: { top: 190, bottom: 210 } };
-    state.attach(identity, geometry, 100);
+    const geometry = { pointX: 0, pointY: 200, rect: { top: 190, bottom: 210 } };
+    state.attach(identity, geometry, { left: 0, top: 100 });
 
     expect(state.canRetainAfterDirectScroll(geometry, 80, 300, visibleArea)).toBe(true);
     expect(state.canRetainAfterDirectScroll(geometry, 170, 300, visibleArea)).toBe(false);
@@ -32,8 +47,8 @@ describe('EditorViewportAnchorState', () => {
 
   it('uses the point when the anchor rect is taller than the guard', () => {
     const state = new EditorViewportAnchorState();
-    const geometry = { pointY: 150, rect: { top: 0, bottom: 1000 } };
-    state.attach(identity, geometry, 0);
+    const geometry = { pointX: 0, pointY: 150, rect: { top: 0, bottom: 1000 } };
+    state.attach(identity, geometry, { left: 0, top: 0 });
 
     expect(state.canRetainAfterDirectScroll(geometry, 0, 300, visibleArea)).toBe(true);
     expect(state.resizeScroll(geometry, 0, 300, 1000, visibleArea)).toBe(0);
@@ -41,57 +56,75 @@ describe('EditorViewportAnchorState', () => {
 
   it('moves minimally after resize pushes the anchor outside the cursor guard', () => {
     const state = new EditorViewportAnchorState();
-    const geometry = { pointY: 260, rect: { top: 250, bottom: 270 } };
-    state.attach(identity, geometry, 100);
+    const geometry = { pointX: 0, pointY: 260, rect: { top: 250, bottom: 270 } };
+    state.attach(identity, geometry, { left: 0, top: 100 });
 
     expect(state.resizeScroll(geometry, 100, 300, 1000, { topInset: 0, bottomInset: 100 })).toBe(130);
   });
 
   it('records the achieved attachment after publication clamping', () => {
     const state = new EditorViewportAnchorState();
-    state.attach(identity, { pointY: 200 }, 100);
-    const candidate = { pointY: 800 };
+    state.attach(identity, { pointX: 200, pointY: 200 }, { left: 100, top: 100 });
+    const candidate = { pointX: 800, pointY: 800 };
 
-    const clamped = state.publicationScroll(candidate, 100, 500);
+    const clamped = state.publicationScroll(candidate, { left: 100, top: 100 }, { left: 500, top: 500 });
     state.acceptGeometry(candidate, clamped);
 
-    expect(clamped).toBe(500);
+    expect(clamped).toEqual({ left: 500, top: 500 });
+    expect(state.pointAttachmentX).toBe(300);
     expect(state.pointAttachmentY).toBe(300);
   });
 
   it('finishes a provisional selection reveal where the measured rect would have revealed initially', () => {
     const state = new EditorViewportAnchorState();
-    const provisional = { pointY: 500.5, rect: { top: 500, bottom: 501 } };
-    const measured = { pointY: 600, rect: { top: 500, bottom: 700 } };
-    state.attachSelection(identity, provisional, 161);
+    const provisional = { pointX: 0, pointY: 500.5, rect: { top: 500, bottom: 501 } };
+    const measured = { pointX: 0, pointY: 600, rect: { top: 500, bottom: 700 } };
+    state.attachSelection(identity, provisional, { left: 0, top: 161 });
 
-    expect(state.publicationRevealScroll(measured, 161, 400, 1000, visibleArea)).toBe(360);
+    expect(state.publicationRevealScroll(measured, 161, 400, 1000, visibleArea)).toEqual({ left: 0, top: 360 });
   });
 
   it('reactivates a preferred selection rect after direct scrolling returns it inside the cursor guard', () => {
     const state = new EditorViewportAnchorState();
-    const selectionGeometry = { pointY: 200, rect: { top: 190, bottom: 210 } };
-    state.attachSelection(identity, selectionGeometry, 100);
-    state.attachViewport(viewportIdentity, { pointY: 500 }, 350);
+    const selectionGeometry = { pointX: 0, pointY: 200, rect: { top: 190, bottom: 210 } };
+    state.attachSelection(identity, selectionGeometry, { left: 0, top: 100 });
+    state.attachViewport(viewportIdentity, { pointX: 0, pointY: 500 }, { left: 0, top: 350 });
 
-    expect(state.tryReactivatePreferredSelection(selectionGeometry, 120, 300, visibleArea)).toBe(true);
+    expect(state.tryReactivatePreferredSelection(selectionGeometry, { left: 0, top: 120 }, 300, visibleArea)).toBe(true);
     expect(state.identity).toBe(identity);
     expect(state.pointAttachmentY).toBe(80);
   });
 
+  it('keeps the directly scrolled horizontal position when the preferred selection remains visible', () => {
+    const state = new EditorViewportAnchorState();
+    const selectionGeometry = { pointX: 200, pointY: 200, rect: { top: 190, bottom: 210 } };
+    state.attachSelection(identity, selectionGeometry, { left: 0, top: 100 });
+
+    expect(state.tryReactivatePreferredSelection(selectionGeometry, { left: 120, top: 100 }, 300, visibleArea)).toBe(true);
+    expect(state.pointAttachmentX).toBe(80);
+    expect(state.publicationScroll(selectionGeometry, { left: 120, top: 100 }, { left: 500, top: 500 }).left).toBe(120);
+  });
+
   it('does not reactivate a preferred selection without a compact rect inside the guard', () => {
     const state = new EditorViewportAnchorState();
-    state.attachSelection(identity, { pointY: 200, rect: { top: 0, bottom: 1000 } }, 100);
-    state.attachViewport(viewportIdentity, { pointY: 500 }, 350);
+    state.attachSelection(identity, { pointX: 0, pointY: 200, rect: { top: 0, bottom: 1000 } }, { left: 0, top: 100 });
+    state.attachViewport(viewportIdentity, { pointX: 0, pointY: 500 }, { left: 0, top: 350 });
 
-    expect(state.tryReactivatePreferredSelection({ pointY: 200, rect: { top: 0, bottom: 1000 } }, 100, 300, visibleArea)).toBe(false);
-    expect(state.tryReactivatePreferredSelection({ pointY: 200 }, 100, 300, visibleArea)).toBe(false);
+    expect(
+      state.tryReactivatePreferredSelection(
+        { pointX: 0, pointY: 200, rect: { top: 0, bottom: 1000 } },
+        { left: 0, top: 100 },
+        300,
+        visibleArea,
+      ),
+    ).toBe(false);
+    expect(state.tryReactivatePreferredSelection({ pointX: 0, pointY: 200 }, { left: 0, top: 100 }, 300, visibleArea)).toBe(false);
     expect(state.identity).toBe(viewportIdentity);
   });
 
   it('compares selection adoption by stable anchor identity', () => {
     const state = new EditorViewportAnchorState();
-    state.attachSelection(identity, { pointY: 200 }, 100);
+    state.attachSelection(identity, { pointX: 0, pointY: 200 }, { left: 0, top: 100 });
 
     expect(state.needsSelectionAdoption({ ...identity })).toBe(false);
     expect(state.needsSelectionAdoption(viewportIdentity)).toBe(true);
@@ -99,9 +132,9 @@ describe('EditorViewportAnchorState', () => {
 
   it('updates the preferred selection without replacing the active viewport anchor', () => {
     const state = new EditorViewportAnchorState();
-    state.attachViewport(viewportIdentity, { pointY: 500 }, 350);
+    state.attachViewport(viewportIdentity, { pointX: 0, pointY: 500 }, { left: 0, top: 350 });
 
-    state.adoptSelection(identity, { pointY: 200 }, 350, 300, visibleArea, true);
+    state.adoptSelection(identity, { pointX: 0, pointY: 200 }, { left: 0, top: 350 }, 300, visibleArea, true);
 
     expect(state.identity).toBe(viewportIdentity);
     expect(state.preferredSelectionIdentity).toBe(identity);

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.ts
@@ -9,12 +9,14 @@ import type { EditorVisibleArea } from './scroll';
 import type { EditorScrollIntoViewTarget, EditorScrollRevealPolicy } from './scroll.svelte';
 
 export type EditorViewportAnchorGeometry = {
+  pointX: number;
   pointY: number;
   rect?: { top: number; bottom: number };
 };
 
 type ActiveViewportAnchor = {
   identity: ViewportAnchor;
+  pointAttachmentX: number;
   pointAttachmentY: number;
   rect?: { top: number; bottom: number };
   revealOrigin?: EditorViewportAnchorRevealOrigin;
@@ -27,9 +29,11 @@ export type EditorViewportAnchorRevealOrigin = {
 };
 
 export type EditorViewportAnchorLayout = {
-  pages: readonly (VerticalSpan & { page: number })[];
+  pages: readonly (VerticalSpan & { page: number; left: number })[];
   zoom: number;
 };
+
+export type EditorViewportScrollPosition = { left: number; top: number };
 
 export class EditorViewportAnchorState {
   #active: ActiveViewportAnchor | null = null;
@@ -38,11 +42,17 @@ export class EditorViewportAnchorState {
   #attachActive(
     identity: ViewportAnchor,
     geometry: EditorViewportAnchorGeometry,
-    scrollTop: number,
+    scroll: EditorViewportScrollPosition,
     revealOrigin?: EditorViewportAnchorRevealOrigin,
   ): void {
-    if (!Number.isFinite(geometry.pointY) || !Number.isFinite(scrollTop)) return;
-    this.#active = { identity, pointAttachmentY: geometry.pointY - scrollTop, rect: geometry.rect, revealOrigin };
+    if (![geometry.pointX, geometry.pointY, scroll.left, scroll.top].every(Number.isFinite)) return;
+    this.#active = {
+      identity,
+      pointAttachmentX: geometry.pointX - scroll.left,
+      pointAttachmentY: geometry.pointY - scroll.top,
+      rect: geometry.rect,
+      revealOrigin,
+    };
   }
 
   get identity(): ViewportAnchor | null {
@@ -51,6 +61,10 @@ export class EditorViewportAnchorState {
 
   get pointAttachmentY(): number | null {
     return this.#active?.pointAttachmentY ?? null;
+  }
+
+  get pointAttachmentX(): number | null {
+    return this.#active?.pointAttachmentX ?? null;
   }
 
   get preferredSelectionIdentity(): ViewportAnchor | null {
@@ -66,37 +80,37 @@ export class EditorViewportAnchorState {
     return this.#preferredSelection === null || stringify(this.#preferredSelection) !== stringify(identity);
   }
 
-  attach(identity: ViewportAnchor, geometry: EditorViewportAnchorGeometry, scrollTop: number): void {
-    this.#attachActive(identity, geometry, scrollTop);
+  attach(identity: ViewportAnchor, geometry: EditorViewportAnchorGeometry, scroll: EditorViewportScrollPosition): void {
+    this.#attachActive(identity, geometry, scroll);
   }
 
   attachSelection(
     identity: ViewportAnchor,
     geometry: EditorViewportAnchorGeometry,
-    scrollTop: number,
+    scroll: EditorViewportScrollPosition,
     revealOrigin?: EditorViewportAnchorRevealOrigin,
   ): void {
     this.#preferredSelection = identity;
-    this.#attachActive(identity, geometry, scrollTop, revealOrigin);
+    this.#attachActive(identity, geometry, scroll, revealOrigin);
   }
 
-  attachViewport(identity: ViewportAnchor, geometry: EditorViewportAnchorGeometry, scrollTop: number): void {
-    this.#attachActive(identity, geometry, scrollTop);
+  attachViewport(identity: ViewportAnchor, geometry: EditorViewportAnchorGeometry, scroll: EditorViewportScrollPosition): void {
+    this.#attachActive(identity, geometry, scroll);
   }
 
   adoptSelection(
     identity: ViewportAnchor,
     geometry: EditorViewportAnchorGeometry,
-    scrollTop: number,
+    scroll: EditorViewportScrollPosition,
     clientHeight: number,
     visibleArea: EditorVisibleArea,
     preserveActiveAnchor: boolean,
   ): void {
     if (!this.needsSelectionAdoption(identity)) return;
     const activate =
-      !preserveActiveAnchor && (this.#active !== null || this.canRetainAfterDirectScroll(geometry, scrollTop, clientHeight, visibleArea));
+      !preserveActiveAnchor && (this.#active !== null || this.canRetainAfterDirectScroll(geometry, scroll.top, clientHeight, visibleArea));
     this.#preferredSelection = identity;
-    if (activate) this.#attachActive(identity, geometry, scrollTop);
+    if (activate) this.#attachActive(identity, geometry, scroll);
   }
 
   clearPreferredSelection(): void {
@@ -105,7 +119,7 @@ export class EditorViewportAnchorState {
 
   tryReactivatePreferredSelection(
     geometry: EditorViewportAnchorGeometry,
-    scrollTop: number,
+    scroll: EditorViewportScrollPosition,
     clientHeight: number,
     visibleArea: EditorVisibleArea,
   ): boolean {
@@ -119,21 +133,33 @@ export class EditorViewportAnchorState {
       !Number.isFinite(rect.top) ||
       !Number.isFinite(rect.bottom) ||
       rect.bottom < rect.top ||
-      rect.top - scrollTop < guard.top ||
-      rect.bottom - scrollTop > guard.bottom
+      rect.top - scroll.top < guard.top ||
+      rect.bottom - scroll.top > guard.bottom
     ) {
       return false;
     }
-    this.#attachActive(identity, geometry, scrollTop);
+    this.#attachActive(identity, geometry, scroll);
     return true;
   }
 
-  publicationScroll(geometry: EditorViewportAnchorGeometry, currentScrollTop: number, maximumScrollTop: number): number {
-    const attachment = this.#active?.pointAttachmentY;
-    if (attachment === undefined || !Number.isFinite(geometry.pointY) || !Number.isFinite(maximumScrollTop) || maximumScrollTop < 0) {
-      return currentScrollTop;
+  publicationScroll(
+    geometry: EditorViewportAnchorGeometry,
+    currentScroll: EditorViewportScrollPosition,
+    maximumScroll: EditorViewportScrollPosition,
+  ): EditorViewportScrollPosition {
+    const active = this.#active;
+    if (
+      !active ||
+      ![geometry.pointX, geometry.pointY, maximumScroll.left, maximumScroll.top].every(Number.isFinite) ||
+      maximumScroll.left < 0 ||
+      maximumScroll.top < 0
+    ) {
+      return currentScroll;
     }
-    return clamp(geometry.pointY - attachment, 0, maximumScrollTop);
+    return {
+      left: clamp(geometry.pointX - active.pointAttachmentX, 0, maximumScroll.left),
+      top: clamp(geometry.pointY - active.pointAttachmentY, 0, maximumScroll.top),
+    };
   }
 
   publicationRevealScroll(
@@ -143,20 +169,26 @@ export class EditorViewportAnchorState {
     scrollHeight: number,
     visibleArea: EditorVisibleArea,
     resolveReveal?: (origin: EditorViewportAnchorRevealOrigin) => number | null,
-  ): number {
-    const exact = this.publicationScroll(geometry, currentScrollTop, Math.max(0, scrollHeight - clientHeight));
+    currentScrollLeft = 0,
+    maximumScrollLeft = 0,
+  ): EditorViewportScrollPosition {
+    const exact = this.publicationScroll(
+      geometry,
+      { left: currentScrollLeft, top: currentScrollTop },
+      { left: maximumScrollLeft, top: Math.max(0, scrollHeight - clientHeight) },
+    );
     if (!rectHeightChanged(this.#active?.rect, geometry.rect)) return exact;
     const revealOrigin = this.#active?.revealOrigin;
     if (revealOrigin) {
       const reveal = resolveReveal?.(revealOrigin);
-      if (reveal !== null && reveal !== undefined) return clamp(reveal, 0, Math.max(0, scrollHeight - clientHeight));
+      if (reveal !== null && reveal !== undefined) return { ...exact, top: clamp(reveal, 0, Math.max(0, scrollHeight - clientHeight)) };
     }
-    return this.resizeScroll(geometry, exact, clientHeight, scrollHeight, visibleArea);
+    return { ...exact, top: this.resizeScroll(geometry, exact.top, clientHeight, scrollHeight, visibleArea) };
   }
 
-  acceptGeometry(geometry: EditorViewportAnchorGeometry, scrollTop: number): void {
+  acceptGeometry(geometry: EditorViewportAnchorGeometry, scroll: EditorViewportScrollPosition): void {
     const active = this.#active;
-    if (active) this.#attachActive(active.identity, geometry, scrollTop, active.revealOrigin);
+    if (active) this.#attachActive(active.identity, geometry, scroll, active.revealOrigin);
   }
 
   finishRevealConvergence(): void {
@@ -206,8 +238,9 @@ export function resolveViewportAnchorGeometry(
 ): EditorViewportAnchorGeometry | null {
   const page = layout.pages[resolved.point.page_idx];
   if (!page || !Number.isFinite(layout.zoom) || layout.zoom <= 0) return null;
+  const pointX = page.left + resolved.point.x * layout.zoom;
   const pointY = page.top + resolved.point.y * layout.zoom;
-  if (!Number.isFinite(pointY)) return null;
+  if (!Number.isFinite(pointX) || !Number.isFinite(pointY)) return null;
 
   const rectPage = resolved.rect ? layout.pages[resolved.rect.page_idx] : undefined;
   const rect =
@@ -217,7 +250,7 @@ export function resolveViewportAnchorGeometry(
           bottom: rectPage.top + (resolved.rect.rect.y + resolved.rect.rect.height) * layout.zoom,
         }
       : undefined;
-  return { pointY, rect };
+  return { pointX, pointY, rect };
 }
 
 export function viewportCenterAnchorPoint(

--- a/apps/website/src/lib/editor-ffi/zoom.test.ts
+++ b/apps/website/src/lib/editor-ffi/zoom.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampDocumentLayoutZoom,
+  computeDocumentFitWidthZoom,
+  computeDocumentZoomBounds,
+  resolveContinuousLayoutViewportWidth,
+  resolveContinuousViewPadding,
+} from './zoom';
+
+describe('continuous document zoom policy', () => {
+  const layout = { type: 'continuous', maxWidth: 600 } as const;
+
+  it.each([
+    [1.5, 500],
+    [1, 500],
+    [0.8, 625],
+  ])('maps committed zoom %s to logical viewport width %s', (committedZoom, expected) => {
+    expect(resolveContinuousLayoutViewportWidth({ viewportWidth: 500, committedZoom })).toBe(expected);
+  });
+
+  it('uses max width plus continuous padding for bounds, fit and snapping', () => {
+    expect(computeDocumentZoomBounds(layout)).toEqual({ min: 0.15625, max: 2 });
+    expect(computeDocumentFitWidthZoom(layout, 500)).toBe(0.78125);
+    expect(computeDocumentFitWidthZoom(layout, 800)).toBe(1.25);
+    expect(clampDocumentLayoutZoom({ zoom: 0.79, layout, viewportWidth: 500 })).toBe(0.78125);
+  });
+
+  it('falls back safely for invalid viewport and zoom input', () => {
+    expect(resolveContinuousLayoutViewportWidth({ viewportWidth: NaN, committedZoom: NaN })).toBe(1);
+    expect(clampDocumentLayoutZoom({ zoom: NaN, layout, viewportWidth: NaN })).toBe(0.15625);
+  });
+
+  it('scales the engine owned continuous padding with visual zoom', () => {
+    expect(resolveContinuousViewPadding(1.5)).toBe(30);
+    expect(resolveContinuousViewPadding(0.5)).toBe(10);
+    expect(resolveContinuousViewPadding(NaN)).toBe(20);
+  });
+});

--- a/apps/website/src/lib/editor-ffi/zoom.ts
+++ b/apps/website/src/lib/editor-ffi/zoom.ts
@@ -1,4 +1,5 @@
 import { clamp } from '@typie/ui/utils';
+import { CONTINUOUS_VIEW_PADDING } from './constants';
 
 export const MIN_DOCUMENT_DISPLAY_WIDTH = 100;
 export const MAX_DOCUMENT_ZOOM = 2;
@@ -12,11 +13,16 @@ export type ZoomBounds = {
   max: number;
 };
 
-export function computePaginatedZoomBounds(pageWidth: number, minDisplayWidth = MIN_DOCUMENT_DISPLAY_WIDTH): ZoomBounds {
-  const safePageWidth = Number.isFinite(pageWidth) && pageWidth > 0 ? pageWidth : 1;
-  const minZoom = clamp(minDisplayWidth / safePageWidth, 0.01, Infinity);
-  const maxZoom = clamp(MAX_DOCUMENT_ZOOM, minZoom, Infinity);
-  return { min: minZoom, max: maxZoom };
+export type DocumentZoomLayout = { type: 'continuous'; maxWidth: number } | { type: 'paginated'; pageWidth: number };
+
+export function documentZoomWidth(layout: DocumentZoomLayout): number {
+  const width = layout.type === 'continuous' ? layout.maxWidth + CONTINUOUS_VIEW_PADDING * 2 : layout.pageWidth;
+  return Number.isFinite(width) && width > 0 ? width : 1;
+}
+
+export function computeDocumentZoomBounds(layout: DocumentZoomLayout, minDisplayWidth = MIN_DOCUMENT_DISPLAY_WIDTH): ZoomBounds {
+  const minZoom = clamp(minDisplayWidth / documentZoomWidth(layout), 0.01, Infinity);
+  return { min: minZoom, max: clamp(MAX_DOCUMENT_ZOOM, minZoom, Infinity) };
 }
 
 export function clampDocumentZoom(zoom: number, bounds: ZoomBounds): number {
@@ -26,21 +32,31 @@ export function clampDocumentZoom(zoom: number, bounds: ZoomBounds): number {
   return clamp(zoom, bounds.min, bounds.max);
 }
 
-export function computePaginatedFitWidthZoom(pageWidth: number, viewportWidth: number): number {
-  const bounds = computePaginatedZoomBounds(pageWidth);
-  const safePageWidth = Number.isFinite(pageWidth) && pageWidth > 0 ? pageWidth : 1;
-  const safeViewportWidth = Number.isFinite(viewportWidth) && viewportWidth > 0 ? viewportWidth : safePageWidth;
-  return clamp(safeViewportWidth / safePageWidth, bounds.min, bounds.max);
+export function computeDocumentFitWidthZoom(layout: DocumentZoomLayout, viewportWidth: number): number {
+  const width = documentZoomWidth(layout);
+  const bounds = computeDocumentZoomBounds(layout);
+  const safeViewportWidth = Number.isFinite(viewportWidth) && viewportWidth > 0 ? viewportWidth : width;
+  return clamp(safeViewportWidth / width, bounds.min, bounds.max);
 }
 
-export function computeInitialPaginatedZoom(pageWidth: number, viewportWidth: number): number {
-  return Math.min(computePaginatedFitWidthZoom(pageWidth, viewportWidth), 1);
+export function computeInitialDocumentZoom(layout: DocumentZoomLayout, viewportWidth: number): number {
+  return layout.type === 'continuous'
+    ? clampDocumentZoom(1, computeDocumentZoomBounds(layout))
+    : Math.min(computeDocumentFitWidthZoom(layout, viewportWidth), 1);
 }
 
-export function clampPaginatedZoom({ zoom, pageWidth, viewportWidth }: { zoom: number; pageWidth: number; viewportWidth: number }): number {
-  const bounds = computePaginatedZoomBounds(pageWidth);
+export function clampDocumentLayoutZoom({
+  zoom,
+  layout,
+  viewportWidth,
+}: {
+  zoom: number;
+  layout: DocumentZoomLayout;
+  viewportWidth: number;
+}): number {
+  const bounds = computeDocumentZoomBounds(layout);
   const clamped = clampDocumentZoom(zoom, bounds);
-  const fitWidthZoom = computePaginatedFitWidthZoom(pageWidth, viewportWidth);
+  const fitWidthZoom = computeDocumentFitWidthZoom(layout, viewportWidth);
   const unitZoom = clampDocumentZoom(1, bounds);
 
   let snapped: number | null = null;
@@ -58,6 +74,22 @@ export function clampPaginatedZoom({ zoom, pageWidth, viewportWidth }: { zoom: n
   }
 
   return snapped ?? clamped;
+}
+
+export function resolveContinuousLayoutViewportWidth({
+  viewportWidth,
+  committedZoom,
+}: {
+  viewportWidth: number;
+  committedZoom: number;
+}): number {
+  const safeWidth = Number.isFinite(viewportWidth) && viewportWidth > 0 ? viewportWidth : 1;
+  const safeZoom = renderZoomForDisplay(committedZoom);
+  return safeWidth / Math.min(safeZoom, 1);
+}
+
+export function resolveContinuousViewPadding(displayZoom: number): number {
+  return CONTINUOUS_VIEW_PADDING * renderZoomForDisplay(displayZoom);
 }
 
 export function renderZoomForDisplay(displayZoom: number): number {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
@@ -2,8 +2,8 @@
   import { css } from '@typie/styled-system/css';
   import { Button, SegmentButtons } from '@typie/ui/components';
   import { untrack } from 'svelte';
-  import { CONTINUOUS_VIEW_PADDING } from '$lib/editor-ffi/constants';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { resolveContinuousViewPadding } from '$lib/editor-ffi/zoom';
   import PrismReviewDetail from '../../../@prism/review/PrismReviewDetail.svelte';
   import { getMarginContext } from './context.svelte.ts';
   import { lanePresentation, targetColumnLeft } from './margin-motion.ts';
@@ -121,11 +121,12 @@
     desiredTops = nextTops;
     marks = nextMarks;
 
-    // 첫 페이지의 화면 좌표에서 본문 왼쪽을 얻는다 — 페이지 모드는 page_margin_left, 연속 모드는 CONTINUOUS_VIEW_PADDING만큼 안쪽이다
+    // 첫 페이지의 화면 좌표에서 본문 왼쪽을 얻는다 — 페이지 모드는 page_margin_left,
+    // 연속 모드는 CONTINUOUS_VIEW_PADDING에 현재 줌을 적용한 만큼 안쪽이다
     const pageEl = editor.pageEls[0];
     const layout = editor.rootAttrs?.layout_mode;
     if (pageEl && layout) {
-      const inset = layout.type === 'paginated' ? layout.page_margin_left * zoom : CONTINUOUS_VIEW_PADDING;
+      const inset = layout.type === 'paginated' ? layout.page_margin_left * zoom : resolveContinuousViewPadding(zoom);
       const pageRect = pageEl.getBoundingClientRect();
       const pageLayoutLeft = layoutLeftWithin(pageEl, area);
       if (pageLayoutLeft !== null) {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -295,9 +295,8 @@
     const editor = ctx.editor;
     const layout = editor?.rootAttrs?.layout_mode;
     if (!editor || !layout) return Infinity;
-    return layout.type === 'paginated'
-      ? (editor.pageSizes[0]?.width ?? 0) * editor.safeDisplayZoom()
-      : layout.max_width + CONTINUOUS_VIEW_PADDING * 2;
+    const pageWidth = editor.pageSizes[0]?.width;
+    return pageWidth ? pageWidth * editor.safeDisplayZoom() : Infinity;
   });
 
   const title = $derived(document?.title ?? '');

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -1294,6 +1294,20 @@ mod invalidation_tests {
     }
 
     #[test]
+    fn continuous_resize_reflows_only_when_effective_content_width_changes() {
+        let mut projected = ProjectedState::empty();
+        projected.commit();
+        let state = State::new(projected, None);
+        let mut view = make_view(500.0);
+
+        view.layout(&state);
+
+        assert!(view.resize(Viewport::new(625.0, 800.0, 1.0), &state));
+        assert!(view.resize(Viewport::new(700.0, 700.0, 2.0), &state));
+        assert!(!view.resize(Viewport::new(800.0, 700.0, 2.0), &state));
+    }
+
+    #[test]
     fn taking_layout_dirty_does_not_clone_a_current_layout_snapshot() {
         let mut projected = ProjectedState::empty();
         projected.commit();

--- a/packages/ui/src/utils/scroll-viewport.ts
+++ b/packages/ui/src/utils/scroll-viewport.ts
@@ -3,6 +3,7 @@ export type ScrollViewport = {
   getRect(): { top: number; bottom: number; left: number; right: number };
   getScrollTop(): number;
   getScrollLeft(): number;
+  getScrollWidth(): number;
   getScrollHeight(): number;
   scrollBy(x: number, y: number): void;
   scrollTo(options: ScrollToOptions): void;
@@ -14,6 +15,7 @@ export function elementScrollViewport(el: HTMLElement): ScrollViewport {
     getRect: () => el.getBoundingClientRect(),
     getScrollTop: () => el.scrollTop,
     getScrollLeft: () => el.scrollLeft,
+    getScrollWidth: () => el.scrollWidth,
     getScrollHeight: () => el.scrollHeight,
     scrollBy: (x, y) => el.scrollBy(x, y),
     scrollTo: (options) => el.scrollTo(options),
@@ -26,6 +28,7 @@ export function windowScrollViewport(): ScrollViewport {
     getRect: () => ({ top: 0, bottom: window.innerHeight, left: 0, right: window.innerWidth }),
     getScrollTop: () => window.scrollY,
     getScrollLeft: () => window.scrollX,
+    getScrollWidth: () => document.scrollingElement?.scrollWidth ?? 0,
     getScrollHeight: () => document.scrollingElement?.scrollHeight ?? 0,
     scrollBy: (x, y) => window.scrollBy(x, y),
     scrollTo: (options) => window.scrollTo(options),


### PR DESCRIPTION
## 배경

연속 레이아웃에서도 문서 줌을 지원하되, 확대할 때는 기존 max width를 유지해 가로 스크롤을 허용하고 축소할 때는 확보된 논리적 공간을 max width까지 레이아웃에 반영해야 합니다.

## 변경 사항

- 연속 레이아웃에 확대·축소와 줌 오버레이를 지원합니다.
- 표시 줌과 렌더 줌을 분리해 제스처 중에는 합성만 갱신하고, 기존 디바운스 시점에 엔진 레이아웃과 surface를 갱신합니다.
- Web과 Compose의 뷰포트 앵커를 양축으로 확장하고 스크롤 소유권을 구분해, 줌 중 초점 유지와 가로 스크롤 도달성을 보장합니다.
- 연속 레이아웃의 실제 표시 폭을 기준으로 line highlight, overlay, PRISM review column과 viewport geometry를 계산합니다.
- paginated에 종속돼 있던 줌 정책을 문서 레이아웃 사양으로 일반화합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>