### PR TITLE
Compose 에디터 viewport 계산 통합

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -47,8 +47,7 @@ internal fun EditorView(
   load: DocumentEditorLoad,
   publishedBundle: PublishedBundle?,
   layoutSpec: EditorDocumentLayoutSpec,
-  viewportWidth: Float,
-  viewportHeight: Float,
+  viewport: Viewport?,
   modifier: Modifier = Modifier,
   editorInputEnabled: Boolean = true,
   suppressSoftwareKeyboard: Boolean = false,
@@ -64,21 +63,15 @@ internal fun EditorView(
   val displayZoom = zoomController.displayZoom
   val themeVariant = currentEditorThemeVariant()
   val canCreateEditor = runtime.canCreateEditor
-  val environment =
-    EditorAttachEnvironment(
-      width = viewportWidth,
-      height = viewportHeight,
-      scaleFactor = density.density.toDouble(),
-      themeVariant = themeVariant,
-    )
+  val environment = viewport?.let {
+    EditorAttachEnvironment(viewport = it, themeVariant = themeVariant)
+  }
   val currentLoad by rememberUpdatedState(load)
   val currentEnvironment by rememberUpdatedState(environment)
   var editorThemeVariant by remember(load) { mutableStateOf<ThemeVariant?>(null) }
 
   LaunchedEffect(load, canCreateEditor, environment) {
-    if (!environment.isValid) {
-      return@LaunchedEffect
-    }
+    val initialEnvironment = environment ?: return@LaunchedEffect
     if (!canCreateEditor) {
       return@LaunchedEffect
     }
@@ -86,11 +79,14 @@ internal fun EditorView(
     if (runtime.editor == null) {
       uiState.clear()
       try {
-        if (editorThemeVariant == null) editorThemeVariant = environment.themeVariant
-        val editor = load.awaitEditor(environment.toViewport(), environment.themeVariant)
+        if (editorThemeVariant == null) editorThemeVariant = initialEnvironment.themeVariant
+        val editor =
+          load.awaitEditor(
+            viewport = initialEnvironment.viewport,
+            themeVariant = initialEnvironment.themeVariant,
+          )
         while (currentLoad === load && !load.isClosed) {
-          val target = currentEnvironment
-          if (!target.isValid) return@LaunchedEffect
+          val target = currentEnvironment ?: return@LaunchedEffect
           val shouldUpdateTheme = editorThemeVariant != target.themeVariant
           if (shouldUpdateTheme) {
             EditorRegistry.commitResourceUpdate {
@@ -102,9 +98,9 @@ internal fun EditorView(
               enqueue(
                 Message.System(
                   SystemEvent.Resize(
-                    width = target.width,
-                    height = target.height,
-                    scaleFactor = target.scaleFactor,
+                    width = target.viewport.width,
+                    height = target.viewport.height,
+                    scaleFactor = target.viewport.scaleFactor,
                   )
                 )
               )
@@ -281,14 +277,4 @@ internal fun EditorView(
   }
 }
 
-private data class EditorAttachEnvironment(
-  val width: Float,
-  val height: Float,
-  val scaleFactor: Double,
-  val themeVariant: ThemeVariant,
-) {
-  val isValid: Boolean
-    get() = width > 0f && height > 0f
-
-  fun toViewport() = Viewport(width = width, height = height, scaleFactor = scaleFactor)
-}
+private data class EditorAttachEnvironment(val viewport: Viewport, val themeVariant: ThemeVariant)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -27,6 +27,7 @@ import co.typie.editor.EditorView
 import co.typie.editor.LocalEditorZoomController
 import co.typie.editor.PublishedBundle
 import co.typie.editor.ext.unclippedBoundsInRoot
+import co.typie.editor.ffi.Viewport
 import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.overlay.editorExtensionAreaLineHighlight
 import co.typie.editor.overlay.editorLineHighlightColor
@@ -49,6 +50,7 @@ private val DebugExtensionFillColor = Color(0x2200B8D4)
 internal fun EditorBody(
   load: DocumentEditorLoad,
   publishedBundle: PublishedBundle?,
+  editorViewport: Viewport?,
   visibleArea: EditorVisibleArea,
   layoutSpec: EditorDocumentLayoutSpec,
   autoScrollPolicy: EditorAutoScrollPolicy,
@@ -60,8 +62,7 @@ internal fun EditorBody(
   overlay: @Composable BoxScope.(EditorBodyGeometry, EditorState) -> Unit = { _, _ -> },
 ) {
   val density = LocalDensity.current
-  val zoomController = LocalEditorZoomController.current
-  val displayZoom = zoomController.displayZoom
+  val displayZoom = LocalEditorZoomController.current.displayZoom
   val editor = LocalEditorRuntime.current.editor
   val uiState = LocalEditorUiState.current
   val interactionScope = LocalEditorInteractionScope.current
@@ -76,15 +77,6 @@ internal fun EditorBody(
       pageSizes = pageSizes,
       displayZoom = displayZoom,
     )
-  val logicalViewportWidth =
-    when (layoutSpec) {
-      is EditorDocumentLayoutSpec.Continuous ->
-        resolveContinuousLayoutViewportWidth(
-          viewportWidth = geometry.visibleBodySize.width,
-          committedZoom = zoomController.renderZoom,
-        )
-      is EditorDocumentLayoutSpec.Paginated -> geometry.visibleBodySize.width
-    }
   val cursor = presentedState.cursor
   val extensionAreaFillSpacerHeight =
     remember(geometry.minimumBodyHeight, bodyContentHeight) {
@@ -151,8 +143,7 @@ internal fun EditorBody(
                 load = load,
                 publishedBundle = presentedBundle,
                 layoutSpec = layoutSpec,
-                viewportWidth = logicalViewportWidth,
-                viewportHeight = geometry.visibleBodySize.height,
+                viewport = editorViewport,
                 modifier = Modifier.fillMaxWidth(),
                 editorInputEnabled = editorInputEnabled,
                 suppressSoftwareKeyboard = suppressSoftwareKeyboard,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -60,6 +60,7 @@ import co.typie.editor.body.EditorBody
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.decodeDocumentLayoutSpec
 import co.typie.editor.body.resolveBaseBottomSpace
+import co.typie.editor.body.resolveContinuousLayoutViewportWidth
 import co.typie.editor.body.resolveEditorBodyGeometry
 import co.typie.editor.body.toEditorDocumentLayoutSpec
 import co.typie.editor.external.EditorExternalElementState
@@ -76,6 +77,7 @@ import co.typie.editor.ffi.Movement
 import co.typie.editor.ffi.NavigationOp
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.SystemEvent
+import co.typie.editor.ffi.Viewport
 import co.typie.editor.input.EditorInputRecorder
 import co.typie.editor.input.LocalEditorIncomingContentHandler
 import co.typie.editor.input.buildInputLogPayload
@@ -1498,13 +1500,41 @@ fun EditorScreen(entityId: String) {
     val typewriterEnabled = Preference.typewriterEnabled
     val typewriterPosition = Preference.typewriterPosition.toFloat()
     val displayZoom = zoomController.displayZoom
+    val requestedRenderZoom = zoomController.renderZoom
+    val physicalEditorViewport = measuredEditorViewport.value
+    val editorViewport =
+      remember(physicalEditorViewport, layoutSpec, requestedRenderZoom, density) {
+        physicalEditorViewport
+          .takeIf {
+            it.width.isFinite() &&
+              it.width > 0f &&
+              it.height.isFinite() &&
+              it.height > 0f &&
+              density.isFinite() &&
+              density > 0f
+          }
+          ?.let { physicalViewport ->
+            Viewport(
+              width =
+                when (layoutSpec) {
+                  is EditorDocumentLayoutSpec.Continuous ->
+                    resolveContinuousLayoutViewportWidth(
+                      viewportWidth = physicalViewport.width,
+                      committedZoom = requestedRenderZoom,
+                    )
+                  is EditorDocumentLayoutSpec.Paginated -> physicalViewport.width
+                },
+              height = physicalViewport.height,
+              scaleFactor = density.toDouble(),
+            )
+          }
+      }
     val committedRenderZoom =
       rememberCommittedEditorRenderZoom(
         editor = editor,
-        physicalViewport = measuredEditorViewport.value,
+        viewport = editorViewport,
         layoutSpec = layoutSpec,
-        requestedRenderZoom = zoomController.renderZoom,
-        scaleFactor = density.toDouble(),
+        requestedRenderZoom = requestedRenderZoom,
       )
     val typewriterTargetLineHeight =
       resolveBringIntoViewTargetHeight(
@@ -2014,6 +2044,7 @@ fun EditorScreen(entityId: String) {
             EditorBody(
               load = editorLoad,
               publishedBundle = presentedBundle,
+              editorViewport = editorViewport,
               visibleArea = visibleArea,
               layoutSpec = layoutSpec,
               autoScrollPolicy = presentedAutoScrollPolicy,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportCommit.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportCommit.kt
@@ -7,20 +7,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.geometry.Size
 import co.typie.editor.Editor
 import co.typie.editor.body.EditorDocumentLayoutSpec
-import co.typie.editor.body.resolveContinuousLayoutViewportWidth
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SystemEvent
+import co.typie.editor.ffi.Viewport
 
 @Composable
 internal fun rememberCommittedEditorRenderZoom(
   editor: Editor?,
-  physicalViewport: Size,
+  viewport: Viewport?,
   layoutSpec: EditorDocumentLayoutSpec,
   requestedRenderZoom: Float,
-  scaleFactor: Double,
 ): Float {
   // Continuous surface scale must not advance before the logical viewport resize it renders.
   // Paginated zoom does not reflow, so it can keep following the requested render zoom directly.
@@ -39,23 +37,9 @@ internal fun rememberCommittedEditorRenderZoom(
       0L
     }
 
-  LaunchedEffect(
-    editor,
-    physicalViewport,
-    layoutSpec,
-    continuousRenderZoom,
-    scaleFactor,
-    localEditAdmissionGeneration,
-  ) {
+  LaunchedEffect(editor, viewport, continuous, continuousRenderZoom, localEditAdmissionGeneration) {
     val activeEditor = editor ?: return@LaunchedEffect
-    if (
-      physicalViewport.width <= 0f ||
-        physicalViewport.height <= 0f ||
-        !scaleFactor.isFinite() ||
-        scaleFactor <= 0.0
-    ) {
-      return@LaunchedEffect
-    }
+    val targetViewport = viewport ?: return@LaunchedEffect
     var resizeCommitted = false
     val resizeEffectCompleted = activeEditor.runEffect {
       resizeCommitted =
@@ -63,17 +47,9 @@ internal fun rememberCommittedEditorRenderZoom(
           enqueue(
             Message.System(
               SystemEvent.Resize(
-                width =
-                  when (layoutSpec) {
-                    is EditorDocumentLayoutSpec.Continuous ->
-                      resolveContinuousLayoutViewportWidth(
-                        viewportWidth = physicalViewport.width,
-                        committedZoom = continuousRenderZoom,
-                      )
-                    is EditorDocumentLayoutSpec.Paginated -> physicalViewport.width
-                  },
-                height = physicalViewport.height,
-                scaleFactor = scaleFactor,
+                width = targetViewport.width,
+                height = targetViewport.height,
+                scaleFactor = targetViewport.scaleFactor,
               )
             )
           )

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import co.typie.editor.body.EditorBody
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.body.resolveContinuousLayoutViewportWidth
 import co.typie.editor.body.resolveEditorBodyGeometry
 import co.typie.editor.body.resolvePageContentTop
 import co.typie.editor.ext.isCollapsed
@@ -40,6 +42,7 @@ import co.typie.editor.ffi.KeyEvent
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.SelectionPointUnit
+import co.typie.editor.ffi.Viewport
 import co.typie.editor.interaction.EditorInteractionScope
 import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.interaction.gestures.EditorSelectionHandleType
@@ -314,13 +317,22 @@ class EditorFrameSyncDesktopTest {
 
     try {
       setContent {
+        val renderZoom = requestedRenderZoom.floatValue
         val committedZoom =
           rememberCommittedEditorRenderZoom(
             editor = fixture.editor,
-            physicalViewport = Size(ViewportWidth, ViewportHeight),
+            viewport =
+              Viewport(
+                width =
+                  resolveContinuousLayoutViewportWidth(
+                    viewportWidth = ViewportWidth,
+                    committedZoom = renderZoom,
+                  ),
+                height = ViewportHeight,
+                scaleFactor = 1.0,
+              ),
             layoutSpec = fixture.layoutSpec,
-            requestedRenderZoom = requestedRenderZoom.floatValue,
-            scaleFactor = 1.0,
+            requestedRenderZoom = renderZoom,
           )
         SideEffect { committedRenderZoom = committedZoom }
       }
@@ -1470,13 +1482,31 @@ class EditorFrameSyncDesktopTest {
         val scrollGestureLockState = remember { ScrollGestureLockState() }
         val zoomController = fixture.zoomController
         val measuredViewport = remember { mutableStateOf(Size.Zero) }
+        val physicalViewport = measuredViewport.value
+        val editorViewport =
+          physicalViewport
+            .takeIf { it.width > 0f && it.height > 0f }
+            ?.let {
+              Viewport(
+                width =
+                  when (fixture.layoutSpec) {
+                    is EditorDocumentLayoutSpec.Continuous ->
+                      resolveContinuousLayoutViewportWidth(
+                        viewportWidth = it.width,
+                        committedZoom = zoomController.renderZoom,
+                      )
+                    is EditorDocumentLayoutSpec.Paginated -> it.width
+                  },
+                height = it.height,
+                scaleFactor = 1.0,
+              )
+            }
         val committedRenderZoom =
           rememberCommittedEditorRenderZoom(
             editor = fixture.editor,
-            physicalViewport = measuredViewport.value,
+            viewport = editorViewport,
             layoutSpec = fixture.layoutSpec,
             requestedRenderZoom = zoomController.renderZoom,
-            scaleFactor = 1.0,
           )
         val publishedBundle = fixture.editor.publishedBundle
         val publishedState = publishedBundle?.snapshot ?: EditorState.Initial
@@ -1545,6 +1575,7 @@ class EditorFrameSyncDesktopTest {
               EditorBody(
                 load = fixture.load,
                 publishedBundle = presentedBundle,
+                editorViewport = editorViewport,
                 visibleArea = fixture.visibleArea,
                 layoutSpec = fixture.layoutSpec,
                 autoScrollPolicy = fixture.autoScrollPolicy,


### PR DESCRIPTION
- Compose의 엔진 viewport 계산을 `EditorScreen`으로 통합합니다.
- 초기 editor attach와 이후 resize가 동일한 viewport를 사용하도록 맞춥니다.
- continuous 줌의 resize 승인 후 renderZoom 커밋과 local edit 재시도 동작을 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>