### PR TITLE
모듈 단위 Svelte context를 HMR 사이에서 유지

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/sveltekit';
-import { createStableContext } from '@typie/ui/context';
+import { createStableContext } from '@typie/ui/context/stable';
 import { debounce } from '@typie/ui/utils';
 import { tick, untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';

--- a/apps/website/src/lib/note/note-edit-state.svelte.ts
+++ b/apps/website/src/lib/note/note-edit-state.svelte.ts
@@ -1,5 +1,6 @@
+import { createStableContext } from '@typie/ui/context/stable';
 import { Toast } from '@typie/ui/notification';
-import { getContext, setContext, untrack } from 'svelte';
+import { untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
 type NoteFieldSnapshot = {
@@ -419,17 +420,6 @@ export class NoteEdits {
   }
 }
 
-const NOTE_EDITS_CONTEXT = Symbol('NoteEdits');
+const [getNoteEditsContext, setNoteEditsContext] = createStableContext<NoteEdits>('note.NoteEdits');
 
-export function setNoteEditsContext(noteEdits: NoteEdits): NoteEdits {
-  setContext(NOTE_EDITS_CONTEXT, noteEdits);
-  return noteEdits;
-}
-
-export function getNoteEditsContext(): NoteEdits {
-  const noteEdits = getContext<NoteEdits>(NOTE_EDITS_CONTEXT);
-  if (!noteEdits) {
-    throw new Error('NoteEdits not found');
-  }
-  return noteEdits;
-}
+export { getNoteEditsContext, setNoteEditsContext };

--- a/apps/website/src/lib/note/note-list-presence.test.ts
+++ b/apps/website/src/lib/note/note-list-presence.test.ts
@@ -14,6 +14,7 @@ vi.mock('@typie/ui/utils', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@typie/ui/utils')>()),
   animateFlip,
 }));
