### PR TITLE
줌 중 뷰포트 좌표 계산 최적화

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorGeometry.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorGeometry.kt
@@ -18,6 +18,7 @@ internal fun pageRectsToContentRect(
   rects: Iterable<PageRect>,
   layoutSpec: EditorDocumentLayoutSpec,
   pageSizes: List<PageSize>,
+  pageContentTops: FloatArray? = null,
   displayZoom: Float = 1f,
   density: Float = 0f,
   contentOriginX: Float = 0f,
@@ -26,13 +27,18 @@ internal fun pageRectsToContentRect(
   val zoom = normalizeDisplayZoom(displayZoom)
   return unionRects(
     rects.mapNotNull { pageRect ->
+      if (pageRect.pageIdx !in pageSizes.indices) return@mapNotNull null
       val pageTop =
-        layoutSpec.resolvePageContentTop(
-          page = pageRect.pageIdx,
-          pageSizes = pageSizes,
-          displayZoom = zoom,
-          density = density,
-        ) ?: return@mapNotNull null
+        if (pageContentTops == null) {
+          layoutSpec.resolvePageContentTop(
+            page = pageRect.pageIdx,
+            pageSizes = pageSizes,
+            displayZoom = zoom,
+            density = density,
+          )
+        } else {
+          pageContentTops.getOrNull(pageRect.pageIdx)
+        } ?: return@mapNotNull null
       val rect = pageRect.rect
       val left = contentOriginX + rect.x * zoom
       val top = contentOriginY + pageTop + rect.y * zoom

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorDocumentLayoutSpec.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorDocumentLayoutSpec.kt
@@ -79,6 +79,25 @@ internal fun EditorDocumentLayoutSpec.resolvePagesContentHeight(
   }
 }
 
+internal fun EditorDocumentLayoutSpec.resolvePageContentTopPrefixes(
+  pageSizes: List<PageSize>,
+  displayZoom: Float = 1f,
+  density: Float = 0f,
+): FloatArray {
+  val effectiveDisplayZoom = normalizeDisplayZoom(displayZoom)
+  val measuredPageGap =
+    resolveMeasuredPageGapLength(displayZoom = effectiveDisplayZoom, density = density)
+  val prefixes = FloatArray(pageSizes.size + 1)
+  var top = 0f
+  pageSizes.forEachIndexed { index, size ->
+    prefixes[index] = top
+    top += resolveMeasuredPageLength(size.height, effectiveDisplayZoom, density)
+    if (index < pageSizes.lastIndex) top += measuredPageGap
+  }
+  prefixes[pageSizes.size] = top
+  return prefixes
+}
+
 internal fun EditorDocumentLayoutSpec.resolvePageContentTop(
   page: Int,
   pageSizes: List<PageSize>,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/scroll/EditorScrollIntent.kt
@@ -2,7 +2,11 @@ package co.typie.editor.scroll
 
 import co.typie.editor.EditorState
 import co.typie.editor.VerticalSpan
+import co.typie.editor.body.EditorBodyGeometry
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.body.resolveEditorBodyGeometry
+import co.typie.editor.body.resolveMeasuredPageLength
+import co.typie.editor.body.resolvePageContentTopPrefixes
 import co.typie.editor.ffi.PageRect
 import co.typie.editor.pageRectsToContentRect
 import co.typie.editor.runtime.EditorBoundsInContainer
@@ -18,6 +22,54 @@ internal data class EditorScrollFrame(
   val density: Float,
   val editorBounds: EditorBoundsInContainer,
 ) {
+  val bodyGeometry: EditorBodyGeometry by
+    lazy(LazyThreadSafetyMode.NONE) {
+      resolveEditorBodyGeometry(
+        visibleArea = visibleArea,
+        layoutSpec = layoutSpec,
+        pageSizes = state.pageSizes,
+        displayZoom = displayZoom,
+      )
+    }
+
+  val pageContentTopPrefixes: FloatArray by
+    lazy(LazyThreadSafetyMode.NONE) {
+      layoutSpec.resolvePageContentTopPrefixes(
+        pageSizes = state.pageSizes,
+        displayZoom = displayZoom,
+        density = density,
+      )
+    }
+
+  val pagesContentHeight: Float
+    get() = pageContentTopPrefixes.lastOrNull() ?: 0f
+
+  fun pageContentTop(page: Int): Float? {
+    if (page !in state.pageSizes.indices) return null
+    return pageContentTopPrefixes[page]
+  }
+
+  fun pageAtContentY(y: Float): Int? {
+    if (state.pageSizes.isEmpty() || !y.isFinite()) return null
+    var low = 0
+    var high = state.pageSizes.lastIndex
+    while (low < high) {
+      val middle = (low + high + 1) ushr 1
+      if (pageContentTopPrefixes[middle] <= y) low = middle else high = middle - 1
+    }
+    if (low == state.pageSizes.lastIndex) return low
+
+    val pageBottom =
+      pageContentTopPrefixes[low] +
+        resolveMeasuredPageLength(
+          length = state.pageSizes[low].height,
+          displayZoom = displayZoom,
+          density = density,
+        )
+    val nextPageTop = pageContentTopPrefixes[low + 1]
+    return if (y >= (pageBottom + nextPageTop) / 2f) low + 1 else low
+  }
+
   fun withState(state: EditorState): EditorScrollFrame {
     return copy(
       state = state,
@@ -109,14 +161,7 @@ internal fun resolveEditorScrollIntent(
   if (!contentOriginY.isFinite()) return EditorScrollIntentResult.Unresolved
 
   val rect =
-    resolveBringIntoViewTargetRect(
-      state = frame.state,
-      layoutSpec = frame.layoutSpec,
-      contentOriginY = contentOriginY,
-      displayZoom = frame.displayZoom,
-      density = frame.density,
-      target = target,
-    )
+    resolveBringIntoViewTargetRect(frame = frame, contentOriginY = contentOriginY, target = target)
   if (rect == null) {
     return EditorScrollIntentResult.NoScroll
   }
@@ -152,14 +197,8 @@ internal fun resolveInstantRevealPreparationViewports(
   maximumScrollY: Float,
 ): List<VerticalSpan> {
   val rect =
-    resolveBringIntoViewTargetRect(
-      state = frame.state,
-      layoutSpec = frame.layoutSpec,
-      contentOriginY = contentOriginY,
-      displayZoom = frame.displayZoom,
-      density = frame.density,
-      target = target,
-    ) ?: return emptyList()
+    resolveBringIntoViewTargetRect(frame = frame, contentOriginY = contentOriginY, target = target)
+      ?: return emptyList()
   return resolveInstantRevealPreparationViewports(
     currentScroll = currentScroll,
     viewportHeight = frame.visibleArea.viewport.height,
@@ -290,11 +329,8 @@ internal fun isEditorScrollTargetVisible(
   if (!editorBounds.isValid) return null
   val rect =
     resolveBringIntoViewTargetRect(
-      state = frame.state,
-      layoutSpec = frame.layoutSpec,
+      frame = frame,
       contentOriginY = frame.headerHeight + editorBounds.y,
-      displayZoom = frame.displayZoom,
-      density = frame.density,
       target = target,
     ) ?: return null
   val visibleTopInContent = currentScroll + visibleArea.visibleViewportTop
@@ -312,6 +348,19 @@ internal fun resolveBringIntoViewTargetHeight(
   displayZoom: Float,
   density: Float = 0f,
 ): Float? {
+  if (target == EditorBringIntoViewTarget.CurrentSelectionHead) {
+    val pageRect = resolveCurrentSelectionHeadPageRect(state) ?: return null
+    if (pageRect.pageIdx !in state.pageSizes.indices) return null
+    val rect = pageRect.rect
+    if (
+      !rect.x.isFinite() || !rect.y.isFinite() || !rect.width.isFinite() || !rect.height.isFinite()
+    ) {
+      return null
+    }
+    val zoom = displayZoom.takeIf { it.isFinite() && it > 0f } ?: 1f
+    return abs(rect.height * zoom).takeIf(Float::isFinite)
+  }
+
   val targetRects =
     resolveBringIntoViewTargetPageRects(state = state, target = target) ?: return null
   return pageRectsToContentRect(
@@ -325,22 +374,20 @@ internal fun resolveBringIntoViewTargetHeight(
 }
 
 private fun resolveBringIntoViewTargetRect(
-  state: EditorState,
-  layoutSpec: EditorDocumentLayoutSpec,
+  frame: EditorScrollFrame,
   contentOriginY: Float,
-  displayZoom: Float,
-  density: Float,
   target: EditorBringIntoViewTarget,
 ): VerticalSpan? {
   val targetRects =
-    resolveBringIntoViewTargetPageRects(state = state, target = target) ?: return null
+    resolveBringIntoViewTargetPageRects(state = frame.state, target = target) ?: return null
   val contentRect =
     pageRectsToContentRect(
       rects = targetRects,
-      layoutSpec = layoutSpec,
-      pageSizes = state.pageSizes,
-      displayZoom = displayZoom,
-      density = density,
+      layoutSpec = frame.layoutSpec,
+      pageSizes = frame.state.pageSizes,
+      pageContentTops = frame.pageContentTopPrefixes,
+      displayZoom = frame.displayZoom,
+      density = frame.density,
       contentOriginY = contentOriginY,
     ) ?: return null
   return VerticalSpan(top = contentRect.top, bottom = contentRect.bottom)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorGeometry.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorGeometry.kt
@@ -2,8 +2,6 @@ package co.typie.editor.viewport
 
 import androidx.compose.ui.geometry.Offset
 import co.typie.editor.VerticalSpan
-import co.typie.editor.body.resolveEditorBodyGeometry
-import co.typie.editor.body.resolvePageContentTop
 import co.typie.editor.ffi.ResolvedViewportAnchor
 import co.typie.editor.ffi.ViewportAnchorPoint
 import co.typie.editor.scroll.EditorScrollFrame
@@ -14,24 +12,12 @@ internal fun ResolvedViewportAnchor.toEditorViewportAnchorGeometry(
 ): EditorViewportAnchorGeometry? {
   if (!contentOriginY.isFinite()) return null
   val zoom = frame.displayZoom.takeIf { it.isFinite() && it > 0f } ?: 1f
-  val bodyGeometry =
-    resolveEditorBodyGeometry(
-      visibleArea = frame.visibleArea,
-      layoutSpec = frame.layoutSpec,
-      pageSizes = frame.state.pageSizes,
-      displayZoom = zoom,
-    )
+  val bodyGeometry = frame.bodyGeometry
   val contentWidth = maxOf(frame.visibleArea.viewport.width, bodyGeometry.pageColumnWidth)
   val pageColumnLeft = (contentWidth - bodyGeometry.pageColumnWidth) / 2f
 
   fun contentY(page: Int, y: Float): Float? {
-    val pageTop =
-      frame.layoutSpec.resolvePageContentTop(
-        page = page,
-        pageSizes = frame.state.pageSizes,
-        displayZoom = zoom,
-        density = frame.density,
-      ) ?: return null
+    val pageTop = frame.pageContentTop(page) ?: return null
     return contentOriginY + pageTop + y * zoom
   }
 
@@ -46,14 +32,7 @@ internal fun ResolvedViewportAnchor.toEditorViewportAnchorGeometry(
 }
 
 internal fun resolveViewportAnchorContentOriginY(frame: EditorScrollFrame): Float {
-  val bodyGeometry =
-    resolveEditorBodyGeometry(
-      visibleArea = frame.visibleArea,
-      layoutSpec = frame.layoutSpec,
-      pageSizes = frame.state.pageSizes,
-      displayZoom = frame.displayZoom,
-    )
-  return (frame.headerHeight.takeIf(Float::isFinite) ?: 0f) + bodyGeometry.topSpacerHeight
+  return (frame.headerHeight.takeIf(Float::isFinite) ?: 0f) + frame.bodyGeometry.topSpacerHeight
 }
 
 internal fun viewportCenterAnchorPoint(
@@ -75,41 +54,16 @@ internal fun viewportCenterAnchorPoint(
   val zoom = frame.displayZoom.takeIf { it.isFinite() && it > 0f } ?: 1f
   val relativeY = scrollOffset.y + viewportCenterY - contentOriginY
 
-  var page = frame.state.pageSizes.lastIndex
-  for (candidate in frame.state.pageSizes.indices) {
-    val nextTop =
-      frame.layoutSpec.resolvePageContentTop(
-        page = candidate + 1,
-        pageSizes = frame.state.pageSizes,
-        displayZoom = zoom,
-        density = frame.density,
-      )
-    if (nextTop == null || relativeY < nextTop) {
-      page = candidate
-      break
-    }
-  }
-  val pageTop =
-    frame.layoutSpec.resolvePageContentTop(
-      page = page,
-      pageSizes = frame.state.pageSizes,
-      displayZoom = zoom,
-      density = frame.density,
-    ) ?: return null
-  val bodyGeometry =
-    resolveEditorBodyGeometry(
-      visibleArea = frame.visibleArea,
-      layoutSpec = frame.layoutSpec,
-      pageSizes = frame.state.pageSizes,
-      displayZoom = zoom,
-    )
+  val page = frame.pageAtContentY(relativeY) ?: return null
+  val pageTop = frame.pageContentTop(page) ?: return null
+  val pageSize = frame.state.pageSizes[page]
+  val bodyGeometry = frame.bodyGeometry
   val contentWidth = maxOf(frame.visibleArea.viewport.width, bodyGeometry.pageColumnWidth)
   val pageColumnLeft = (contentWidth - bodyGeometry.pageColumnWidth) / 2f
   val viewportCenterX = scrollOffset.x + frame.visibleArea.viewport.width / 2f
-  val pageWidth = frame.state.pageSizes[page].width
   return ViewportAnchorPoint(
     pageIdx = page,
-    x = ((viewportCenterX - pageColumnLeft) / zoom).coerceIn(0f, pageWidth),
-    y = (relativeY - pageTop) / zoom,
+    x = ((viewportCenterX - pageColumnLeft) / zoom).coerceIn(0f, pageSize.width),
+    y = ((relativeY - pageTop) / zoom).coerceIn(0f, pageSize.height),
   )
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -53,10 +53,7 @@ import co.typie.editor.Editor
 import co.typie.editor.PublishedBundle
 import co.typie.editor.SurfacePageSpan
 import co.typie.editor.VerticalSpan
-import co.typie.editor.body.resolveEditorBodyGeometry
 import co.typie.editor.body.resolveMeasuredPageLength
-import co.typie.editor.body.resolvePageContentTop
-import co.typie.editor.body.resolvePagesContentHeight
 import co.typie.editor.ext.unclippedBoundsInRoot
 import co.typie.editor.interaction.EditorPlatformIndirectScaleBridge
 import co.typie.editor.interaction.EditorScreenPointerSequence
@@ -755,14 +752,7 @@ internal fun resolveAnchoredEditorSurfacePreparation(
 }
 
 private fun resolveMaximumScrollX(frame: EditorScrollFrame): Float {
-  val bodyGeometry =
-    resolveEditorBodyGeometry(
-      visibleArea = frame.visibleArea,
-      layoutSpec = frame.layoutSpec,
-      pageSizes = frame.state.pageSizes,
-      displayZoom = frame.displayZoom,
-    )
-  return (bodyGeometry.pageColumnWidth - frame.visibleArea.viewport.width).coerceAtLeast(0f)
+  return (frame.bodyGeometry.pageColumnWidth - frame.visibleArea.viewport.width).coerceAtLeast(0f)
 }
 
 internal fun resolveEditorSurfacePreparation(
@@ -774,24 +764,12 @@ internal fun resolveEditorSurfacePreparation(
 ): EditorSurfacePreparation? {
   val state = scrollFrame.state
   val viewportHeight = scrollFrame.visibleArea.viewport.height
-  val bodyGeometry =
-    resolveEditorBodyGeometry(
-      visibleArea = scrollFrame.visibleArea,
-      layoutSpec = scrollFrame.layoutSpec,
-      pageSizes = state.pageSizes,
-      displayZoom = scrollFrame.displayZoom,
-    )
+  val bodyGeometry = scrollFrame.bodyGeometry
   val headerHeight = scrollFrame.headerHeight.takeIf(Float::isFinite) ?: 0f
   val resolvedContentOrigin = headerHeight + bodyGeometry.topSpacerHeight
   val pageSpans =
     state.pageSizes.mapIndexedNotNull { page, size ->
-      val pageTop =
-        scrollFrame.layoutSpec.resolvePageContentTop(
-          page = page,
-          pageSizes = state.pageSizes,
-          displayZoom = scrollFrame.displayZoom,
-          density = scrollFrame.density,
-        ) ?: return@mapIndexedNotNull null
+      val pageTop = scrollFrame.pageContentTop(page) ?: return@mapIndexedNotNull null
       val top = resolvedContentOrigin + pageTop
       SurfacePageSpan(
         page = page,
@@ -805,12 +783,7 @@ internal fun resolveEditorSurfacePreparation(
             ),
       )
     }
-  val pagesContentHeight =
-    scrollFrame.layoutSpec.resolvePagesContentHeight(
-      pageSizes = state.pageSizes,
-      displayZoom = scrollFrame.displayZoom,
-      density = scrollFrame.density,
-    )
+  val pagesContentHeight = scrollFrame.pagesContentHeight
   val contentExtent =
     headerHeight +
       maxOf(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/scroll/EditorScrollResolverTest.kt
@@ -17,6 +17,7 @@ import co.typie.editor.runtime.EditorBoundsInContainer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class EditorScrollResolverTest {
@@ -638,6 +639,54 @@ class EditorScrollResolverTest {
   }
 
   @Test
+  fun `selection head target height does not scan preceding pages`() {
+    val pageSizes = CountingPageSizes(List(128) { PageSize(width = 300f, height = 620f) })
+    val height =
+      resolveBringIntoViewTargetHeight(
+        state =
+          state(
+            cursor =
+              CursorMetrics(
+                pageIdx = pageSizes.lastIndex,
+                caret = FfiRect(0f, 580f, 0f, 20f),
+                line = FfiRect(0f, 580f, 0f, 20f),
+              ),
+            pageSizes = pageSizes,
+          ),
+        layoutSpec = paginatedLayout(),
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        displayZoom = 1f,
+      )
+
+    assertEquals(20f, requireNotNull(height), 0.0001f)
+    assertTrue(
+      pageSizes.readCount <= 2,
+      "Expected constant page-size reads, got ${pageSizes.readCount}",
+    )
+  }
+
+  @Test
+  fun `selection head target height preserves rect normalization and validation`() {
+    val negativeHeight =
+      resolveBringIntoViewTargetHeight(
+        state = unitSelectionState(FfiRect(0f, 20f, 0f, -16f)),
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 300f),
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        displayZoom = 1.5f,
+      )
+    val invalid =
+      resolveBringIntoViewTargetHeight(
+        state = unitSelectionState(FfiRect(Float.NaN, 20f, 0f, 16f)),
+        layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 300f),
+        target = EditorBringIntoViewTarget.CurrentSelectionHead,
+        displayZoom = 1f,
+      )
+
+    assertEquals(24f, requireNotNull(negativeHeight), 0.0001f)
+    assertNull(invalid)
+  }
+
+  @Test
   fun `tracked item target height resolves from the vertical union across pages`() {
     val target = EditorBringIntoViewTarget.TrackedItem("comment-1")
     val rects =
@@ -763,4 +812,17 @@ class EditorScrollResolverTest {
       rects = rects,
       text = "comment",
     )
+
+  private class CountingPageSizes(private val values: List<PageSize>) : AbstractList<PageSize>() {
+    var readCount = 0
+      private set
+
+    override val size: Int
+      get() = values.size
+
+    override fun get(index: Int): PageSize {
+      readCount += 1
+      return values[index]
+    }
+  }
 }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorGeometryTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorGeometryTest.kt
@@ -32,6 +32,49 @@ class EditorViewportAnchorGeometryTest {
   }
 
   @Test
+  fun `viewport center clamps to the last page bottom`() {
+    val frame = frame(visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 20f)))
+
+    val point =
+      viewportCenterAnchorPoint(
+        frame = frame,
+        scrollOffset = Offset(x = 0f, y = 1000f),
+        contentOriginY = 0f,
+      )
+
+    assertEquals(900f, point?.y)
+  }
+
+  @Test
+  fun `paginated viewport center chooses the nearest page across a gap`() {
+    val frame =
+      frame(
+        pageSizes =
+          listOf(PageSize(width = 600f, height = 100f), PageSize(width = 600f, height = 100f)),
+        layoutSpec =
+          EditorDocumentLayoutSpec.Paginated(
+            pageWidth = 600f,
+            pageHeight = 100f,
+            pageMarginTop = 0f,
+            pageMarginBottom = 0f,
+            pageMarginLeft = 0f,
+            pageMarginRight = 0f,
+          ),
+        visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 20f)),
+      )
+
+    val beforeMidpoint =
+      viewportCenterAnchorPoint(frame, Offset(x = 0f, y = 100f), contentOriginY = 0f)
+    val afterMidpoint =
+      viewportCenterAnchorPoint(frame, Offset(x = 0f, y = 104f), contentOriginY = 0f)
+
+    assertEquals(0, beforeMidpoint?.pageIdx)
+    assertEquals(100f, beforeMidpoint?.y)
+    assertEquals(1, afterMidpoint?.pageIdx)
+    assertEquals(0f, afterMidpoint?.y)
+  }
+
+  @Test
   fun `continuous viewport anchor origin includes the body top spacer`() {
     assertEquals(40f, resolveViewportAnchorContentOriginY(frame()))
   }
@@ -49,21 +92,24 @@ class EditorViewportAnchorGeometryTest {
     assertEquals(90f, geometry?.pointY)
   }
 
-  private fun frame(): EditorScrollFrame {
-    val visibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 300f))
+  private fun frame(
+    pageSizes: List<PageSize> = listOf(PageSize(width = 600f, height = 900f)),
+    layoutSpec: EditorDocumentLayoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+    visibleArea: EditorVisibleArea = EditorVisibleArea(viewport = Size(width = 300f, height = 300f)),
+  ): EditorScrollFrame {
     return EditorScrollFrame(
       state =
         EditorState(
           version = 1L,
           cursor = null,
           selection = null,
-          pageSizes = listOf(PageSize(width = 600f, height = 900f)),
+          pageSizes = pageSizes,
           externalElements = emptyList(),
           rootAttrs = null,
           rootModifiers = null,
           ime = null,
         ),
-      layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f),
+      layoutSpec = layoutSpec,
       displayZoom = 1f,
       visibleArea = visibleArea,
       autoScrollPolicy = resolveEditorAutoScrollPolicy(visibleArea = visibleArea),

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
@@ -278,6 +278,33 @@ class EditorSurfacePreparationTest {
       )
     }
 
+  @Test
+  fun `surface planning reads long document page sizes linearly`() = runTest {
+    val pageCount = 128
+    val pageSizes = CountingPageSizes(List(pageCount) { PageSize(width = 600f, height = 1_000f) })
+    val baseFrame = frame()
+    val longDocumentFrame =
+      baseFrame.copy(
+        state = baseFrame.state.copy(pageSizes = pageSizes),
+        editorBounds =
+          EditorBoundsInContainer(x = 0f, y = 0f, width = 600f, height = pageCount * 1_000f),
+      )
+
+    val preparation =
+      resolveEditorSurfacePreparation(
+        editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)),
+        scrollFrame = longDocumentFrame,
+        currentScroll = 0f,
+        bringIntoViewRequest = null,
+      )
+
+    assertEquals(setOf(0), preparation?.requiredPages)
+    assertTrue(
+      pageSizes.readCount <= pageCount * 5,
+      "Expected linear page-size reads, but read ${pageSizes.readCount} values for $pageCount pages",
+    )
+  }
+
   private fun frame(): EditorScrollFrame {
     val visibleArea = EditorVisibleArea(viewport = Size(width = 600f, height = 400f))
     return EditorScrollFrame(
@@ -326,5 +353,18 @@ class EditorSurfacePreparationTest {
             )
         )
     )
+  }
+
+  private class CountingPageSizes(private val values: List<PageSize>) : AbstractList<PageSize>() {
+    var readCount = 0
+      private set
+
+    override val size: Int
+      get() = values.size
+
+    override fun get(index: Int): PageSize {
+      readCount += 1
+      return values[index]
+    }
   }
 }

--- a/apps/website/src/lib/editor-ffi/components/DocumentEmbeds.svelte
+++ b/apps/website/src/lib/editor-ffi/components/DocumentEmbeds.svelte
@@ -2,7 +2,7 @@
   import { css } from '@typie/styled-system/css';
   import { SvelteSet } from 'svelte/reactivity';
   import { PAGE_GAP } from '../constants';
-  import { resolvePageSpans, roundToScale } from '../geometry';
+  import { resolveCachedPageSpans, roundToScale } from '../geometry';
   import ExternalElement from './ExternalElement.svelte';
   import type { Editor } from '../editor.svelte';
 
@@ -19,7 +19,7 @@
   const isPaginated = $derived(layoutMode?.type === 'paginated');
   const displayZoom = $derived(editor.safeDisplayZoom());
   const pageSpans = $derived(
-    resolvePageSpans(editor.pageSizes, {
+    resolveCachedPageSpans(editor.pageSizes, {
       displayZoom,
       scaleFactor: editor.scaleFactor,
       pageGap: isPaginated ? PAGE_GAP * displayZoom : 0,

--- a/apps/website/src/lib/editor-ffi/components/DocumentOverlayLayer.svelte
+++ b/apps/website/src/lib/editor-ffi/components/DocumentOverlayLayer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { getEditorContext } from '../editor.svelte';
-  import { resolvePageSpans, roundToScale } from '../geometry';
+  import { resolveCachedPageSpans, roundToScale } from '../geometry';
   import TableOverlay from './TableOverlay.svelte';
 
   type PageAnchor = {
@@ -17,7 +17,7 @@
   const displayZoom = $derived(ctx.editor?.safeDisplayZoom() ?? 1);
   const pageAnchors = $derived.by(() => {
     const pageSizes = ctx.editor?.pageSizes ?? [];
-    return resolvePageSpans(pageSizes, { scaleFactor, displayZoom }).map<PageAnchor>(({ page, top, bottom }) => ({
+    return resolveCachedPageSpans(pageSizes, { scaleFactor, displayZoom }).map<PageAnchor>(({ page, top, bottom }) => ({
       top,
       slotWidth: roundToScale(pageSizes[page].width * displayZoom, scaleFactor),
       slotHeight: bottom - top,

--- a/apps/website/src/lib/editor-ffi/components/LineHighlight.svelte
+++ b/apps/website/src/lib/editor-ffi/components/LineHighlight.svelte
@@ -2,7 +2,7 @@
   import { css } from '@typie/styled-system/css';
   import { tryAppContext } from '@typie/ui/context';
   import { getEditorContext } from '../editor.svelte';
-  import { presentedPageElement, resolvePageSpans } from '../geometry';
+  import { presentedPageElement, resolveCachedPageSpans } from '../geometry';
 
   const { editor } = getEditorContext();
   const app = tryAppContext();
@@ -17,6 +17,8 @@
 
   const isPaginated = $derived(editor?.rootAttrs?.layout_mode.type === 'paginated');
   const displayZoom = $derived(editor?.safeDisplayZoom() ?? 1);
+  const scaleFactor = $derived(editor?.scaleFactor ?? 1);
+  const pageSpans = $derived(!isPaginated && editor ? resolveCachedPageSpans(editor.pageSizes, { displayZoom, scaleFactor }) : []);
 
   const container = $derived.by(() => {
     if (!cursor || !editor) return;
@@ -27,7 +29,7 @@
   const top = $derived.by(() => {
     if (!cursor || !editor) return 0;
     if (isPaginated) return cursor.line.y;
-    const pageTop = resolvePageSpans(editor.pageSizes, { displayZoom })[cursor.page_idx]?.top ?? 0;
+    const pageTop = pageSpans[cursor.page_idx]?.top ?? 0;
     return pageTop + cursor.line.y * displayZoom;
   });
 

--- a/apps/website/src/lib/editor-ffi/components/Page.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Page.svelte
@@ -48,7 +48,6 @@
     style:height={`${cssHeight}px`}
     style:transform={displayZoom === 1 ? undefined : `scale(${displayZoom})`}
     style:transform-origin={displayZoom === 1 ? undefined : 'top left'}
-    style:will-change={displayZoom === 1 ? undefined : 'transform'}
     class={css({
       position: 'relative',
       isolation: 'isolate',

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -448,6 +448,7 @@
           use:touchPanLock={ctx.editor.gesture.panLockActive}
         >
           <div
+            bind:this={ctx.editor.documentTrackEl}
             style:--editor-content-from-x={`${contentMotion?.fromX ?? 0}px`}
             style:animation={contentAnimation}
             class={css({

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
@@ -147,6 +147,7 @@
     {onclick}
   >
     <div
+      bind:this={editor.documentTrackEl}
       style:row-gap={`${isPaginated ? PAGE_GAP * editor.displayZoom : 0}px`}
       style="position: relative; display: flex; flex-direction: column; align-items: center; flex: 1 0 auto; width: 100%;"
       data-editor-document-track

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -629,6 +629,24 @@ function expectActualCanvas(editor: Editor, pageIndex: number, requirePaintedPix
 }
 
 describe('web editor frame synchronization', () => {
+  it('resolves pointer coordinates from the document track without measuring individual pages', async () => {
+    const { editor } = await mountEditor(paginatedDocWithPageBreaks(3));
+    await waitForPresentation(editor);
+    await tick();
+    const firstPage = editor.pageEls[0];
+    expect(firstPage).toBeDefined();
+    expect(editor.documentTrackEl).toBe(document.querySelector('[data-editor-document-track]'));
+    if (!firstPage) throw new Error('Expected the first page element');
+    const firstPageRect = firstPage.getBoundingClientRect();
+    const pageMeasurements = Object.values(editor.pageEls).flatMap((page) => (page ? [vi.spyOn(page, 'getBoundingClientRect')] : []));
+    for (const measurePage of pageMeasurements) measurePage.mockClear();
+
+    const local = editor.clientToLocal(firstPageRect.left + 10, firstPageRect.top + 20);
+
+    expect(local).toMatchObject({ page: 0, x: 10, y: 20 });
+    for (const measurePage of pageMeasurements) expect(measurePage).not.toHaveBeenCalled();
+  });
+
   it('reveals search matches instantly while preserving smooth tracked-item reveals by default', async () => {
     const { editor } = await mountEditor(doc('match between match'));
     const reveals: Parameters<Editor['scrollIntoView']>[0][] = [];

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -6,10 +6,10 @@ import { SvelteMap } from 'svelte/reactivity';
 import { match } from 'ts-pattern';
 import { initWasm, wasm } from '$lib/wasm-ffi.svelte';
 import { EditorAttachmentImporter } from './attachment-importer';
-import { IS_MAC } from './constants';
+import { IS_MAC, PAGE_GAP } from './constants';
 import { EditorRequest, EditorUpdate } from './editor-update';
 import { fontDataMissingHandler } from './fonts';
-import { isSelectionCollapsed, presentedPageElement } from './geometry';
+import { isSelectionCollapsed, presentedPageElement, resolveCachedPageSpans, resolvePageAtY, roundToScale } from './geometry';
 import { TouchGestureController } from './gesture.svelte';
 import { readClipboardRich, writeClipboardPayload } from './handlers/clipboard';
 import { encodeLengthPrefixedBlobs } from './length-prefix';
@@ -457,6 +457,7 @@ export class Editor {
   inputEl = $state<HTMLTextAreaElement>();
   pageEls = $state<Record<number, HTMLDivElement | undefined>>({});
   extensionAreaEl = $state<HTMLDivElement>();
+  documentTrackEl = $state<HTMLDivElement>();
   scrollContainerEl = $state<HTMLDivElement>();
   scrollViewport = $state<ScrollViewport>();
   scrollRootEl = $state<HTMLElement | null>();
@@ -1606,6 +1607,24 @@ export class Editor {
     const pages = this.pageSizes;
     if (pages.length === 0) return null;
     const zoom = this.safeDisplayZoom();
+    const documentTrackRect = this.documentTrackEl?.getBoundingClientRect();
+
+    if (documentTrackRect) {
+      const pageGap = this.rootAttrs?.layout_mode.type === 'paginated' ? PAGE_GAP * zoom : 0;
+      const spans = resolveCachedPageSpans(pages, {
+        displayZoom: zoom,
+        scaleFactor: this.scaleFactor,
+        pageGap,
+      });
+      const relativeClientY = clientY - documentTrackRect.top;
+      const resolved = resolvePageAtY(spans, pages, relativeClientY, zoom);
+      if (!resolved || !presentedPageElement(this, resolved.page)) return null;
+      const size = pages[resolved.page];
+      const slotWidth = roundToScale(size.width * zoom, this.scaleFactor);
+      const pageLeft = documentTrackRect.left + Math.max(0, (documentTrackRect.width - slotWidth) / 2);
+      const localX = Math.max(0, Math.min((clientX - pageLeft) / zoom, size.width));
+      return { page: resolved.page, x: localX, y: resolved.y };
+    }
 
     let lo = 0;
     let hi = pages.length - 1;

--- a/apps/website/src/lib/editor-ffi/geometry.test.ts
+++ b/apps/website/src/lib/editor-ffi/geometry.test.ts
@@ -4,6 +4,8 @@ import {
   isSelectionCollapsed,
   pageRectsToRevealTargetSpan,
   pageRectsToVirtualElement,
+  resolveCachedPageSpans,
+  resolvePageAtY,
   resolvePageSpans,
   selectionHeadRect,
 } from './geometry';
@@ -32,17 +34,38 @@ describe('boundingClientRect', () => {
 describe('resolvePageSpans', () => {
   it('accumulates the same device-scale-rounded height used by each page slot', () => {
     expect(
-      resolvePageSpans([{ height: 221 }, { height: 221 }, { height: 221 }], {
+      resolvePageSpans([{ height: 223 }, { height: 223 }, { height: 223 }], {
         origin: 10,
         displayZoom: 0.75,
         scaleFactor: 2,
         pageGap: 9,
       }),
     ).toEqual([
-      { page: 0, top: 10, bottom: 176 },
-      { page: 1, top: 185, bottom: 351 },
-      { page: 2, top: 360, bottom: 526 },
+      { page: 0, top: 10, bottom: 177.5 },
+      { page: 1, top: 186.5, bottom: 354 },
+      { page: 2, top: 363, bottom: 530.5 },
     ]);
+  });
+
+  it('reuses page projections while their geometry inputs are unchanged', () => {
+    const pageSizes = [{ height: 221 }, { height: 221 }];
+    const options = { displayZoom: 0.75, scaleFactor: 2, pageGap: 9 };
+
+    const first = resolveCachedPageSpans(pageSizes, options);
+
+    expect(resolveCachedPageSpans(pageSizes, options)).toBe(first);
+    expect(resolveCachedPageSpans(pageSizes, { ...options, displayZoom: 1 })).not.toBe(first);
+    expect(resolveCachedPageSpans([...pageSizes], options)).not.toBe(first);
+  });
+
+  it('chooses the nearest page across gaps and clamps outside the document', () => {
+    const pageSizes = [{ height: 100 }, { height: 100 }];
+    const pages = resolvePageSpans(pageSizes, { pageGap: 24 });
+
+    expect(resolvePageAtY(pages, pageSizes, -20, 1)).toEqual({ page: 0, y: 0 });
+    expect(resolvePageAtY(pages, pageSizes, 110, 1)).toEqual({ page: 0, y: 100 });
+    expect(resolvePageAtY(pages, pageSizes, 114, 1)).toEqual({ page: 1, y: 0 });
+    expect(resolvePageAtY(pages, pageSizes, 300, 1)).toEqual({ page: 1, y: 100 });
   });
 });
 

--- a/apps/website/src/lib/editor-ffi/geometry.ts
+++ b/apps/website/src/lib/editor-ffi/geometry.ts
@@ -7,14 +7,16 @@ export function roundToScale(value: number, scaleFactor: number): number {
   return Math.round(value * scaleFactor) / scaleFactor;
 }
 
+type PageSpanOptions = {
+  origin?: number;
+  displayZoom?: number;
+  scaleFactor?: number;
+  pageGap?: number;
+};
+
 export function resolvePageSpans(
   pageSizes: readonly { height: number }[],
-  {
-    origin = 0,
-    displayZoom = 1,
-    scaleFactor = 1,
-    pageGap = 0,
-  }: { origin?: number; displayZoom?: number; scaleFactor?: number; pageGap?: number } = {},
+  { origin = 0, displayZoom = 1, scaleFactor = 1, pageGap = 0 }: PageSpanOptions = {},
 ) {
   let top = origin;
   return pageSizes.map((size, page) => {
@@ -22,6 +24,62 @@ export function resolvePageSpans(
     top = span.bottom + pageGap;
     return span;
   });
+}
+
+type CachedPageSpanOptions = Omit<PageSpanOptions, 'origin'>;
+
+type PageSpanCacheEntry = Required<CachedPageSpanOptions> & {
+  spans: ReturnType<typeof resolvePageSpans>;
+};
+
+const pageSpanCache = new WeakMap<readonly { height: number }[], PageSpanCacheEntry>();
+
+export function resolveCachedPageSpans(pageSizes: readonly { height: number }[], options: CachedPageSpanOptions = {}) {
+  const displayZoom = options.displayZoom ?? 1;
+  const scaleFactor = options.scaleFactor ?? 1;
+  const pageGap = options.pageGap ?? 0;
+  const cached = pageSpanCache.get(pageSizes);
+  if (cached?.displayZoom === displayZoom && cached.scaleFactor === scaleFactor && cached.pageGap === pageGap) {
+    return cached.spans;
+  }
+
+  const spans = resolvePageSpans(pageSizes, { displayZoom, scaleFactor, pageGap });
+  pageSpanCache.set(pageSizes, { displayZoom, scaleFactor, pageGap, spans });
+  return spans;
+}
+
+export function resolvePageAtY(
+  pages: readonly { page: number; top: number; bottom: number }[],
+  pageSizes: readonly { height: number }[],
+  contentY: number,
+  zoom: number,
+): { page: number; y: number } | null {
+  if (pages.length === 0 || !Number.isFinite(contentY) || !Number.isFinite(zoom) || zoom <= 0) return null;
+
+  let low = 0;
+  let high = pages.length - 1;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (pages[middle].bottom <= contentY) low = middle + 1;
+    else high = middle;
+  }
+
+  let span = pages[low];
+  let size = pageSizes[span.page];
+  if (!size) return null;
+  let y = (contentY - span.top) / zoom;
+  if (y < 0 && low > 0) {
+    const previous = pages[low - 1];
+    if (contentY < (previous.bottom + span.top) / 2) {
+      span = previous;
+      size = pageSizes[span.page];
+      if (!size) return null;
+      y = size.height;
+    } else {
+      y = 0;
+    }
+  }
+  return { page: span.page, y: Math.max(0, Math.min(y, size.height)) };
 }
 
 export function pageRectsToRevealTargetSpan(

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -88,6 +88,7 @@ function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; positi
     if (options.behavior === 'instant' && options.left !== undefined) scrollLeft = options.left;
   });
   const requestPublication = vi.fn();
+  const measureViewport = vi.fn(() => new DOMRect(0, 0, 600, 400));
   const editor = {
     destroyed: false,
     appliedSnapshot: snapshot,
@@ -108,7 +109,7 @@ function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; positi
       },
     },
     scrollViewport: {
-      getRect: () => new DOMRect(0, 0, 600, 400),
+      getRect: measureViewport,
       getScrollTop: () => scrollTop,
       getScrollLeft: () => scrollLeft,
       getScrollWidth: () => 600,
@@ -133,6 +134,7 @@ function setup(snapshot: EditorSnapshot, typewriter?: { enabled: boolean; positi
     editor,
     getScrollLeft: () => scrollLeft,
     getScrollTop: () => scrollTop,
+    measureViewport,
     requestPublication,
     setScrollLeft: (value: number) => {
       scrollLeft = value;
@@ -817,6 +819,32 @@ describe('EditorScrollScope', () => {
     expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 300, top: 220, behavior: 'instant' });
   });
 
+  it('measures the document track once without reading every page during direct scroll reconciliation', () => {
+    const snapshot = trackedSnapshot('unused', {
+      page_idx: 0,
+      rect: { x: 0, y: 0, width: 1, height: 1 },
+    });
+    const { editor, scope, setScrollTop } = setup(snapshot);
+    const measureTrack = vi.fn(() => new DOMRect(0, 0, 600, 2400));
+    const measureFirstPage = vi.fn(() => new DOMRect(0, 0, 600, 1200));
+    const measureSecondPage = vi.fn(() => new DOMRect(0, 1200, 600, 1200));
+    Object.assign(editor, {
+      documentTrackEl: { getBoundingClientRect: measureTrack },
+      pageEls: {
+        0: { getBoundingClientRect: measureFirstPage },
+        1: { getBoundingClientRect: measureSecondPage },
+      },
+    });
+
+    setScrollTop(10);
+    scope.observeViewportScroll();
+
+    expect(measureTrack).toHaveBeenCalledOnce();
+    expect(editor.clientToLocal).not.toHaveBeenCalled();
+    expect(measureFirstPage).not.toHaveBeenCalled();
+    expect(measureSecondPage).not.toHaveBeenCalled();
+  });
+
   it('derives a wider candidate page x position from candidate geometry', () => {
     const current = {
       ...trackedSnapshot('unused', { page_idx: 0, rect: { x: 0, y: 0, width: 1, height: 1 } }),
@@ -926,6 +954,8 @@ describe('EditorScrollScope', () => {
     }));
 
     expect(scope.prepareViewportAnchorPublication(initial).type).toBe('ready');
+    const measureExtension = vi.fn(() => new DOMRect(0, 0, 600, 1200));
+    editor.extensionAreaEl = { getBoundingClientRect: measureExtension } as unknown as HTMLDivElement;
     capture = { identity: nextAnchor, geometry: nextGeometry };
     Object.assign(editor, {
       published: { snapshot: next, frames: editor.published?.frames ?? new Map() },
@@ -935,6 +965,7 @@ describe('EditorScrollScope', () => {
     const publication = scope.prepareViewportAnchorPublication(next);
     scope.applyViewportAnchorPublication(publication);
 
+    expect(measureExtension).toHaveBeenCalledOnce();
     expect(scrollTo).not.toHaveBeenCalled();
     expect(getScrollTop()).toBe(0);
 
@@ -1239,6 +1270,23 @@ describe('EditorScrollScope', () => {
 
     expect(scrollTo).not.toHaveBeenCalled();
     expect(getScrollTop()).toBe(580);
+  });
+
+  it('measures viewport geometry once when resizing during a smooth reveal', () => {
+    const snapshot = trackedSnapshot('target', {
+      page_idx: 0,
+      rect: { x: 0, y: 900, width: 1, height: 20 },
+    });
+    const { measureViewport, scope } = setup(snapshot);
+    scope.scrollIntoView({ target: { type: 'tracked_item', id: 'target' }, policy: 'reveal', behavior: 'smooth' });
+    const request = scope.pendingRequest;
+    if (!request) throw new Error('Expected a pending reveal');
+    expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
+    measureViewport.mockClear();
+
+    scope.reconcileViewportResize();
+
+    expect(measureViewport).toHaveBeenCalledOnce();
   });
 
   it('finishes an in-flight smooth reveal at its current position when a no-op publication is within scroll tolerance', () => {

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -1,7 +1,7 @@
 import { tryAppContext } from '@typie/ui/context';
 import { untrack } from 'svelte';
 import { CURSOR_VISIBLE_MARGIN, PAGE_GAP } from './constants';
-import { pageRectsToRevealTargetSpan, resolvePageSpans, selectionHeadRect } from './geometry';
+import { pageRectsToRevealTargetSpan, resolveCachedPageSpans, roundToScale, selectionHeadRect } from './geometry';
 import {
   resolveGuardedScrollTop,
   resolveInstantRevealPreparationViewports,
@@ -44,6 +44,18 @@ export type EditorViewportAnchorPublication =
       targetScrollTop: number | null;
     }
   | { type: 'unavailable' };
+
+type EditorViewportMetrics = {
+  layout: EditorViewportAnchorLayout;
+  scrollLeft: number;
+  scrollTop: number;
+  clientWidth: number;
+  clientHeight: number;
+  scrollWidth: number;
+  scrollHeight: number;
+  maximumScrollLeft: number;
+  maximumScrollTop: number;
+};
 
 type TypewriterPreferences = {
   enabled: boolean;
@@ -288,17 +300,17 @@ export class EditorScrollScope {
   prepareViewportAnchorPublication(snapshot: EditorSnapshot): EditorViewportAnchorPublication {
     const viewport = this.#editor.scrollViewport;
     if (!viewport) return { type: 'ready', geometry: null, targetScrollLeft: null, targetScrollTop: null };
+    const metrics = this.#viewportMetrics(snapshot, true);
+    if (!metrics) return { type: 'unavailable' };
     const selectionCapture = this.#editor.captureSelectionViewportAnchor(snapshot.revision);
     if (selectionCapture && this.#viewportAnchor.needsSelectionAdoption(selectionCapture.identity)) {
-      const selectionMetrics = this.#viewportMetrics(snapshot, true);
-      if (!selectionMetrics) return { type: 'unavailable' };
-      const selectionGeometry = resolveViewportAnchorGeometry(selectionCapture.geometry, selectionMetrics.layout);
+      const selectionGeometry = resolveViewportAnchorGeometry(selectionCapture.geometry, metrics.layout);
       if (!selectionGeometry) return { type: 'unavailable' };
       this.#viewportAnchor.adoptSelection(
         selectionCapture.identity,
         selectionGeometry,
-        { left: selectionMetrics.scrollLeft, top: selectionMetrics.scrollTop },
-        selectionMetrics.clientHeight,
+        { left: metrics.scrollLeft, top: metrics.scrollTop },
+        metrics.clientHeight,
         this.visibleArea,
         this.#smoothMotion !== null,
       );
@@ -309,8 +321,6 @@ export class EditorScrollScope {
     if (this.#smoothMotion) this.#attachViewportCenter();
     else this.#ensureViewportAnchor();
 
-    const metrics = this.#viewportMetrics(snapshot, true);
-    if (!metrics) return { type: 'unavailable' };
     const clampedScrollLeft = Math.max(0, Math.min(metrics.scrollLeft, metrics.maximumScrollLeft));
     const clampedScrollTop = Math.max(0, Math.min(metrics.scrollTop, metrics.maximumScrollTop));
     const fallbackPublication = (): EditorViewportAnchorPublication => ({
@@ -424,11 +434,12 @@ export class EditorScrollScope {
     if (this.#smoothMotion) this.cancel();
     this.#viewportAnchor.finishRevealConvergence();
 
-    const metrics = this.#viewportMetrics(this.#editor.published?.snapshot);
-    const preferred = this.#resolvePreferredSelectionAnchor();
+    const snapshot = this.#editor.published?.snapshot;
+    const metrics = this.#viewportMetrics(snapshot);
+    if (!snapshot || !metrics) return;
+    const preferred = this.#resolvePreferredSelectionAnchor(snapshot, metrics);
     if (
       preferred &&
-      metrics &&
       this.#viewportAnchor.tryReactivatePreferredSelection(
         preferred,
         { left: metrics.scrollLeft, top: metrics.scrollTop },
@@ -439,34 +450,29 @@ export class EditorScrollScope {
       return;
     }
 
-    const current = this.#resolveCurrentAnchor();
-    if (
-      current &&
-      metrics &&
-      this.#viewportAnchor.canRetainAfterDirectScroll(current, metrics.scrollTop, metrics.clientHeight, this.visibleArea)
-    ) {
+    const current = this.#resolveCurrentAnchor(snapshot, metrics);
+    if (current && this.#viewportAnchor.canRetainAfterDirectScroll(current, metrics.scrollTop, metrics.clientHeight, this.visibleArea)) {
       this.#viewportAnchor.acceptGeometry(current, { left: metrics.scrollLeft, top: metrics.scrollTop });
     } else {
-      this.#attachViewportCenter();
+      this.#attachViewportCenter(snapshot, metrics);
     }
   }
 
   reconcileViewportResize(): void {
+    const snapshot = this.#editor.published?.snapshot;
+    const metrics = this.#viewportMetrics(snapshot);
+    if (!snapshot || !metrics) return;
     if (this.#smoothMotion) {
-      const viewport = this.#editor.scrollViewport;
-      const rect = viewport?.getRect();
-      const viewportHeight = rect ? rect.bottom - rect.top : 0;
-      if (viewportHeight > 0) {
+      if (metrics.clientHeight > 0) {
         const target = this.#smoothMotion.snapshot().target;
-        this.#smoothMotion.retarget(target, viewportHeight);
+        this.#smoothMotion.retarget(target, metrics.clientHeight);
       }
-      this.#attachViewportCenter();
+      this.#attachViewportCenter(snapshot, metrics);
       return;
     }
-    const geometry = this.#resolveCurrentAnchor();
-    const metrics = this.#viewportMetrics(this.#editor.published?.snapshot);
-    if (!geometry || !metrics) {
-      this.#ensureViewportAnchor();
+    const geometry = this.#resolveCurrentAnchor(snapshot, metrics);
+    if (!geometry) {
+      this.#ensureViewportAnchor(snapshot, metrics);
       return;
     }
     const target = this.#viewportAnchor.resizeScroll(
@@ -651,57 +657,57 @@ export class EditorScrollScope {
     return request.presentation;
   }
 
-  #ensureViewportAnchor(): void {
+  #ensureViewportAnchor(snapshot = this.#editor.published?.snapshot, metrics?: EditorViewportMetrics): void {
     if (this.#viewportAnchor.identity) return;
-    this.#attachSelectionOrCenter();
+    this.#attachSelectionOrCenter(true, undefined, snapshot, metrics);
   }
 
-  #attachSelectionOrCenter(requireGuard = true, revealOrigin?: EditorViewportAnchorRevealOrigin): void {
-    const snapshot = this.#editor.published?.snapshot;
-    const metrics = this.#viewportMetrics(snapshot);
-    if (!snapshot || !metrics) return;
+  #attachSelectionOrCenter(
+    requireGuard = true,
+    revealOrigin?: EditorViewportAnchorRevealOrigin,
+    snapshot = this.#editor.published?.snapshot,
+    metrics?: EditorViewportMetrics,
+  ): void {
+    const resolvedMetrics = metrics ?? this.#viewportMetrics(snapshot);
+    if (!snapshot || !resolvedMetrics) return;
     const capture = this.#editor.captureSelectionViewportAnchor(snapshot.revision);
     if (capture) {
-      const geometry = resolveViewportAnchorGeometry(capture.geometry, metrics.layout);
+      const geometry = resolveViewportAnchorGeometry(capture.geometry, resolvedMetrics.layout);
       if (
         geometry &&
         (!requireGuard ||
-          this.#viewportAnchor.canRetainAfterDirectScroll(geometry, metrics.scrollTop, metrics.clientHeight, this.visibleArea))
+          this.#viewportAnchor.canRetainAfterDirectScroll(
+            geometry,
+            resolvedMetrics.scrollTop,
+            resolvedMetrics.clientHeight,
+            this.visibleArea,
+          ))
       ) {
         this.#viewportAnchor.attachSelection(
           capture.identity,
           geometry,
-          { left: metrics.scrollLeft, top: metrics.scrollTop },
+          { left: resolvedMetrics.scrollLeft, top: resolvedMetrics.scrollTop },
           revealOrigin,
         );
         return;
       }
     }
-    this.#attachViewportCenter();
+    this.#attachViewportCenter(snapshot, resolvedMetrics);
   }
 
-  #attachViewportCenter(): boolean {
-    const snapshot = this.#editor.published?.snapshot;
-    const metrics = this.#viewportMetrics(snapshot);
-    if (!snapshot || !metrics) return false;
-    const viewportRect = this.#editor.scrollViewport?.getRect();
-    const topInset = Math.max(0, this.visibleArea.topInset);
-    const visibleHeight = Math.max(0, metrics.clientHeight - topInset - Math.max(0, this.visibleArea.bottomInset));
-    const local = viewportRect
-      ? this.#editor.clientToLocal(
-          viewportRect.left + (viewportRect.right - viewportRect.left) / 2,
-          viewportRect.top + topInset + visibleHeight / 2,
-        )
-      : null;
-    const point = local
-      ? { page_idx: local.page, x: local.x, y: local.y }
-      : viewportCenterAnchorPoint(snapshot, metrics.layout, metrics.scrollTop, metrics.clientHeight, this.visibleArea);
+  #attachViewportCenter(snapshot = this.#editor.published?.snapshot, metrics?: EditorViewportMetrics): boolean {
+    const resolvedMetrics = metrics ?? this.#viewportMetrics(snapshot);
+    if (!snapshot || !resolvedMetrics) return false;
+    const point = viewportCenterAnchorPoint(snapshot, resolvedMetrics.layout, resolvedMetrics, this.visibleArea);
     if (!point) return false;
     const capture = this.#editor.captureViewportAnchorAt(snapshot.revision, point);
     if (!capture) return false;
-    const geometry = resolveViewportAnchorGeometry(capture.geometry, metrics.layout);
+    const geometry = resolveViewportAnchorGeometry(capture.geometry, resolvedMetrics.layout);
     if (!geometry) return false;
-    this.#viewportAnchor.attachViewport(capture.identity, geometry, { left: metrics.scrollLeft, top: metrics.scrollTop });
+    this.#viewportAnchor.attachViewport(capture.identity, geometry, {
+      left: resolvedMetrics.scrollLeft,
+      top: resolvedMetrics.scrollTop,
+    });
     return true;
   }
 
@@ -711,44 +717,27 @@ export class EditorScrollScope {
       : undefined;
   }
 
-  #resolvePreferredSelectionAnchor(): EditorViewportAnchorGeometry | null {
-    const snapshot = this.#editor.published?.snapshot;
+  #resolvePreferredSelectionAnchor(snapshot: EditorSnapshot, metrics: EditorViewportMetrics): EditorViewportAnchorGeometry | null {
     const identity = this.#viewportAnchor.preferredSelectionIdentity;
-    if (!snapshot || !identity) return null;
+    if (!identity) return null;
     const resolution = this.#editor.resolveViewportAnchor(snapshot.revision, identity);
     if (resolution.type === 'deleted') {
       this.#viewportAnchor.clearPreferredSelection();
       return null;
     }
     if (resolution.type !== 'resolved') return null;
-    const metrics = this.#viewportMetrics(snapshot);
-    return metrics ? resolveViewportAnchorGeometry(resolution.geometry, metrics.layout) : null;
+    return resolveViewportAnchorGeometry(resolution.geometry, metrics.layout);
   }
 
-  #resolveCurrentAnchor(): EditorViewportAnchorGeometry | null {
-    const snapshot = this.#editor.published?.snapshot;
+  #resolveCurrentAnchor(snapshot: EditorSnapshot, metrics: EditorViewportMetrics): EditorViewportAnchorGeometry | null {
     const identity = this.#viewportAnchor.identity;
-    if (!snapshot || !identity) return null;
+    if (!identity) return null;
     const resolution = this.#editor.resolveViewportAnchor(snapshot.revision, identity);
     if (resolution.type !== 'resolved') return null;
-    const metrics = this.#viewportMetrics(snapshot);
-    return metrics ? resolveViewportAnchorGeometry(resolution.geometry, metrics.layout) : null;
+    return resolveViewportAnchorGeometry(resolution.geometry, metrics.layout);
   }
 
-  #viewportMetrics(
-    snapshot: EditorSnapshot | undefined,
-    candidateExtent = false,
-  ): {
-    layout: EditorViewportAnchorLayout;
-    scrollLeft: number;
-    scrollTop: number;
-    clientWidth: number;
-    clientHeight: number;
-    scrollWidth: number;
-    scrollHeight: number;
-    maximumScrollLeft: number;
-    maximumScrollTop: number;
-  } | null {
+  #viewportMetrics(snapshot: EditorSnapshot | undefined, candidateExtent = false): EditorViewportMetrics | null {
     const viewport = this.#editor.scrollViewport;
     if (!snapshot || !viewport) return null;
     const viewportRect = viewport.getRect();
@@ -756,10 +745,21 @@ export class EditorScrollScope {
     const clientHeight = viewportRect.bottom - viewportRect.top;
     const scrollLeft = viewport.getScrollLeft();
     const scrollTop = viewport.getScrollTop();
-    if (![scrollLeft, scrollTop, clientWidth, clientHeight].every(Number.isFinite) || clientWidth <= 0 || clientHeight <= 0) return null;
+    if (
+      !Number.isFinite(scrollLeft) ||
+      !Number.isFinite(scrollTop) ||
+      !Number.isFinite(clientWidth) ||
+      !Number.isFinite(clientHeight) ||
+      clientWidth <= 0 ||
+      clientHeight <= 0
+    ) {
+      return null;
+    }
     const zoom = this.#editor.safeDisplayZoom();
-    const extensionRect = this.#editor.extensionAreaEl?.getBoundingClientRect();
-    const origin = extensionRect ? extensionRect.top - viewportRect.top + scrollTop : 0;
+    const documentTrackRect = candidateExtent ? undefined : this.#editor.documentTrackEl?.getBoundingClientRect();
+    const extensionRect = candidateExtent || !documentTrackRect ? this.#editor.extensionAreaEl?.getBoundingClientRect() : undefined;
+    const originRect = documentTrackRect ?? extensionRect;
+    const origin = originRect ? originRect.top - viewportRect.top + scrollTop : 0;
     const extensionLeft = extensionRect ? extensionRect.left - viewportRect.left + scrollLeft : 0;
     const useCandidateHorizontalGeometry = candidateExtent && extensionRect !== undefined;
     const parsedPaddingLeft = useCandidateHorizontalGeometry
@@ -773,28 +773,34 @@ export class EditorScrollScope {
     const candidateExtensionWidth = useCandidateHorizontalGeometry
       ? Math.max(
           clientWidth,
-          snapshot.pageSizes.reduce((width, page) => Math.max(width, page.width * zoom), 0) + extensionPaddingLeft + extensionPaddingRight,
+          snapshot.pageSizes.reduce((width, page) => Math.max(width, roundToScale(page.width * zoom, this.#editor.scaleFactor)), 0) +
+            extensionPaddingLeft +
+            extensionPaddingRight,
         )
       : clientWidth;
     const candidateContentWidth = Math.max(0, candidateExtensionWidth - extensionPaddingLeft - extensionPaddingRight);
-    const pageSpans = resolvePageSpans(snapshot.pageSizes, {
-      origin,
+    const pageSpans = resolveCachedPageSpans(snapshot.pageSizes, {
       displayZoom: zoom,
       scaleFactor: this.#editor.scaleFactor,
       pageGap: snapshot.rootAttrs?.layout_mode.type === 'paginated' ? PAGE_GAP * zoom : 0,
     });
     const pages = pageSpans.map((span) => {
-      const pageRect = this.#editor.pageEls[span.page]?.getBoundingClientRect();
-      const displayedWidth = snapshot.pageSizes[span.page].width * zoom;
-      const left = useCandidateHorizontalGeometry
-        ? extensionLeft + extensionPaddingLeft + Math.max(0, (candidateContentWidth - displayedWidth) / 2)
-        : pageRect
+      const slotWidth = roundToScale(snapshot.pageSizes[span.page].width * zoom, this.#editor.scaleFactor);
+      let left: number;
+      if (useCandidateHorizontalGeometry) {
+        left = extensionLeft + extensionPaddingLeft + Math.max(0, (candidateContentWidth - slotWidth) / 2);
+      } else if (documentTrackRect) {
+        left = documentTrackRect.left - viewportRect.left + scrollLeft + Math.max(0, (documentTrackRect.width - slotWidth) / 2);
+      } else {
+        const pageRect = this.#editor.pageEls[span.page]?.getBoundingClientRect();
+        left = pageRect
           ? pageRect.left - viewportRect.left + scrollLeft
-          : extensionLeft + Math.max(0, ((extensionRect?.width ?? clientWidth) - displayedWidth) / 2);
-      return { ...span, left };
+          : extensionLeft + Math.max(0, ((extensionRect?.width ?? clientWidth) - slotWidth) / 2);
+      }
+      return { ...span, top: origin + span.top, bottom: origin + span.bottom, left };
     });
     const predictedRight = pages.reduce(
-      (right, page) => Math.max(right, page.left + snapshot.pageSizes[page.page].width * zoom),
+      (right, page) => Math.max(right, page.left + roundToScale(snapshot.pageSizes[page.page].width * zoom, this.#editor.scaleFactor)),
       useCandidateHorizontalGeometry ? Math.max(clientWidth, extensionLeft + candidateExtensionWidth) : clientWidth,
     );
     const predictedExtent = pages.at(-1)?.bottom ?? origin;

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
@@ -1,12 +1,49 @@
 import { describe, expect, it } from 'vitest';
-import { EditorViewportAnchorState, resolveViewportAnchorGeometry } from './viewport-anchor';
+import { EditorViewportAnchorState, resolveViewportAnchorGeometry, viewportCenterAnchorPoint } from './viewport-anchor';
 import type { ViewportAnchor } from '@typie/editor-ffi/browser';
+import type { EditorSnapshot } from './editor.svelte';
 
 const identity: ViewportAnchor = { type: 'node', node: '1:1', offset_x: 0, offset_y: 0 };
 const viewportIdentity: ViewportAnchor = { type: 'node', node: '2:1', offset_x: 0, offset_y: 0 };
 const visibleArea = { topInset: 0, bottomInset: 0 };
 
 describe('EditorViewportAnchorState', () => {
+  it('resolves the viewport center on both axes without DOM geometry', () => {
+    const snapshot = {
+      pageSizes: [{ width: 600, height: 1200 }],
+    } as EditorSnapshot;
+
+    expect(
+      viewportCenterAnchorPoint(
+        snapshot,
+        { pages: [{ page: 0, left: 100, top: 20, bottom: 1220 }], zoom: 2 },
+        { scrollLeft: 300, scrollTop: 220, clientWidth: 400, clientHeight: 200 },
+        { topInset: 20, bottomInset: 40 },
+      ),
+    ).toEqual({ page_idx: 0, x: 200, y: 145 });
+  });
+
+  it('uses the gap midpoint and clamps viewport centers to page bounds', () => {
+    const snapshot = {
+      pageSizes: [
+        { width: 600, height: 100 },
+        { width: 600, height: 100 },
+      ],
+    } as EditorSnapshot;
+    const layout = {
+      pages: [
+        { page: 0, left: 0, top: 0, bottom: 100 },
+        { page: 1, left: 0, top: 124, bottom: 224 },
+      ],
+      zoom: 1,
+    };
+
+    const metrics = (scrollTop: number) => ({ scrollLeft: 0, scrollTop, clientWidth: 600, clientHeight: 20 });
+    expect(viewportCenterAnchorPoint(snapshot, layout, metrics(100), visibleArea)).toMatchObject({ page_idx: 0, y: 100 });
+    expect(viewportCenterAnchorPoint(snapshot, layout, metrics(104), visibleArea)).toMatchObject({ page_idx: 1, y: 0 });
+    expect(viewportCenterAnchorPoint(snapshot, layout, metrics(300), visibleArea)).toMatchObject({ page_idx: 1, y: 100 });
+  });
+
   it('resolves page-local points through the displayed page origin and zoom on both axes', () => {
     const resolved = resolveViewportAnchorGeometry(
       { point: { page_idx: 0, x: 40, y: 50 }, rect: undefined },

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.ts
@@ -1,6 +1,7 @@
 import { clamp } from '@typie/ui/utils';
 import stringify from 'fast-json-stable-stringify';
 import { CURSOR_VISIBLE_MARGIN } from './constants';
+import { resolvePageAtY } from './geometry';
 import { resolveGuardedScrollTop } from './scroll';
 import type { ResolvedViewportAnchor, ViewportAnchor, ViewportAnchorPoint } from '@typie/editor-ffi/browser';
 import type { EditorSnapshot } from './editor.svelte';
@@ -34,6 +35,13 @@ export type EditorViewportAnchorLayout = {
 };
 
 export type EditorViewportScrollPosition = { left: number; top: number };
+
+export type EditorViewportCenterMetrics = {
+  scrollLeft: number;
+  scrollTop: number;
+  clientWidth: number;
+  clientHeight: number;
+};
 
 export class EditorViewportAnchorState {
   #active: ActiveViewportAnchor | null = null;
@@ -256,31 +264,36 @@ export function resolveViewportAnchorGeometry(
 export function viewportCenterAnchorPoint(
   snapshot: EditorSnapshot,
   layout: EditorViewportAnchorLayout,
-  scrollTop: number,
-  clientHeight: number,
+  metrics: EditorViewportCenterMetrics,
   visibleArea: EditorVisibleArea,
 ): ViewportAnchorPoint | null {
-  if (layout.pages.length === 0 || !Number.isFinite(scrollTop) || !Number.isFinite(clientHeight) || clientHeight <= 0) return null;
+  const { scrollLeft, scrollTop, clientWidth, clientHeight } = metrics;
+  if (
+    layout.pages.length === 0 ||
+    !Number.isFinite(scrollLeft) ||
+    !Number.isFinite(scrollTop) ||
+    !Number.isFinite(clientWidth) ||
+    !Number.isFinite(clientHeight) ||
+    clientWidth <= 0 ||
+    clientHeight <= 0
+  ) {
+    return null;
+  }
   const topInset = Math.max(0, visibleArea.topInset);
   const visibleHeight = Math.max(0, clientHeight - topInset - Math.max(0, visibleArea.bottomInset));
   const viewportCenter = topInset + visibleHeight / 2;
+  const contentX = scrollLeft + clientWidth / 2;
   const contentY = scrollTop + viewportCenter;
 
-  let page = layout.pages.at(-1);
-  for (let index = 0; index < layout.pages.length; index += 1) {
-    const next = layout.pages[index + 1];
-    if (!next || contentY < next.top) {
-      page = layout.pages[index];
-      break;
-    }
-  }
-  if (!page) return null;
-  const size = snapshot.pageSizes[page.page];
-  if (!size) return null;
+  const resolved = resolvePageAtY(layout.pages, snapshot.pageSizes, contentY, layout.zoom);
+  if (!resolved) return null;
+  const page = layout.pages[resolved.page];
+  const size = snapshot.pageSizes[resolved.page];
+  if (!page || !size) return null;
   return {
-    page_idx: page.page,
-    x: size.width / 2,
-    y: (contentY - page.top) / layout.zoom,
+    page_idx: resolved.page,
+    x: Math.max(0, Math.min((contentX - page.left) / layout.zoom, size.width)),
+    y: resolved.y,
   };
 }
 


### PR DESCRIPTION
- Web과 Compose의 페이지 위치 계산을 공유하고 반복 계산을 줄입니다.
- 페이지별 DOM 측정과 앞 페이지 순회를 제거합니다.
- 뷰포트 앵커, 포인터 좌표, line highlight가 동일한 줌 좌표계를 사용하도록 맞춥니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>