### PR TITLE
PrismMarginLayer를 `presentation geometry` 에 동기화

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -276,6 +276,37 @@
   $effect(() => {
     ctx.editor?.setThemeVariant(theme.currentThemeVariant);
   });
+
+  // 화면 좌표 소비자는 줌 자체가 아니라 현재 제시된 문서 geometry를 관찰한다.
+  // 선언 입력과 페이지 요소 설치가 한 프레임에 여러 번 바뀌어도 Editor가 한 번만 발행한다.
+  $effect(() => {
+    const editor = ctx.editor;
+    if (!editor) return;
+    void editor.publishedRevision;
+    void editor.safeDisplayZoom();
+    void editor.scaleFactor;
+    void editor.extensionAreaEl;
+    void editor.documentTrackEl;
+    void clientWidth;
+    void clientHeight;
+    void windowViewportHeight;
+    void contentInsetLeft;
+    void contentInsetRight;
+    for (const pageEl of Object.values(editor.pageEls)) void pageEl;
+    untrack(() => editor.requestPresentationGeometryUpdate());
+  });
+
+  // 바깥 CSS나 내재 크기 변화처럼 선언 입력으로 드러나지 않는 geometry 변화의 폴백이다.
+  $effect(() => {
+    const editor = ctx.editor;
+    const area = editor?.extensionAreaEl;
+    const track = editor?.documentTrackEl;
+    if (!editor || !area) return;
+    const observer = new ResizeObserver(() => editor.requestPresentationGeometryUpdate());
+    observer.observe(area);
+    if (track) observer.observe(track);
+    return () => observer.disconnect();
+  });
 </script>
 
 <svelte:window

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -401,6 +401,7 @@ export class Editor {
   #pointerStyle = $state<PointerStyle>('default');
   #lastPointerClient: { x: number; y: number } | null = null;
   #pointerStyleDomRefreshQueued = false;
+  #presentationGeometryFrame: number | null = null;
 
   #linkHover = $state<{ link: LinkRect; page: number; clientX: number; clientY: number } | undefined>();
   #modifierHeld = $state(false);
@@ -461,6 +462,7 @@ export class Editor {
   scrollContainerEl = $state<HTMLDivElement>();
   scrollViewport = $state<ScrollViewport>();
   scrollRootEl = $state<HTMLElement | null>();
+  presentationGeometryRevision = $state(0);
   displayZoom = $state(1);
   renderZoom = $state(1);
 
@@ -580,6 +582,10 @@ export class Editor {
 
   #stopRuntime(): void {
     this.#clearScheduledTick();
+    if (this.#presentationGeometryFrame !== null) {
+      cancelAnimationFrame(this.#presentationGeometryFrame);
+      this.#presentationGeometryFrame = null;
+    }
     if (this.#characterCountsDebounceTimer !== null) {
       clearTimeout(this.#characterCountsDebounceTimer);
       this.#characterCountsDebounceTimer = null;
@@ -1555,6 +1561,14 @@ export class Editor {
   safeDisplayZoom(): number {
     const zoom = this.rootAttrs?.layout_mode ? this.displayZoom : 1;
     return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+  }
+
+  requestPresentationGeometryUpdate(): void {
+    if (this.terminal || this.#presentationGeometryFrame !== null) return;
+    this.#presentationGeometryFrame = requestAnimationFrame(() => {
+      this.#presentationGeometryFrame = null;
+      if (!this.terminal) this.presentationGeometryRevision += 1;
+    });
   }
 
   captureSelectionViewportAnchor(revision: number): CapturedViewportAnchor | undefined {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardColumn.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardColumn.svelte
@@ -40,13 +40,6 @@
   const presentation = $derived(lanePresentation(margin.presentationProgress));
   const presentationAnimating = $derived(margin.presentationProgress < 1);
 
-  // 갈래가 바뀌면 카드가 새로 마운트되어 top 0에서 시작한다 — 전환이 켜진 채면 전 카드가 위에서 미끄러진다.
-  // 첫 배치와 같은 취급으로 되돌리면 relayout의 이중 rAF가 제자리에 세운 뒤 다시 켠다.
-  $effect(() => {
-    void margin.segment;
-    untrack(() => (animated = false));
-  });
-
   const emptyCopy = $derived(
     margin.segment === 'settled'
       ? '지난 회차에서 정리된 피드백이 여기 모여요'
@@ -55,16 +48,10 @@
         : '이번 회차에서는 짚은 곳이 없어요',
   );
 
-  // items는 적용 스냅숏마다 새로 지어지고 desiredTops도 그때마다 새 객체다 — 신원으로 재배치를 걸면
-  // 타이핑 한 번마다 전 카드의 offsetHeight를 읽는다. 배치는 카드 집합과 좌표가 실제로 바뀔 때만 돈다
+  // cards는 적용 스냅숏마다 새 배열이므로 id 집합만 본다. desiredTops의 새 객체는
+  // MarginLayer가 한 번의 측정을 마쳤다는 뜻이므로 신원으로 외부 재배치를 건다.
   const cardsKey = $derived(cards.map((item) => item.id).join(' '));
-  const desiredKey = $derived(
-    Object.entries(desiredTops)
-      .map(([id, top]) => `${id}:${top}`)
-      .join(' '),
-  );
 
-  let columnEl = $state<HTMLDivElement>();
   let cardEls = $state<Record<string, HTMLDivElement | undefined>>({});
   let tops = $state<Record<string, number>>({});
   let spacer = $state(0);
@@ -72,6 +59,8 @@
   let preparedKey: string | null = null;
   let preparationFrame: number | undefined;
   let preparationPaintFrame: number | undefined;
+  let animationFrame: number | undefined;
+  let animationPaintFrame: number | undefined;
 
   const TOGGLE_WINDOW_MS = 270;
   let heightOverrides: Record<string, number> = {};
@@ -81,6 +70,35 @@
   // relayout은 여러 경로에서 반복되므로 준비된 활성만 한 번 소비하고, mode 변화로 같은 활성을 다시 등록하지 않는다.
   let pendingRevealSequence: number | null = null;
   let revealedSequence = 0;
+
+  const cancelAnimationEnable = () => {
+    if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
+    if (animationPaintFrame !== undefined) cancelAnimationFrame(animationPaintFrame);
+    animationFrame = undefined;
+    animationPaintFrame = undefined;
+  };
+
+  const disablePlacementAnimation = () => {
+    cancelAnimationEnable();
+    animated = false;
+  };
+
+  const scheduleAnimationEnable = () => {
+    cancelAnimationEnable();
+    animationFrame = requestAnimationFrame(() => {
+      animationFrame = undefined;
+      animationPaintFrame = requestAnimationFrame(() => {
+        animationPaintFrame = undefined;
+        animated = true;
+      });
+    });
+  };
+
+  // 갈래가 바뀌면 카드가 새로 마운트되어 top 0에서 시작한다 — 첫 배치가 칠해질 때까지 전환을 끈다.
+  $effect(() => {
+    void margin.segment;
+    untrack(disablePlacementAnimation);
+  });
 
   const cancelPreparation = () => {
     if (preparationFrame !== undefined) cancelAnimationFrame(preparationFrame);
@@ -152,9 +170,7 @@
     }
 
     // 같은 커밋에서 전환을 켜면 top 0→N 이동 자체가 애니메이션되어 전 카드가 위에서 미끄러진다
-    if (!animated && entries.length > 0) {
-      requestAnimationFrame(() => requestAnimationFrame(() => (animated = true)));
-    }
+    if (!animated && entries.length > 0) scheduleAnimationEnable();
 
     updateEdgeCounts();
     // 카드 이동·성장이 0.25s 곡선을 달리는 동안의 셈은 이동 전 좌표다 — 곡선이 끝난 뒤 한 번 다시 센다
@@ -229,11 +245,17 @@
   $effect(() => {
     void preparationKey;
     void cardsKey;
-    void desiredKey;
-    void tick().then(relayout);
+    void desiredTops;
+    untrack(() => {
+      disablePlacementAnimation();
+      void tick().then(relayout);
+    });
   });
 
-  $effect(() => () => cancelPreparation());
+  $effect(() => () => {
+    cancelPreparation();
+    cancelAnimationEnable();
+  });
 
   $effect(() => {
     const currentActivation = margin.activation;
@@ -274,15 +296,13 @@
     return () => scroll?.setContentBottomOverflow(0);
   });
 
-  // 원고 리플로우는 컨테이너로, 카드 성장은 카드 자신으로 감지한다.
-  // 토글 창 안의 발화는 무시한다 — 성장 중간 높이로 재배치하면 확정된 목표가 흔들린다
+  // 카드가 소유한 크기 변화만 애니메이션한다. 원고 presentation 변화는 외부 placement 경로가
+  // transition을 끄고 재배치하므로 여기서 컨테이너까지 함께 관찰해 원인을 섞지 않는다.
   $effect(() => {
     const observer = new ResizeObserver(() => {
       if (performance.now() < suppressUntil) return;
       relayout();
     });
-    const container = columnEl?.parentElement;
-    if (container) observer.observe(container);
     for (const el of Object.values(cardEls)) {
       if (el) observer.observe(el);
     }
@@ -425,7 +445,7 @@
       {emptyCopy}
     </p>
   {:else if anchored}
-    <div bind:this={columnEl} class={css({ position: 'relative', flexGrow: '1', overflowY: 'clip' })}>
+    <div class={css({ position: 'relative', flexGrow: '1', overflowY: 'clip' })}>
       <div style:opacity={presentation.opacity} class={css(edgeLineRecipe.raw({ edge: 'top' }))}>
         <button class={css(edgeRowRecipe.raw({ shown: hiddenAbove > 0 }))} onclick={() => jumpEdge('up')} type="button">
           <div class={css(edgeBlurRecipe.raw({ layer: 'outermost', shown: hiddenAbove > 0 }))}></div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
@@ -2,7 +2,9 @@
   import { css } from '@typie/styled-system/css';
   import { Button, SegmentButtons } from '@typie/ui/components';
   import { untrack } from 'svelte';
+  import { PAGE_GAP } from '$lib/editor-ffi/constants';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
+  import { resolveCachedPageSpans } from '$lib/editor-ffi/geometry';
   import { resolveContinuousViewPadding } from '$lib/editor-ffi/zoom';
   import PrismReviewDetail from '../../../@prism/review/PrismReviewDetail.svelte';
   import { getMarginContext } from './context.svelte.ts';
@@ -13,6 +15,7 @@
   import PrismOverviewRuler from './PrismOverviewRuler.svelte';
   import PrismRail from './PrismRail.svelte';
   import { RAIL_TEXT_GAP, RAIL_WIDTH, railTone } from './rail-layout.ts';
+  import type { TrackedRange } from '@typie/editor-ffi/browser';
   import type { MarginItem } from './context.svelte.ts';
   import type { RailSpan, RailTone } from './rail-layout.ts';
 
@@ -51,11 +54,11 @@
     return current === ancestor ? left : null;
   };
 
-  // items는 적용 스냅숏마다 새로 지어지고 published도 프레임 교체마다 새 번들이다 — 신원으로 재측정을 걸면
-  // 타이핑 한 번마다 rect를 읽어 강제 리플로우가 난다. 측정은 판 번호와 항목 집합이 실제로 바뀔 때만 돈다.
-  // anchored는 일부러 뺐다 — measure가 읽지 않으면서 적용 스냅숏마다 뒤집히는 값이다
-  const publishedRevision = $derived(ctx.editor?.publishedRevision);
+  // items는 적용 스냅숏마다 새로 지어지고 published도 프레임 교체마다 새 번들이다 — 신원이 아니라
+  // 판 번호와 항목 집합이 실제로 바뀔 때만 논리 range를 다시 읽는다. presentation 변화는 이 캐시를 재투영한다.
+  // anchored는 일부러 뺐다 — measure가 읽지 않으면서 적용 스냅숏마다 뒤집히는 값이다.
   const itemsKey = $derived(margin.items.map((item) => `${item.id}:${item.number}:${toneOf(item)}:${item.rangeIds.join(',')}`).join(' '));
+  let trackedRanges = new Map<string, TrackedRange>();
 
   const measure = () => {
     const editor = ctx.editor;
@@ -66,15 +69,30 @@
     const areaRect = area.getBoundingClientRect();
     const zoom = editor.safeDisplayZoom();
 
-    // 타이핑 한 번에 한 번씩 도는 자리다 — 조회는 색인으로, 페이지 rect는 페이지당 한 번만 읽는다.
-    // 스냅숏의 사본은 tracked_ranges 필드가 설 때만 갈려 리플로우를 못 따라간다 — 코어에서 지금 것을 받는다
-    const ranges = new Map(editor.freshTrackedRanges().map((range) => [range.id, range]));
+    const trackRect = editor.documentTrackEl?.getBoundingClientRect();
+    const pageSpans = trackRect
+      ? resolveCachedPageSpans(snapshot.pageSizes, {
+          displayZoom: zoom,
+          scaleFactor: editor.scaleFactor,
+          pageGap: editor.rootAttrs?.layout_mode.type === 'paginated' ? PAGE_GAP * zoom : 0,
+        })
+      : null;
     const pageTops: (number | null | undefined)[] = [];
     const pageTopOf = (page: number): number | null => {
       const cached = pageTops[page];
       if (cached !== undefined) return cached;
       const el = editor.pageEls[page];
-      const top = el ? el.getBoundingClientRect().top - areaRect.top : null;
+      if (!el) {
+        pageTops[page] = null;
+        return null;
+      }
+      const span = pageSpans?.[page];
+      if (trackRect && span) {
+        const top = trackRect.top - areaRect.top + span.top;
+        pageTops[page] = top;
+        return top;
+      }
+      const top = el.getBoundingClientRect().top - areaRect.top;
       pageTops[page] = top;
       return top;
     };
@@ -94,7 +112,7 @@
       let first = Infinity;
 
       for (const rangeId of item.rangeIds) {
-        const range = ranges.get(rangeId);
+        const range = trackedRanges.get(rangeId);
         if (!range || range.rects.length === 0) continue;
 
         let top = Infinity;
@@ -140,10 +158,21 @@
     }
   };
 
-  // 좌표는 판이 바뀔 때만 다시 잰다 — 스크롤은 브라우저가 콘텐츠와 함께 옮긴다
+  // 의미 좌표는 판이 바뀔 때만 갱신한다. presentation 측정은 아래 effect 한 곳에서 수행한다.
   $effect(() => {
-    void publishedRevision;
+    const editor = ctx.editor;
+    void editor?.publishedRevision;
+    untrack(() => {
+      trackedRanges = new Map(editor?.freshTrackedRanges().map((range) => [range.id, range]));
+    });
+  });
+
+  // 항목 집합이나 현재 presentation geometry가 바뀌면 캐시된 의미 좌표를 화면에 다시 투영한다.
+  // 스크롤은 브라우저가 콘텐츠와 함께 옮기므로 별도 측정 원인이 아니다.
+  $effect(() => {
+    const editor = ctx.editor;
     void itemsKey;
+    void editor?.presentationGeometryRevision;
     untrack(measure);
   });
 
@@ -190,15 +219,6 @@
     { label: `지난 회차 ${margin.segmentCounts.settled}`, value: 'settled' as const },
     { label: `자리 잃음 ${margin.segmentCounts.lost}`, value: 'lost' as const },
   ]);
-
-  // 리플로우·줌·인셋 전환은 확장 영역의 크기로 나타난다
-  $effect(() => {
-    const area = ctx.editor?.extensionAreaEl;
-    if (!area) return;
-    const observer = new ResizeObserver(() => measure());
-    observer.observe(area);
-    return () => observer.disconnect();
-  });
 </script>
 
 {#if margin.ready}


### PR DESCRIPTION
## 문제

zoom 등으로 문서의 화면 좌표가 달라져도 scroll extent가 그대로면 PRISM rail과 card가 기존 위치에 남을 수 있었습니다. 재배치 시에는 `top` transition 때문에 카드가 뒤늦게 따라오는 현상도 있었습니다.

## 변경

- Editor가 presentation geometry 변화를 프레임 단위로 발행하도록 했습니다.
- PRISM margin이 논리 range를 현재 화면 geometry에 다시 투영하도록 했습니다.
- 외부 geometry에 따른 card 재배치는 즉시 적용하고, card 자체 변화의 애니메이션은 유지했습니다.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>