+vi.mock('./note-mutation', () => ({ getNoteOperationsContext: () => ({ move: vi.fn() }) }));
 vi.mock('./note-sync.svelte', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./note-sync.svelte')>()),
   getNoteSyncContext: () => syncContext.current,

--- a/apps/website/src/lib/note/note-list-remote-reorder.test.ts
+++ b/apps/website/src/lib/note/note-list-remote-reorder.test.ts
@@ -9,6 +9,7 @@ const { onTerminalDelete, retainRelatedEntity } = vi.hoisted(() => ({
 }));
 
 vi.mock('@sentry/sveltekit', () => ({ captureException: vi.fn() }));
+vi.mock('./note-mutation', () => ({ getNoteOperationsContext: () => ({ move: vi.fn() }) }));
 vi.mock('./note-sync.svelte', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./note-sync.svelte')>()),
   getNoteSyncContext: () => ({ onTerminalDelete, retainRelatedEntity }),

--- a/apps/website/src/lib/note/note-mutation.ts
+++ b/apps/website/src/lib/note/note-mutation.ts
@@ -1,7 +1,7 @@
 import { createMutation } from '@mearie/svelte';
 import * as Sentry from '@sentry/sveltekit';
 import { TypieError } from '@typie/lib/errors';
-import { getContext, setContext } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
 import { unwrapError } from '$lib/graphql/error';
 import { graphql } from '$mearie';
 import type { VariablesOf } from '@mearie/svelte';
@@ -324,13 +324,6 @@ export class NoteOperations {
   }
 }
 
-const NOTE_OPERATIONS_CONTEXT = Symbol('NoteOperations');
+const [getNoteOperationsContext, setNoteOperationsContext] = createStableContext<NoteOperations>('note.NoteOperations');
 
-export function setNoteOperationsContext(operations: NoteOperations): NoteOperations {
-  setContext(NOTE_OPERATIONS_CONTEXT, operations);
-  return operations;
-}
-
-export function getNoteOperationsContext(): NoteOperations {
-  return getContext<NoteOperations>(NOTE_OPERATIONS_CONTEXT);
-}
+export { getNoteOperationsContext, setNoteOperationsContext };

--- a/apps/website/src/lib/note/note-sync.svelte.ts
+++ b/apps/website/src/lib/note/note-sync.svelte.ts
@@ -1,5 +1,6 @@
 /* eslint-disable svelte/prefer-svelte-reactivity -- Subscription registries must not retrigger the effects that register them. */
-import { getContext, setContext, untrack } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
+import { untrack } from 'svelte';
 
 export type NoteUpdate = {
   kind: 'CREATED' | 'UPDATED' | 'DELETED';
@@ -141,13 +142,6 @@ export class NoteSync {
   }
 }
 
-const NOTE_SYNC_CONTEXT = Symbol('NoteSync');
+const [getNoteSyncContext, setNoteSyncContext] = createStableContext<NoteSync>('note.NoteSync');
 
-export function setNoteSyncContext(noteSync: NoteSync): NoteSync {
-  setContext(NOTE_SYNC_CONTEXT, noteSync);
-  return noteSync;
-}
-
-export function getNoteSyncContext(): NoteSync {
-  return getContext<NoteSync>(NOTE_SYNC_CONTEXT);
-}
+export { getNoteSyncContext, setNoteSyncContext };

--- a/apps/website/src/lib/prism/open-documents.svelte.ts
+++ b/apps/website/src/lib/prism/open-documents.svelte.ts
@@ -1,4 +1,5 @@
-import { getContext, setContext, untrack } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
+import { untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
 export type OpenDocument = {
@@ -12,7 +13,9 @@ export type OpenDocument = {
   active: boolean;
 };
 
-const key: unique symbol = Symbol('OpenDocuments');
+const [getOpenDocuments, setOpenDocuments] = createStableContext<OpenDocumentRegistry>('prism.OpenDocuments');
+
+export { getOpenDocuments };
 
 export class OpenDocumentRegistry {
   #entries = new SvelteMap<string, OpenDocument | null>();
@@ -112,14 +115,6 @@ export class OpenDocumentRegistry {
 
 export const setupOpenDocuments = () => {
   const registry = new OpenDocumentRegistry();
-  setContext(key, registry);
-  return registry;
-};
-
-export const getOpenDocuments = (): OpenDocumentRegistry => {
-  const registry = getContext<OpenDocumentRegistry>(key);
-  if (!registry) {
-    throw new Error('OpenDocumentRegistry not found');
-  }
+  setOpenDocuments(registry);
   return registry;
 };

--- a/apps/website/src/routes/website/(dashboard)/@notes/notes-overlay.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@notes/notes-overlay.browser.test.ts
@@ -14,7 +14,7 @@ vi.mock(import('@mearie/svelte'), async (importOriginal) => ({
   createQuery: vi.fn(),
 }));
 vi.mock('@sentry/sveltekit', () => ({ captureException: vi.fn() }));
-vi.mock('@typie/ui/context', () => ({ getAppContext: vi.fn() }));
+vi.mock('@typie/ui/context', () => ({ getAppContext: vi.fn(), tryAppContext: vi.fn() }));
 vi.mock('mixpanel-browser', () => ({ default: { track: vi.fn() } }));
 vi.mock('$app/navigation', () => ({ afterNavigate: vi.fn(), beforeNavigate: vi.fn() }));
 vi.mock('$lib/graphql', () => ({ cache: { invalidate: vi.fn() } }));

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-panel-boundary.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-panel-boundary.browser.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import PrismPanelBoundaryTestHost, { prismPanelBoundaryHarness } from './PrismPanelBoundaryTestHost.svelte';
 
 vi.mock('@sentry/sveltekit', () => ({ captureException: vi.fn() }));
-vi.mock('@typie/ui/context', () => ({ getAppContext: vi.fn() }));
+vi.mock('@typie/ui/context', () => ({ getAppContext: vi.fn(), tryAppContext: vi.fn() }));
 
 const app = {
   preference: {

--- a/apps/website/src/routes/website/(dashboard)/@tree/state.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/@tree/state.svelte.ts
@@ -1,4 +1,4 @@
-import { getContext, setContext } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import type { TreeEntity } from './@selection/types';
 
@@ -10,11 +10,9 @@ export type TreeState = {
   element?: HTMLElement;
 };
 
-const key: unique symbol = Symbol('TreeContext');
+const [getTreeContext, setTreeContext] = createStableContext<TreeState>('tree.TreeContext');
 
-export const getTreeContext = () => {
-  return getContext<TreeState>(key);
-};
+export { getTreeContext };
 
 export const setupTreeContext = () => {
   const treeState = $state<TreeState>({
@@ -25,7 +23,7 @@ export const setupTreeContext = () => {
     element: undefined,
   });
 
-  setContext(key, treeState);
+  setTreeContext(treeState);
 
   return treeState;
 };

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widget-context.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widget-context.svelte.ts
@@ -1,4 +1,4 @@
-import { getContext, setContext } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
 import type {
   Editor_Widget_CharacterCountChangeWidget_document$key,
   Editor_Widget_DocumentRelatedNoteWidget_document$key,
@@ -26,7 +26,9 @@ type WidgetEnvironment = {
     | undefined;
 };
 
-const key: unique symbol = Symbol('WidgetContext');
+const [getWidgetContext, setWidgetContext] = createStableContext<WidgetContext>('widgets.WidgetContext');
+
+export { getWidgetContext };
 
 export class WidgetContext {
   env = $state<WidgetEnvironment>({
@@ -45,14 +47,6 @@ export class WidgetContext {
 
 export const setupWidgetContext = () => {
   const context = new WidgetContext();
-  setContext(key, context);
-  return context;
-};
-
-export const getWidgetContext = (): WidgetContext => {
-  const context = getContext<WidgetContext>(key);
-  if (!context) {
-    throw new Error('WidgetContext not found');
-  }
+  setWidgetContext(context);
   return context;
 };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/context.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/context.svelte.ts
@@ -1,3 +1,4 @@
+import { createStableContext } from '@typie/ui/context/stable';
 import { LocalStore } from '@typie/ui/state';
 import { nanoid } from 'nanoid';
 import { getContext, setContext } from 'svelte';
@@ -22,11 +23,9 @@ export type {
   Rect,
 } from './types';
 
-const key: unique symbol = Symbol('PaneGroup');
+const [getPaneGroup, setPaneGroup] = createStableContext<PaneGroup>('pane.PaneGroup');
 
-export const getPaneGroup = () => {
-  return getContext<PaneGroup>(key);
-};
+export { getPaneGroup };
 
 const defaultPaneGroupState: PaneGroupState = {
   root: null,
@@ -344,7 +343,7 @@ export const setupPaneGroup = (initialSiteId: string, options: PaneGroupOptions)
     },
   };
 
-  setContext(key, context);
+  setPaneGroup(context);
 
   return context;
 };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/editor-registry.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/editor-registry.svelte.ts
@@ -1,10 +1,12 @@
-import { getContext, setContext } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
 import { SvelteMap } from 'svelte/reactivity';
 import type { Editor as FfiEditor } from '$lib/editor-ffi/editor.svelte';
 
 export type RegisteredEditor = FfiEditor;
 
-const key: unique symbol = Symbol('EditorRegistry');
+const [getEditorRegistry, setEditorRegistry] = createStableContext<EditorRegistry>('pane.EditorRegistry');
+
+export { getEditorRegistry };
 
 class EditorRegistry {
   #entries = new SvelteMap<string, RegisteredEditor>();
@@ -29,14 +31,6 @@ class EditorRegistry {
 
 export const setupEditorRegistry = () => {
   const registry = new EditorRegistry();
-  setContext(key, registry);
-  return registry;
-};
-
-export const getEditorRegistry = (): EditorRegistry => {
-  const registry = getContext<EditorRegistry>(key);
-  if (!registry) {
-    throw new Error('EditorRegistry not found');
-  }
+  setEditorRegistry(registry);
   return registry;
 };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/open-documents-panes.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/open-documents-panes.test.ts
@@ -23,6 +23,7 @@ const localStorageStub = vi.hoisted(() => {
 
 vi.mock('@typie/ui/context', () => ({
   getAppContext: () => ({ preference: { current: { zenModeEnabled: false } } }),
+  tryAppContext: vi.fn(),
 }));
 
 vi.mock('./EntityPane.svelte', async () => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/context.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/context.svelte.ts
@@ -1,4 +1,4 @@
-import { getContext, setContext } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
 import type { CommentAnchor } from '$lib/editor-ffi/comments';
 import type { CommentComposerV2_user$key, CommentPopoverV2_thread$key, DocumentPanelV2CommentItem_thread$key } from '$mearie';
 
@@ -34,6 +34,7 @@ export type CommentController = {
   unresolveThread: (threadId: string) => Promise<void>;
 };
 
-const KEY = Symbol('DocumentComments');
-export const setupCommentContext = (c: CommentController) => setContext(KEY, c);
-export const getCommentContext = () => getContext<CommentController>(KEY);
+const [getCommentContext, setCommentContext] = createStableContext<CommentController>('document-comments.DocumentComments');
+
+export { getCommentContext };
+export const setupCommentContext = (controller: CommentController) => setCommentContext(controller);

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/focus-return.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/focus-return.svelte.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
 import { FocusReturnSession } from '$lib/focus-return-session';
 
 type DocumentPanelFocusReturn = {
@@ -7,7 +7,9 @@ type DocumentPanelFocusReturn = {
   discard: () => void;
 };
 
-const [getDocumentPanelFocusReturn, setDocumentPanelFocusReturn] = createContext<DocumentPanelFocusReturn>();
+const [getDocumentPanelFocusReturn, setDocumentPanelFocusReturn] = createStableContext<DocumentPanelFocusReturn>(
+  'document-panel.DocumentPanelFocusReturn',
+);
 
 export { getDocumentPanelFocusReturn };
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/context.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/context.svelte.ts
@@ -1,4 +1,4 @@
-import { getContext, setContext } from 'svelte';
+import { createStableContext } from '@typie/ui/context/stable';
 import type { DataOf } from '@mearie/svelte';
 import type { DocumentPrismReviewMargin_Round_Query } from '$mearie';
 import type { DetailRound } from '../../../@prism/review/round-view.ts';
@@ -59,16 +59,15 @@ export type MarginController = {
   react: (threadId: string, value: 'UP' | 'DOWN' | null) => Promise<void>;
 };
 
-const KEY = Symbol('PrismReviewMargin');
+const [getRequiredMarginContext, setMarginContext, getOptionalMarginContext] =
+  createStableContext<MarginController>('prism-review.PrismReviewMargin');
 
-export const setupMarginContext = (controller: MarginController) => setContext(KEY, controller);
+export const setupMarginContext = (controller: MarginController) => setMarginContext(controller);
 
 // 여백 안쪽 컴포넌트용 — 컨텍스트 없이 뜨는 일이 없으므로 없으면 결함이다
 export const getMarginContext = (): MarginController => {
-  const controller = getContext<MarginController | undefined>(KEY);
-  if (!controller) throw new Error('PrismReviewMargin context not found');
-  return controller;
+  return getRequiredMarginContext();
 };
 
 // 툴바용 — 미리보기·뷰어 에디터는 이 컨텍스트 없이 뜬다
-export const tryMarginContext = (): MarginController | undefined => getContext<MarginController | undefined>(KEY);
+export const tryMarginContext = (): MarginController | undefined => getOptionalMarginContext();

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,7 @@
     "./components": "./src/components/index.ts",
     "./constants": "./src/constants/index.ts",
     "./context": "./src/context/index.ts",
+    "./context/stable": "./src/context/stable-context.ts",
     "./effects": "./src/effects/index.ts",
     "./form": "./src/form/index.ts",
     "./notification": "./src/notification/index.ts",

--- a/packages/ui/src/components/Menu.svelte
+++ b/packages/ui/src/components/Menu.svelte
@@ -5,7 +5,7 @@
   import { scale } from 'svelte/transition';
   import { afterNavigate } from '$app/navigation';
   import { createFloatingActions, deactivateFocusTrap, focusTrap, portal, updateFocusTrapContainers } from '../actions';
-  import { getAppContext } from '../context';
+  import { tryAppContext } from '../context';
   import { createHoverFocusHandler, pushEscapeHandler } from '../utils';
   import type { OffsetOptions, Placement } from '@floating-ui/dom';
   import type { SystemStyleObject } from '@typie/styled-system/types';
@@ -50,7 +50,7 @@
   let buttonEl = $state<HTMLButtonElement>();
   let menuEl = $state<HTMLUListElement>();
 
-  const app = getAppContext();
+  const app = tryAppContext();
 
   const { anchor, floating } = createFloatingActions({
     placement,

--- a/packages/ui/src/context/app.svelte.ts
+++ b/packages/ui/src/context/app.svelte.ts
@@ -1,5 +1,5 @@
-import { getContext, setContext } from 'svelte';
 import { LocalStore, SessionStore } from '../state';
+import { createStableContext } from './stable-context';
 
 export type AppPreference = {
   sidebarWidth: number;
@@ -96,11 +96,9 @@ export type AppContext = {
   timerState: SessionStore<AppTimerState>;
 };
 
-const key: unique symbol = Symbol('AppContext');
+const [getAppContext, setAppContext, tryAppContext] = createStableContext<AppContext>('ui.AppContext');
 
-export const getAppContext = () => {
-  return getContext<AppContext>(key);
-};
+export { getAppContext, tryAppContext };
 
 export const setupAppContext = (userId: string) => {
   const appState = $state<AppState>({
@@ -184,7 +182,7 @@ export const setupAppContext = (userId: string) => {
     }),
   };
 
-  setContext(key, context);
+  setAppContext(context);
 
   return context;
 };

--- a/packages/ui/src/context/index.ts
+++ b/packages/ui/src/context/index.ts
@@ -1,3 +1,2 @@
 export * from './app.svelte';
-export * from './stable-context';
 export * from './theme.svelte';

--- a/packages/ui/src/context/stable-context.ts
+++ b/packages/ui/src/context/stable-context.ts
@@ -11,5 +11,6 @@ export const createStableContext = <T>(name: string) => {
       return getContext<T>(key);
     },
     (context: T) => setContext(key, context),
+    () => getContext<T | undefined>(key),
   ] as const;
 };

--- a/packages/ui/src/context/theme.svelte.ts
+++ b/packages/ui/src/context/theme.svelte.ts
@@ -1,8 +1,8 @@
-import { getContext, setContext } from 'svelte';
 import { MediaQuery } from 'svelte/reactivity';
 import Cookies from 'universal-cookie';
 import { browser } from '$app/environment';
 import { page } from '$app/state';
+import { createStableContext } from './stable-context';
 import type { CookieChangeOptions } from 'universal-cookie';
 
 export type Theme = 'light' | 'dark' | 'auto';
@@ -147,16 +147,14 @@ export class ThemeState {
   }
 }
 
-const key: unique symbol = Symbol('ThemeContext');
+const [getThemeContext, setThemeContext] = createStableContext<ThemeState>('ui.ThemeContext');
 
-export const getThemeContext = () => {
-  return getContext<ThemeState>(key);
-};
+export { getThemeContext };
 
 export const setupThemeContext = () => {
   const themeState = $state<ThemeState>(new ThemeState());
 
-  setContext(key, themeState);
+  setThemeContext(themeState);
 
   return themeState;
 };


### PR DESCRIPTION
## 변경 사항

- `createStableContext`를 전용 `@typie/ui/context/stable` 경로로 노출
- 앱, 테마, 노트, pane, widget, PRISM 등의 모듈 단위 Svelte context에 HMR 사이에서 재사용되는 key 적용
- context provider 밖에서도 사용되는 `Menu`를 위해 optional getter 추가
- 변경된 context getter에 맞춰 관련 테스트 mock 보완

## 배경

HMR 중 provider와 consumer가 서로 다른 모듈 버전을 참조하면 module-local `Symbol`이 서로 다른 key로 생성될 수 있었습니다. 이 경우 context가 실제로 제공되고 있어도 `missing context` 오류가 발생하며, dev 서버를 재시작해야 복구됐습니다.

이름을 기준으로 재사용되는 context key를 사용해 HMR 이후에도 provider와 consumer가 같은 context를 참조하도록 변경했습니다.