### PR TITLE
스크롤 모드 줌 2

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/Editor.kt
@@ -68,6 +68,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -294,6 +295,9 @@ internal constructor(
   }
 
   internal fun quiesceLocalEdits(): LocalEditQuiescence = localEdits.quiesce()
+
+  internal val localEditAdmissionGeneration: StateFlow<Long>
+    get() = localEdits.admissionGeneration
 
   suspend fun update(
     admit: () -> Boolean = { true },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorLocalEditCoordinator.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorLocalEditCoordinator.kt
@@ -5,7 +5,10 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 
 internal class LocalEditQuiescence
@@ -46,6 +49,9 @@ internal class EditorLocalEditCoordinator {
   )
 
   private val state = MutableStateFlow(State())
+  private val mutableAdmissionGeneration = MutableStateFlow(0L)
+
+  val admissionGeneration: StateFlow<Long> = mutableAdmissionGeneration.asStateFlow()
 
   fun register(): LocalEdit? {
     while (true) {
@@ -118,7 +124,10 @@ internal class EditorLocalEditCoordinator {
       val current = state.value
       val next =
         current.copy(accepting = true, failures = current.failures.filterKeys { it > through })
-      if (state.compareAndSet(current, next)) return
+      if (state.compareAndSet(current, next)) {
+        if (!current.accepting) mutableAdmissionGeneration.update { it + 1L }
+        return
+      }
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -63,7 +62,6 @@ internal fun EditorView(
   val incomingContentHandler = LocalEditorIncomingContentHandler.current
   val zoomController = LocalEditorZoomController.current
   val displayZoom = zoomController.displayZoom
-  val renderZoom = zoomController.renderZoom
   val themeVariant = currentEditorThemeVariant()
   val canCreateEditor = runtime.canCreateEditor
   val environment =
@@ -75,34 +73,10 @@ internal fun EditorView(
     )
   val currentLoad by rememberUpdatedState(load)
   val currentEnvironment by rememberUpdatedState(environment)
-  val attachedEditor = runtime.editor
   var editorThemeVariant by remember(load) { mutableStateOf<ThemeVariant?>(null) }
-  var attachedEditorRenderZoom by remember(load, attachedEditor) { mutableFloatStateOf(renderZoom) }
 
-  LaunchedEffect(load, canCreateEditor, environment, attachedEditor, layoutSpec, renderZoom) {
+  LaunchedEffect(load, canCreateEditor, environment) {
     if (!environment.isValid) {
-      return@LaunchedEffect
-    }
-    if (attachedEditor != null && layoutSpec is EditorDocumentLayoutSpec.Continuous) {
-      if (zoomEquals(attachedEditorRenderZoom, renderZoom)) {
-        return@LaunchedEffect
-      }
-      val resizeApplied = attachedEditor.runEffect {
-        attachedEditor.update {
-          enqueue(
-            Message.System(
-              SystemEvent.Resize(
-                width = environment.width,
-                height = environment.height,
-                scaleFactor = environment.scaleFactor,
-              )
-            )
-          )
-        }
-      }
-      if (resizeApplied) {
-        attachedEditorRenderZoom = renderZoom
-      }
       return@LaunchedEffect
     }
     if (!canCreateEditor) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
@@ -59,7 +60,6 @@ import co.typie.editor.body.EditorBody
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.decodeDocumentLayoutSpec
 import co.typie.editor.body.resolveBaseBottomSpace
-import co.typie.editor.body.resolveContinuousLayoutViewportWidth
 import co.typie.editor.body.resolveEditorBodyGeometry
 import co.typie.editor.body.toEditorDocumentLayoutSpec
 import co.typie.editor.external.EditorExternalElementState
@@ -155,6 +155,7 @@ import co.typie.screen.editor.editor.header.resolveEditorHeaderGeometry
 import co.typie.screen.editor.editor.layout.EditorScreenLayout
 import co.typie.screen.editor.editor.layout.EditorViewportScrollReconcileMode
 import co.typie.screen.editor.editor.layout.attachViewportZoomAnchor
+import co.typie.screen.editor.editor.layout.rememberCommittedEditorRenderZoom
 import co.typie.screen.editor.editor.overlay.EditorCharacterCountOverlay
 import co.typie.screen.editor.editor.overlay.EditorRepasteAsTextOverlay
 import co.typie.screen.editor.editor.overlay.EditorScreenOverlayHost
@@ -1121,6 +1122,7 @@ fun EditorScreen(entityId: String) {
   ) { innerPadding ->
     val layoutPageSizes = layoutPublishedState.pageSizes
     val density = LocalDensity.current.density
+    val measuredEditorViewport = remember(entityId) { mutableStateOf(Size.Zero) }
     val focusManager = LocalFocusManager.current
     val haptic = LocalHapticFeedback.current
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -1496,6 +1498,14 @@ fun EditorScreen(entityId: String) {
     val typewriterEnabled = Preference.typewriterEnabled
     val typewriterPosition = Preference.typewriterPosition.toFloat()
     val displayZoom = zoomController.displayZoom
+    val committedRenderZoom =
+      rememberCommittedEditorRenderZoom(
+        editor = editor,
+        physicalViewport = measuredEditorViewport.value,
+        layoutSpec = layoutSpec,
+        requestedRenderZoom = zoomController.renderZoom,
+        scaleFactor = density.toDouble(),
+      )
     val typewriterTargetLineHeight =
       resolveBringIntoViewTargetHeight(
         state = publishedEditorState,
@@ -1792,7 +1802,7 @@ fun EditorScreen(entityId: String) {
       runtime.session?.editor?.let { activeEditor ->
         EditorSurfaceHost(
           editor = activeEditor,
-          scaleFactor = density.toDouble() * zoomController.renderZoom.toDouble(),
+          scaleFactor = density.toDouble() * committedRenderZoom.toDouble(),
           onDeactivate = bringIntoViewRequests::cancel,
           onPublicationFailure = bringIntoViewRequests::discardFailedForVersion,
           onFailure = { error -> runtime.fail(activeEditor, error) },
@@ -1827,32 +1837,7 @@ fun EditorScreen(entityId: String) {
           } else {
             null
           },
-        onMeasuredViewportSizeChange = { viewport ->
-          val editor = runtime.editor
-          if (editor != null && viewport.width > 0f && viewport.height > 0f) {
-            editor.launchEffect(coroutineScope = scope) {
-              editor.update {
-                enqueue(
-                  Message.System(
-                    SystemEvent.Resize(
-                      width =
-                        when (layoutSpec) {
-                          is EditorDocumentLayoutSpec.Continuous ->
-                            resolveContinuousLayoutViewportWidth(
-                              viewportWidth = viewport.width,
-                              committedZoom = zoomController.renderZoom,
-                            )
-                          is EditorDocumentLayoutSpec.Paginated -> viewport.width
-                        },
-                      height = viewport.height,
-                      scaleFactor = density.toDouble(),
-                    )
-                  )
-                )
-              }
-            }
-          }
-        },
+        onMeasuredViewportSizeChange = { measuredEditorViewport.value = it },
         header = {
           EditorHeaderFrame(
             geometry = headerGeometry,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportCommit.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportCommit.kt
@@ -1,0 +1,92 @@
+package co.typie.screen.editor.editor.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Size
+import co.typie.editor.Editor
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.body.resolveContinuousLayoutViewportWidth
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.SystemEvent
+
+@Composable
+internal fun rememberCommittedEditorRenderZoom(
+  editor: Editor?,
+  physicalViewport: Size,
+  layoutSpec: EditorDocumentLayoutSpec,
+  requestedRenderZoom: Float,
+  scaleFactor: Double,
+): Float {
+  // Continuous surface scale must not advance before the logical viewport resize it renders.
+  // Paginated zoom does not reflow, so it can keep following the requested render zoom directly.
+  val continuous = layoutSpec is EditorDocumentLayoutSpec.Continuous
+  var committedContinuousRenderZoom by remember(editor, continuous) { mutableFloatStateOf(1f) }
+  val continuousRenderZoom =
+    if (continuous) {
+      requestedRenderZoom.takeIf { it.isFinite() && it > 0f } ?: 1f
+    } else {
+      1f
+    }
+  val localEditAdmissionGeneration =
+    if (continuous && editor != null) {
+      editor.localEditAdmissionGeneration.collectAsState().value
+    } else {
+      0L
+    }
+
+  LaunchedEffect(
+    editor,
+    physicalViewport,
+    layoutSpec,
+    continuousRenderZoom,
+    scaleFactor,
+    localEditAdmissionGeneration,
+  ) {
+    val activeEditor = editor ?: return@LaunchedEffect
+    if (
+      physicalViewport.width <= 0f ||
+        physicalViewport.height <= 0f ||
+        !scaleFactor.isFinite() ||
+        scaleFactor <= 0.0
+    ) {
+      return@LaunchedEffect
+    }
+    var resizeCommitted = false
+    val resizeEffectCompleted = activeEditor.runEffect {
+      resizeCommitted =
+        activeEditor.update {
+          enqueue(
+            Message.System(
+              SystemEvent.Resize(
+                width =
+                  when (layoutSpec) {
+                    is EditorDocumentLayoutSpec.Continuous ->
+                      resolveContinuousLayoutViewportWidth(
+                        viewportWidth = physicalViewport.width,
+                        committedZoom = continuousRenderZoom,
+                      )
+                    is EditorDocumentLayoutSpec.Paginated -> physicalViewport.width
+                  },
+                height = physicalViewport.height,
+                scaleFactor = scaleFactor,
+              )
+            )
+          )
+        } != null
+    }
+    if (resizeEffectCompleted && resizeCommitted && continuous) {
+      committedContinuousRenderZoom = continuousRenderZoom
+    }
+  }
+
+  return if (continuous) {
+    committedContinuousRenderZoom
+  } else {
+    requestedRenderZoom
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
@@ -7,12 +7,14 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asSkiaBitmap
 import androidx.compose.ui.graphics.compositeOver
@@ -54,6 +56,7 @@ import co.typie.editor.surface.EditorSurfaceHost
 import co.typie.ext.ScrollGestureLockState
 import co.typie.screen.editor.editor.layout.EditorScreenLayout
 import co.typie.screen.editor.editor.layout.EditorViewportScrollReconcileMode
+import co.typie.screen.editor.editor.layout.rememberCommittedEditorRenderZoom
 import co.typie.screen.editor.editor.overlay.resolveSelectionHandleOverlayGeometry
 import co.typie.screen.editor.editor.overlay.resolveSelectionHandleOverlayPlacements
 import co.typie.screen.editor.editor.state.EditorScreenState
@@ -264,6 +267,8 @@ class EditorFrameSyncDesktopTest {
   @Test
   fun continuousZoomOutReflowsAtTheCommittedLogicalViewportWidth() = runComposeUiTest {
     val fixture = FrameSyncFixture(continuous = true, continuousMaxWidth = 600)
+    val expectedPageWidth = ViewportWidth / 0.75f
+    val expectedFrameWidth = (expectedPageWidth * 0.75f).roundToInt()
     fixture.zoomController.syncLayout(
       layoutSpec = fixture.layoutSpec,
       viewportWidth = ViewportWidth,
@@ -285,15 +290,59 @@ class EditorFrameSyncDesktopTest {
         fixture.zoomController.commitRenderZoom()
       }
 
-      waitUntil(timeoutMillis = 1_000) {
-        fixture.editor.appliedState.pageSizes.single().width > ViewportWidth
+      waitUntil(timeoutMillis = 10_000) {
+        val published = fixture.editor.publishedBundle ?: return@waitUntil false
+        val pageWidth = published.snapshot.pageSizes.singleOrNull()?.width ?: return@waitUntil false
+        abs(pageWidth - expectedPageWidth) <= 0.01f &&
+          published.frames[0]?.pixelSize?.width == expectedFrameWidth
       }
-      assertEquals(
-        ViewportWidth / 0.75f,
-        fixture.editor.appliedState.pageSizes.single().width,
-        0.01f,
-      )
+      val published = assertNotNull(fixture.editor.publishedBundle)
+      assertEquals(expectedPageWidth, published.snapshot.pageSizes.single().width, 0.01f)
+      assertEquals(expectedFrameWidth, assertNotNull(published.frames[0]).pixelSize.width)
     } finally {
+      fixture.close()
+    }
+  }
+
+  @Test
+  fun continuousRenderZoomStaysCommittedUntilViewportResizeIsAdmitted() = runComposeUiTest {
+    val fixture = FrameSyncFixture(continuous = true, continuousMaxWidth = 600)
+    val requestedRenderZoom = mutableFloatStateOf(1f)
+    val initialRevision = fixture.editor.appliedRevision
+    var committedRenderZoom = Float.NaN
+    var quiescence: LocalEditQuiescence? = null
+
+    try {
+      setContent {
+        val committedZoom =
+          rememberCommittedEditorRenderZoom(
+            editor = fixture.editor,
+            physicalViewport = Size(ViewportWidth, ViewportHeight),
+            layoutSpec = fixture.layoutSpec,
+            requestedRenderZoom = requestedRenderZoom.floatValue,
+            scaleFactor = 1.0,
+          )
+        SideEffect { committedRenderZoom = committedZoom }
+      }
+      waitUntil(timeoutMillis = 10_000) {
+        fixture.editor.appliedRevision > initialRevision && committedRenderZoom == 1f
+      }
+
+      quiescence = fixture.editor.quiesceLocalEdits()
+      runOnIdle { requestedRenderZoom.floatValue = 0.75f }
+      waitForIdle()
+
+      assertEquals(1f, committedRenderZoom)
+      assertEquals(ViewportWidth, fixture.editor.appliedState.pageSizes.single().width, 0.01f)
+
+      quiescence.resume()
+      quiescence = null
+      waitUntil(timeoutMillis = 1_000) {
+        committedRenderZoom == 0.75f &&
+          abs(fixture.editor.appliedState.pageSizes.single().width - ViewportWidth / 0.75f) <= 0.01f
+      }
+    } finally {
+      quiescence?.resume()
       fixture.close()
     }
   }
@@ -1420,6 +1469,15 @@ class EditorFrameSyncDesktopTest {
         val interactionScope = remember { EditorInteractionScope(fixture.scope) }
         val scrollGestureLockState = remember { ScrollGestureLockState() }
         val zoomController = fixture.zoomController
+        val measuredViewport = remember { mutableStateOf(Size.Zero) }
+        val committedRenderZoom =
+          rememberCommittedEditorRenderZoom(
+            editor = fixture.editor,
+            physicalViewport = measuredViewport.value,
+            layoutSpec = fixture.layoutSpec,
+            requestedRenderZoom = zoomController.renderZoom,
+            scaleFactor = 1.0,
+          )
         val publishedBundle = fixture.editor.publishedBundle
         val publishedState = publishedBundle?.snapshot ?: EditorState.Initial
         val geometry =
@@ -1468,7 +1526,7 @@ class EditorFrameSyncDesktopTest {
         ) {
           EditorSurfaceHost(
             editor = fixture.editor,
-            scaleFactor = 1.0,
+            scaleFactor = committedRenderZoom.toDouble(),
             onDeactivate = fixture.bringIntoViewRequests::cancel,
             onFailure = { throw it },
           )
@@ -1480,7 +1538,7 @@ class EditorFrameSyncDesktopTest {
             viewportScrollableState = viewportScrollableState,
             viewportContentWidth = geometry.pageColumnWidth,
             viewportScrollReconcileMode = EditorViewportScrollReconcileMode.Disabled,
-            onMeasuredViewportSizeChange = {},
+            onMeasuredViewportSizeChange = { measuredViewport.value = it },
             header = {},
             body = { presentedBundle ->
               val presentedState = presentedBundle?.snapshot ?: EditorState.Initial

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -26,7 +26,7 @@
   } from '../handlers/pointer';
   import { setupEditorScroll } from '../scroll.svelte';
   import { touchPanLock } from '../touch-pan-lock';
-  import { resolveContinuousLayoutViewportWidth, zoomDiffers } from '../zoom';
+  import { resolveContinuousLayoutViewportWidth } from '../zoom';
   import Caret from './Caret.svelte';
   import ContextMenu from './ContextMenu.svelte';
   import DocumentOverlayLayer from './DocumentOverlayLayer.svelte';
@@ -228,7 +228,6 @@
 
   let readyFired = false;
   let viewportEditor: (typeof ctx)['editor'];
-  let viewportRenderZoom = 1;
   let viewportLayoutType: 'continuous' | 'paginated' | undefined;
 
   $effect(() => {
@@ -245,10 +244,7 @@
       : physicalWidth;
 
     untrack(() => {
-      const committedLayoutChanged =
-        viewportEditor === editor &&
-        (viewportLayoutType !== layoutMode?.type || (isContinuous && zoomDiffers(viewportRenderZoom, renderZoom)));
-      viewportRenderZoom = renderZoom;
+      const committedLayoutChanged = viewportEditor === editor && viewportLayoutType !== layoutMode?.type;
       viewportLayoutType = layoutMode?.type;
       if (viewportEditor === editor && !committedLayoutChanged) {
         editor.resizeViewport(effectiveWidth, height, viewportScaleFactor);

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
@@ -48,7 +48,7 @@
 
   $effect(() => {
     editor.displayZoom = displayZoom;
-    editor.setRenderZoom(renderZoom);
+    editor.commitRenderZoom(renderZoom);
   });
 
   $effect(() => {
@@ -68,7 +68,7 @@
     return () => {
       zoom.destroy();
       editor.displayZoom = 1;
-      editor.setRenderZoom(1);
+      editor.commitRenderZoom(1);
     };
   });
 

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
@@ -23,7 +23,6 @@
   import { setupEditorPublication } from './editor-publication.svelte';
   import { EditorSurfaceHost } from './editor-surface-host.svelte';
   import { setupEditorScroll } from './scroll.svelte';
-  import { resolveContinuousLayoutViewportWidth } from './zoom';
   import type { MouseEventHandler } from 'svelte/elements';
   import type { Editor } from './editor.svelte';
   import type { DocumentZoomLayout } from './zoom';
@@ -86,22 +85,6 @@
 
   $effect(() => {
     editor.readOnly = readOnly;
-  });
-
-  $effect(() => {
-    const layout = zoomLayout;
-    const width = viewportWidth;
-    const renderZoom = editor.renderZoom;
-    if (!withZoom || layout?.type !== 'continuous' || width <= 0) return;
-    untrack(() => {
-      const height = editor.viewport.height;
-      if (height <= 0) return;
-      editor.resizeViewportNow(
-        resolveContinuousLayoutViewportWidth({ viewportWidth: width, committedZoom: renderZoom }),
-        height,
-        editor.scaleFactor,
-      );
-    });
   });
 
   $effect(() => {

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -279,7 +279,7 @@ async function mountEditor(
   editor = await Editor.createFromDoc(plain, { width: 360, height: 180, scale_factor: 1 });
   if (options.displayZoom !== undefined) {
     editor.displayZoom = options.displayZoom;
-    editor.setRenderZoom(options.displayZoom);
+    editor.commitRenderZoom(options.displayZoom);
   }
   const target = document.createElement('div');
   document.body.append(target);
@@ -1315,6 +1315,8 @@ describe('web editor frame synchronization', () => {
   it('delays continuous reflow until the render commit and replaces it coherently', async () => {
     const { editor, scrollRoot } = await mountEditor(continuousDoc('continuous zoom '.repeat(40)), { withZoom: true });
     await waitForPresentation(editor);
+    const attachSurface = editor.attachSurface.bind(editor);
+    const attachSurfaceSpy = vi.spyOn(editor, 'attachSurface').mockImplementation((...args) => attachSurface(...args));
     const initialPageWidth = editor.appliedSnapshot.pageSizes[0]?.width;
     const initialCanvas = editor.published?.frames.get(0)?.canvas;
     expect(initialPageWidth).toBeCloseTo(360);
@@ -1350,7 +1352,22 @@ describe('web editor frame synchronization', () => {
     expect(editor.pageEls[0]?.getBoundingClientRect().width).toBeCloseTo(360, 0);
     expect(editor.published?.frames.get(0)?.canvas.width).toBeGreaterThan(0);
     expect(editor.published?.frames.get(0)?.canvas.height).toBeGreaterThan(0);
+    expect(attachSurfaceSpy.mock.calls.filter(([page]) => page === 0)).toHaveLength(1);
     expectActualCanvas(editor, 0, false);
+  });
+
+  it('derives a continuous render commit from the editor viewport target', async () => {
+    const { editor } = await mountEditor(continuousDoc('continuous zoom '.repeat(40)));
+    await waitForPresentation(editor);
+
+    editor.resizeViewportNow(300, 180, 1);
+    await waitForPresentation(editor);
+    expect(editor.viewport.width).toBeCloseTo(300);
+
+    editor.commitRenderZoom(0.75);
+
+    expect(editor.viewport.width).toBeCloseTo(400);
+    expect(editor.appliedSnapshot.pageSizes[0]?.width).toBeCloseTo(400);
   });
 
   it('makes the entire zoomed continuous track horizontally reachable without oversized line highlight paint', async () => {

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -1329,10 +1329,18 @@ export class Editor {
     });
   }
 
-  setRenderZoom(renderZoom: number): void {
+  commitRenderZoom(renderZoom: number): void {
     const safeRenderZoom = Number.isFinite(renderZoom) && renderZoom > 0 ? renderZoom : 1;
-    if (zoomDiffers(this.renderZoom, safeRenderZoom)) {
-      this.renderZoom = safeRenderZoom;
+    if (!zoomDiffers(this.renderZoom, safeRenderZoom)) return;
+
+    const previousRenderZoom = this.renderZoom;
+    const physicalViewportWidth = this.#viewport.width * Math.min(previousRenderZoom, 1);
+    this.renderZoom = safeRenderZoom;
+    if (isContinuousLayout(this.#applied.rootAttrs)) {
+      // Resize installs and reconciles the continuous layout synchronously. Make its matching
+      // surface scale visible first so geometry and scale replace each surface only once.
+      // Reactive publication remains deferred until the updated snapshot is installed.
+      this.resizeViewportNow(physicalViewportWidth / Math.min(safeRenderZoom, 1), this.#viewport.height, this.#viewport.scale_factor);
     }
   }
 


### PR DESCRIPTION
- continuous 레이아웃의 viewport reflow와 surface zoom을 같은 시점에 커밋
- Web viewport 너비 소유권을 `Editor`로 통합
- Compose에서 거부된 resize를 local edit 재개 후 재시도
- 중복 resize 경로 제거 및 frame-sync 회귀 테스트 보강