### PR TITLE
renderZoom 커밋 스케줄링 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomState.kt
@@ -22,6 +22,9 @@ private const val FitWidthZoomSnapThreshold = 0.02f
 private const val UnitZoomSnapThreshold = 0.02f
 private const val ZoomEpsilon = 0.0001f
 private const val RenderZoomDebounceMs = 120L
+private const val RenderZoomMinCommitIntervalMs = 160L
+private const val RenderZoomMaxCommitDelayMs = 300L
+private const val RenderZoomScaleRatioThreshold = 1.18f
 
 @Stable
 internal class EditorZoomController(
@@ -40,7 +43,10 @@ internal class EditorZoomController(
   private var initializedLayoutKey: String? = null
   private var currentLayoutSpec: EditorDocumentLayoutSpec = EditorDocumentLayoutSpec.Continuous(0f)
   private var currentViewportWidth: Float = 0f
-  private var renderZoomJob: Job? = null
+  private var renderZoomQuietJob: Job? = null
+  private var renderZoomMaxDelayJob: Job? = null
+  private var renderZoomCooldownJob: Job? = null
+  private var renderZoomCommitPending = false
 
   fun syncLayout(layoutSpec: EditorDocumentLayoutSpec, viewportWidth: Float) {
     currentLayoutSpec = layoutSpec
@@ -86,9 +92,7 @@ internal class EditorZoomController(
   }
 
   fun commitRenderZoom() {
-    renderZoomJob?.cancel()
-    renderZoomJob = null
-    syncRenderZoomNow()
+    requestRenderZoomCommit()
   }
 
   fun resolveSnapKey(zoom: Float = displayZoom): EditorZoomSnapKey? {
@@ -128,25 +132,88 @@ internal class EditorZoomController(
       displayZoom = resolvedZoom
     }
 
-    renderZoomJob?.cancel()
-    renderZoomJob = null
-
     if (commitRender) {
+      clearRenderZoomSchedule()
       syncRenderZoomNow()
       return changed
     }
 
-    renderZoomJob = scope?.launch {
-      delay(renderZoomDebounceMs)
-      syncRenderZoomNow()
-    }
+    scheduleRenderZoom()
     return changed
+  }
+
+  private fun scheduleRenderZoom() {
+    renderZoomQuietJob?.cancel()
+    renderZoomQuietJob = null
+    renderZoomCommitPending = false
+
+    val nextRenderZoom = renderZoomForDisplay(displayZoom)
+    if (!zoomDiffers(renderZoom, nextRenderZoom)) {
+      clearRenderZoomSchedule()
+      return
+    }
+
+    if (renderZoomMaxDelayJob?.isActive != true) {
+      renderZoomMaxDelayJob = scope?.launch {
+        delay(RenderZoomMaxCommitDelayMs)
+        renderZoomMaxDelayJob = null
+        requestRenderZoomCommit()
+      }
+    }
+
+    val scaleRatio = maxOf(displayZoom / renderZoom, renderZoom / displayZoom)
+    if (scaleRatio >= RenderZoomScaleRatioThreshold) {
+      requestRenderZoomCommit()
+      return
+    }
+
+    renderZoomQuietJob = scope?.launch {
+      delay(renderZoomDebounceMs)
+      renderZoomQuietJob = null
+      requestRenderZoomCommit()
+    }
+  }
+
+  private fun requestRenderZoomCommit() {
+    renderZoomQuietJob?.cancel()
+    renderZoomQuietJob = null
+
+    val nextRenderZoom = renderZoomForDisplay(displayZoom)
+    if (!zoomDiffers(renderZoom, nextRenderZoom)) {
+      clearRenderZoomSchedule()
+      return
+    }
+
+    if (renderZoomCooldownJob?.isActive == true) {
+      renderZoomCommitPending = true
+      return
+    }
+
+    clearRenderZoomSchedule()
+    syncRenderZoomNow()
+  }
+
+  private fun clearRenderZoomSchedule() {
+    renderZoomQuietJob?.cancel()
+    renderZoomQuietJob = null
+    renderZoomMaxDelayJob?.cancel()
+    renderZoomMaxDelayJob = null
+    renderZoomCommitPending = false
   }
 
   private fun syncRenderZoomNow() {
     val nextRenderZoom = renderZoomForDisplay(displayZoom)
     if (!zoomEquals(renderZoom, nextRenderZoom)) {
       renderZoom = nextRenderZoom
+      renderZoomCooldownJob?.cancel()
+      renderZoomCooldownJob = scope?.launch {
+        delay(RenderZoomMinCommitIntervalMs)
+        renderZoomCooldownJob = null
+        if (renderZoomCommitPending) {
+          renderZoomCommitPending = false
+          requestRenderZoomCommit()
+        }
+      }
     }
   }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomStateTest.kt
@@ -119,7 +119,7 @@ class EditorZoomControllerTest {
     )
 
     state.setDisplayZoom(
-      zoom = 1.4f,
+      zoom = 1.1f,
       layoutSpec =
         EditorDocumentLayoutSpec.Paginated(
           pageWidth = 720f,
@@ -132,7 +132,7 @@ class EditorZoomControllerTest {
       viewportWidth = 720f,
     )
 
-    assertEquals(1.4f, state.displayZoom, 0.0001f)
+    assertEquals(1.1f, state.displayZoom, 0.0001f)
     assertEquals(1f, state.renderZoom, 0.0001f)
 
     advanceTimeBy(119)
@@ -141,7 +141,7 @@ class EditorZoomControllerTest {
 
     advanceTimeBy(1)
     runCurrent()
-    assertEquals(1.4f, state.renderZoom, 0.0001f)
+    assertEquals(1.1f, state.renderZoom, 0.0001f)
   }
 
   @Test
@@ -150,16 +150,16 @@ class EditorZoomControllerTest {
     val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
     state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
 
-    state.setDisplayZoom(zoom = 0.75f, layoutSpec = layout, viewportWidth = 500f)
+    state.setDisplayZoom(zoom = 0.9f, layoutSpec = layout, viewportWidth = 500f)
 
-    assertEquals(0.75f, state.displayZoom, 0.0001f)
+    assertEquals(0.9f, state.displayZoom, 0.0001f)
     assertEquals(1f, state.renderZoom, 0.0001f)
     advanceTimeBy(119)
     runCurrent()
     assertEquals(1f, state.renderZoom, 0.0001f)
     advanceTimeBy(1)
     runCurrent()
-    assertEquals(0.75f, state.renderZoom, 0.0001f)
+    assertEquals(0.9f, state.renderZoom, 0.0001f)
   }
 
   @Test
@@ -176,14 +176,107 @@ class EditorZoomControllerTest {
       )
 
     state.syncLayout(layoutSpec = layoutSpec, viewportWidth = 720f)
-    state.setDisplayZoom(zoom = 1.4f, layoutSpec = layoutSpec, viewportWidth = 720f)
+    state.setDisplayZoom(zoom = 1.1f, layoutSpec = layoutSpec, viewportWidth = 720f)
 
-    assertEquals(1.4f, state.displayZoom, 0.0001f)
+    assertEquals(1.1f, state.displayZoom, 0.0001f)
     assertEquals(1f, state.renderZoom, 0.0001f)
 
     state.commitRenderZoom()
 
-    assertEquals(1.4f, state.renderZoom, 0.0001f)
+    assertEquals(1.1f, state.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `large scale difference commits without waiting for the quiet period`() = runTest {
+    val state = EditorZoomController(scope = backgroundScope)
+    val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+    state.setDisplayZoom(zoom = 0.84f, layoutSpec = layout, viewportWidth = 500f)
+
+    assertEquals(0.84f, state.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `rapid large scale changes keep the minimum render commit interval`() = runTest {
+    val state = EditorZoomController(scope = backgroundScope)
+    val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+    state.setDisplayZoom(zoom = 0.84f, layoutSpec = layout, viewportWidth = 500f)
+    state.setDisplayZoom(zoom = 1.2f, layoutSpec = layout, viewportWidth = 500f)
+    advanceTimeBy(159)
+    state.setDisplayZoom(zoom = 1.3f, layoutSpec = layout, viewportWidth = 500f)
+
+    assertEquals(0.84f, state.renderZoom, 0.0001f)
+
+    advanceTimeBy(1)
+    runCurrent()
+    assertEquals(1.3f, state.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `latest small change replaces a blocked threshold commit without extending maximum delay`() =
+    runTest {
+      val state = EditorZoomController(scope = backgroundScope)
+      val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+      state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+      state.setDisplayZoom(zoom = 0.84f, layoutSpec = layout, viewportWidth = 500f)
+      advanceTimeBy(20)
+      state.setDisplayZoom(zoom = 1.2f, layoutSpec = layout, viewportWidth = 500f)
+      advanceTimeBy(80)
+      state.setDisplayZoom(zoom = 0.9f, layoutSpec = layout, viewportWidth = 500f)
+      advanceTimeBy(100)
+      state.setDisplayZoom(zoom = 0.91f, layoutSpec = layout, viewportWidth = 500f)
+      advanceTimeBy(100)
+      state.setDisplayZoom(zoom = 0.9f, layoutSpec = layout, viewportWidth = 500f)
+      advanceTimeBy(19)
+      runCurrent()
+
+      assertEquals(0.84f, state.renderZoom, 0.0001f)
+
+      advanceTimeBy(1)
+      runCurrent()
+      assertEquals(0.9f, state.renderZoom, 0.0001f)
+    }
+
+  @Test
+  fun `continuous input commits by the maximum render delay`() = runTest {
+    val state = EditorZoomController(scope = backgroundScope)
+    val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+    state.setDisplayZoom(zoom = 0.95f, layoutSpec = layout, viewportWidth = 500f)
+    advanceTimeBy(100)
+    state.setDisplayZoom(zoom = 0.96f, layoutSpec = layout, viewportWidth = 500f)
+    advanceTimeBy(100)
+    state.setDisplayZoom(zoom = 0.95f, layoutSpec = layout, viewportWidth = 500f)
+    advanceTimeBy(99)
+    runCurrent()
+
+    assertEquals(1f, state.renderZoom, 0.0001f)
+
+    advanceTimeBy(1)
+    runCurrent()
+    assertEquals(0.95f, state.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `gesture end waits for the minimum interval after an intermediate commit`() = runTest {
+    val state = EditorZoomController(scope = backgroundScope)
+    val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+    state.setDisplayZoom(zoom = 0.84f, layoutSpec = layout, viewportWidth = 500f)
+    state.setDisplayZoom(zoom = 1.1f, layoutSpec = layout, viewportWidth = 500f)
+    state.commitRenderZoom()
+
+    assertEquals(0.84f, state.renderZoom, 0.0001f)
+
+    advanceTimeBy(160)
+    runCurrent()
+    assertEquals(1.1f, state.renderZoom, 0.0001f)
   }
 
   @Test

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
@@ -5,6 +5,9 @@ import {
   computeDocumentZoomBounds,
   computeInitialDocumentZoom,
   RENDER_ZOOM_DEBOUNCE_MS,
+  RENDER_ZOOM_MAX_COMMIT_DELAY_MS,
+  RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS,
+  RENDER_ZOOM_SCALE_RATIO_THRESHOLD,
   renderZoomForDisplay,
   zoomDiffers,
   zoomEquals,
@@ -35,6 +38,8 @@ export class EditorZoomController {
 
   #initializedLayoutKey: string | null = null;
   #renderZoomTimer: ReturnType<typeof setTimeout> | null = null;
+  #renderZoomMismatchStartedAt: number | null = null;
+  #lastRenderZoomCommitAt = -Infinity;
   #wheelRawZoomResetTimer: ReturnType<typeof setTimeout> | null = null;
   #wheelRawZoom: number | null = null;
   #options: EditorZoomControllerOptions;
@@ -108,6 +113,52 @@ export class EditorZoomController {
     this.#wheelRawZoom = null;
   }
 
+  #clearRenderZoomTimer(): void {
+    if (this.#renderZoomTimer) {
+      clearTimeout(this.#renderZoomTimer);
+      this.#renderZoomTimer = null;
+    }
+  }
+
+  #commitLatestRenderZoom(now: number): void {
+    this.#clearRenderZoomTimer();
+    this.#renderZoomMismatchStartedAt = null;
+    const nextRenderZoom = this.#options.layout() ? renderZoomForDisplay(this.displayZoom) : 1;
+    if (zoomDiffers(this.renderZoom, nextRenderZoom)) {
+      this.renderZoom = nextRenderZoom;
+      this.#lastRenderZoomCommitAt = now;
+    }
+  }
+
+  #scheduleRenderZoom(final = false): void {
+    this.#clearRenderZoomTimer();
+    const nextRenderZoom = this.#options.layout() ? renderZoomForDisplay(this.displayZoom) : 1;
+    if (!zoomDiffers(this.renderZoom, nextRenderZoom)) {
+      this.#renderZoomMismatchStartedAt = null;
+      return;
+    }
+
+    const now = Date.now();
+    this.#renderZoomMismatchStartedAt ??= now;
+    const minimumIntervalDeadline = this.#lastRenderZoomCommitAt + RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS;
+    const quietDeadline = now + RENDER_ZOOM_DEBOUNCE_MS;
+    const maximumDelayDeadline = this.#renderZoomMismatchStartedAt + RENDER_ZOOM_MAX_COMMIT_DELAY_MS;
+    const scaleRatio = Math.max(this.displayZoom / this.renderZoom, this.renderZoom / this.displayZoom);
+
+    const requestedDeadline =
+      final || scaleRatio >= RENDER_ZOOM_SCALE_RATIO_THRESHOLD ? now : Math.min(quietDeadline, maximumDelayDeadline);
+    const deadline = Math.max(requestedDeadline, minimumIntervalDeadline);
+
+    const delay = Math.max(0, deadline - now);
+    if (delay === 0) {
+      this.#commitLatestRenderZoom(now);
+      return;
+    }
+    this.#renderZoomTimer = setTimeout(() => {
+      this.#commitLatestRenderZoom(Date.now());
+    }, delay);
+  }
+
   async #syncZoomAnchor(anchor: ZoomAnchor, zoom: number): Promise<void> {
     const viewport = this.#options.getScrollViewport();
     if (!viewport) {
@@ -144,10 +195,8 @@ export class EditorZoomController {
   }
 
   destroy(): void {
-    if (this.#renderZoomTimer) {
-      clearTimeout(this.#renderZoomTimer);
-      this.#renderZoomTimer = null;
-    }
+    this.#clearRenderZoomTimer();
+    this.#renderZoomMismatchStartedAt = null;
     this.#resetWheelRawZoom();
   }
 
@@ -156,10 +205,7 @@ export class EditorZoomController {
       this.#resetWheelRawZoom();
     }
 
-    if (this.#renderZoomTimer) {
-      clearTimeout(this.#renderZoomTimer);
-      this.#renderZoomTimer = null;
-    }
+    this.#clearRenderZoomTimer();
 
     const layout = this.#options.layout();
     if (!layout) {
@@ -168,7 +214,9 @@ export class EditorZoomController {
       }
       if (zoomDiffers(this.renderZoom, 1)) {
         this.renderZoom = 1;
+        this.#lastRenderZoomCommitAt = Date.now();
       }
+      this.#renderZoomMismatchStartedAt = null;
       return;
     }
 
@@ -178,32 +226,16 @@ export class EditorZoomController {
       layout,
       viewportWidth,
     });
-    const nextRenderZoom = renderZoomForDisplay(clamped);
-
     if (zoomDiffers(this.displayZoom, clamped)) {
       this.displayZoom = clamped;
     }
 
     if (commitRender) {
-      if (zoomDiffers(this.renderZoom, nextRenderZoom)) {
-        this.renderZoom = nextRenderZoom;
-      }
+      this.#commitLatestRenderZoom(Date.now());
       return;
     }
 
-    this.#renderZoomTimer = setTimeout(() => {
-      this.#renderZoomTimer = null;
-      if (!this.#options.layout()) {
-        if (zoomDiffers(this.renderZoom, 1)) {
-          this.renderZoom = 1;
-        }
-        return;
-      }
-      const latestRenderZoom = renderZoomForDisplay(this.displayZoom);
-      if (zoomDiffers(this.renderZoom, latestRenderZoom)) {
-        this.renderZoom = latestRenderZoom;
-      }
-    }, RENDER_ZOOM_DEBOUNCE_MS);
+    this.#scheduleRenderZoom();
   }
 
   syncInitialZoom(): void {
@@ -301,6 +333,7 @@ export class EditorZoomController {
   }
 
   commitRenderZoom(): void {
-    this.setZoom(this.displayZoom, { commitRender: true });
+    this.#resetWheelRawZoom();
+    this.#scheduleRenderZoom(true);
   }
 }

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  RENDER_ZOOM_MAX_COMMIT_DELAY_MS,
+  RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS,
+  RENDER_ZOOM_SCALE_RATIO_THRESHOLD,
+} from '$lib/editor-ffi/zoom';
 import { EditorZoomController } from './editor-zoom.svelte';
 import type { Editor } from '$lib/editor-ffi/editor.svelte';
 import type { DocumentZoomLayout } from '$lib/editor-ffi/zoom';
@@ -36,19 +41,19 @@ describe('EditorZoomController continuous timing', () => {
     expect(controller.renderZoom).toBe(1);
   });
 
-  it('commits continuous render zoom only at the existing debounce boundary', () => {
+  it('commits a small continuous render zoom change at the existing debounce boundary', () => {
     vi.useFakeTimers();
     const controller = createController({ type: 'continuous', maxWidth: 600 });
 
-    controller.setZoom(0.8);
-    expect(controller.displayZoom).toBe(0.8);
+    controller.setZoom(0.9);
+    expect(controller.displayZoom).toBe(0.9);
     expect(controller.renderZoom).toBe(1);
 
     vi.advanceTimersByTime(119);
     expect(controller.renderZoom).toBe(1);
 
     vi.advanceTimersByTime(1);
-    expect(controller.renderZoom).toBe(0.8);
+    expect(controller.renderZoom).toBe(0.9);
   });
 
   it('commits continuous render zoom immediately at gesture end', () => {
@@ -60,6 +65,84 @@ describe('EditorZoomController continuous timing', () => {
 
     expect(controller.renderZoom).toBe(0.8);
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('commits a large scale difference without waiting for the quiet period', () => {
+    vi.useFakeTimers();
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+
+    controller.setZoom(1 / RENDER_ZOOM_SCALE_RATIO_THRESHOLD);
+
+    expect(controller.renderZoom).toBeCloseTo(1 / RENDER_ZOOM_SCALE_RATIO_THRESHOLD);
+  });
+
+  it('keeps the minimum interval while coalescing rapid large scale changes', () => {
+    vi.useFakeTimers();
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+
+    controller.setZoom(1 / RENDER_ZOOM_SCALE_RATIO_THRESHOLD);
+    const firstRenderZoom = controller.renderZoom;
+    controller.setZoom(1.2);
+    vi.advanceTimersByTime(RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS - 1);
+    controller.setZoom(1.3);
+
+    expect(controller.renderZoom).toBe(firstRenderZoom);
+
+    vi.advanceTimersByTime(1);
+    expect(controller.renderZoom).toBe(1.3);
+  });
+
+  it('replaces a blocked threshold commit with the latest input without extending the maximum delay', () => {
+    vi.useFakeTimers();
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+
+    controller.setZoom(0.84);
+    vi.advanceTimersByTime(20);
+    controller.setZoom(1.2);
+    vi.advanceTimersByTime(80);
+    controller.setZoom(0.9);
+    vi.advanceTimersByTime(100);
+    controller.setZoom(0.91);
+    vi.advanceTimersByTime(100);
+    controller.setZoom(0.9);
+    vi.advanceTimersByTime(19);
+
+    expect(controller.renderZoom).toBe(0.84);
+
+    vi.advanceTimersByTime(1);
+    expect(controller.renderZoom).toBe(0.9);
+  });
+
+  it('commits continuous input by the maximum delay even when the quiet period keeps moving', () => {
+    vi.useFakeTimers();
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+
+    controller.setZoom(0.95);
+    vi.advanceTimersByTime(100);
+    controller.setZoom(0.96);
+    vi.advanceTimersByTime(100);
+    controller.setZoom(0.95);
+    vi.advanceTimersByTime(RENDER_ZOOM_MAX_COMMIT_DELAY_MS - 201);
+
+    expect(controller.renderZoom).toBe(1);
+
+    vi.advanceTimersByTime(1);
+    expect(controller.renderZoom).toBe(0.95);
+  });
+
+  it('defers a gesture-end commit until the minimum interval after an intermediate commit', () => {
+    vi.useFakeTimers();
+    const controller = createController({ type: 'continuous', maxWidth: 600 });
+
+    controller.setZoom(1 / RENDER_ZOOM_SCALE_RATIO_THRESHOLD);
+    const firstRenderZoom = controller.renderZoom;
+    controller.setZoom(1.1);
+    controller.commitRenderZoom();
+
+    expect(controller.renderZoom).toBe(firstRenderZoom);
+
+    vi.advanceTimersByTime(RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS);
+    expect(controller.renderZoom).toBe(1.1);
   });
 });
 

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -1303,6 +1303,7 @@ describe('web editor frame synchronization', () => {
       }
       return result;
     });
+    let previousSample: WebFrameSample | undefined;
 
     for (let event = 0; event < 12; event += 1) {
       scrollRoot.dispatchEvent(
@@ -1315,17 +1316,26 @@ describe('web editor frame synchronization', () => {
         }),
       );
       await nextAnimationFrame();
-      expect(attachSurfaceSpy).not.toHaveBeenCalled();
+      const sample = readWebFrameSample(editor, scrollRoot, 0, event, null);
+      const mismatch = describeWebFrameMismatch(sample, previousSample);
+      expect(mismatch, mismatch).toBeUndefined();
+      previousSample = sample;
       expect(editor.published?.frames.get(0)?.canvas.isConnected).toBe(true);
+      expectActualCanvas(editor, 0);
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await expect.poll(() => editor.renderZoom).toBeCloseTo(editor.displayZoom);
     for (let frame = 0; frame < 60 && editor.published?.frames.get(0)?.canvas === displayed; frame += 1) {
       await nextAnimationFrame();
+      const sample = readWebFrameSample(editor, scrollRoot, 0, 12 + frame, null);
+      const mismatch = describeWebFrameMismatch(sample, previousSample);
+      expect(mismatch, mismatch).toBeUndefined();
+      previousSample = sample;
       expect(editor.published?.frames.get(0)?.canvas.isConnected).toBe(true);
     }
+    await waitForPresentation(editor);
     expect(editor.published?.frames.get(0)?.canvas).not.toBe(displayed);
-    expect(attachSurfaceSpy.mock.calls.filter(([page]) => page === 0)).toHaveLength(1);
+    expect(attachSurfaceSpy.mock.calls.filter(([page]) => page === 0).length).toBeGreaterThan(0);
     expect(editor.published?.frames.get(0)?.canvas.isConnected).toBe(true);
     expectActualCanvas(editor, 0);
   });
@@ -1344,7 +1354,7 @@ describe('web editor frame synchronization', () => {
     const viewportRect = scrollRoot.getBoundingClientRect();
     scrollRoot.dispatchEvent(
       new WheelEvent('wheel', {
-        deltaY: 69,
+        deltaY: 24,
         metaKey: navigator.platform.toUpperCase().includes('MAC'),
         ctrlKey: !navigator.platform.toUpperCase().includes('MAC'),
         clientX: viewportRect.left + viewportRect.width / 2,
@@ -1371,6 +1381,54 @@ describe('web editor frame synchronization', () => {
     expect(editor.published?.frames.get(0)?.canvas.width).toBeGreaterThan(0);
     expect(editor.published?.frames.get(0)?.canvas.height).toBeGreaterThan(0);
     expect(attachSurfaceSpy.mock.calls.filter(([page]) => page === 0)).toHaveLength(1);
+    expectActualCanvas(editor, 0, false);
+  });
+
+  it('commits a large continuous scale gap with coherent layout and surface publication', async () => {
+    const { editor, scrollRoot } = await mountEditor(continuousDoc('continuous threshold zoom '.repeat(40)), { withZoom: true });
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_at', page: 0, x: PAGE_MARGIN, y: PAGE_MARGIN } }));
+    await waitForPresentation(editor);
+    editor.focus();
+    await tick();
+    const initialPageWidth = editor.appliedSnapshot.pageSizes[0]?.width;
+    const initialCanvas = editor.published?.frames.get(0)?.canvas;
+    expect(initialPageWidth).toBeCloseTo(360);
+    expect(initialCanvas).toBeDefined();
+    const initialSample = readWebFrameSample(editor, scrollRoot, 0, -1, null);
+    const initialMismatch = describeWebFrameMismatch(initialSample);
+    expect(initialMismatch, initialMismatch).toBeUndefined();
+
+    const viewportRect = scrollRoot.getBoundingClientRect();
+    scrollRoot.dispatchEvent(
+      new WheelEvent('wheel', {
+        deltaY: 69,
+        metaKey: navigator.platform.toUpperCase().includes('MAC'),
+        ctrlKey: !navigator.platform.toUpperCase().includes('MAC'),
+        clientX: viewportRect.left + viewportRect.width / 2,
+        clientY: viewportRect.top + viewportRect.height / 2,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await nextAnimationFrame();
+
+    expect(editor.displayZoom).toBeLessThan(1);
+    expect(editor.renderZoom).toBeCloseTo(editor.displayZoom);
+    expect(editor.viewport.width).toBeGreaterThan(360);
+    expect(editor.appliedSnapshot.pageSizes[0]?.width).toBeGreaterThan(initialPageWidth ?? Infinity);
+    const intermediateSample = readWebFrameSample(editor, scrollRoot, 0, 0, null);
+    const intermediateMismatch = describeWebFrameMismatch(intermediateSample, initialSample);
+    expect(intermediateMismatch, intermediateMismatch).toBeUndefined();
+    expect(editor.published?.frames.get(0)?.canvas.isConnected).toBe(true);
+    expectActualCanvas(editor, 0, false);
+
+    await waitForPresentation(editor);
+
+    const settledSample = readWebFrameSample(editor, scrollRoot, 0, 1, null);
+    const settledMismatch = describeWebFrameMismatch(settledSample, intermediateSample);
+    expect(settledMismatch, settledMismatch).toBeUndefined();
+    expect(editor.published?.frames.get(0)?.canvas).not.toBe(initialCanvas);
+    expect(editor.pageEls[0]?.getBoundingClientRect().width).toBeCloseTo(360, 0);
     expectActualCanvas(editor, 0, false);
   });
 

--- a/apps/website/src/lib/editor-ffi/zoom.ts
+++ b/apps/website/src/lib/editor-ffi/zoom.ts
@@ -6,6 +6,9 @@ export const MAX_DOCUMENT_ZOOM = 2;
 export const FIT_WIDTH_ZOOM_SNAP_THRESHOLD = 0.02;
 export const UNIT_ZOOM_SNAP_THRESHOLD = 0.02;
 export const RENDER_ZOOM_DEBOUNCE_MS = 120;
+export const RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS = 160;
+export const RENDER_ZOOM_MAX_COMMIT_DELAY_MS = 300;
+export const RENDER_ZOOM_SCALE_RATIO_THRESHOLD = 1.18;
 export const ZOOM_EPSILON = 0.0001;
 
 export type ZoomBounds = {


### PR DESCRIPTION
이제 debounce되는 연속 줌 중에 stale한 텍스처가 크게 확대/축소되어 보이는 일이 적어집니다.

- 입력이 잠잠해진 뒤 120ms에 커밋
- 연속 커밋 사이에 최소 160ms 간격 유지
- 첫 render/display mismatch 이후 최대 300ms 안에 커밋
- display/render 배율 차이가 1.18배 이상이면 조기 커밋
- gesture 종료 시에도 최소 커밋 간격을 지키며 최신 배율 커밋
- 최소 간격에 막힌 임계치 요청은 이후 입력으로 대체하되, 기존 maximum stale deadline은 유지

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>