### PR TITLE
ViewportOverlay, Scrollbar가 presentation geometry 에 동기화

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/Scrollbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Scrollbar.svelte
@@ -145,6 +145,19 @@
     return `${Math.round(y.ratio * 100)}%`;
   });
 
+  function sync() {
+    if (!scrollContainer) return;
+    metrics = {
+      scrollTop: scrollContainer.scrollTop,
+      scrollLeft: scrollContainer.scrollLeft,
+      scrollHeight: scrollContainer.scrollHeight,
+      scrollWidth: scrollContainer.scrollWidth,
+      clientHeight: scrollContainer.clientHeight,
+      clientWidth: scrollContainer.clientWidth,
+    };
+    containerRect = scrollContainer.getBoundingClientRect();
+  }
+
   function markUserScroll() {
     userScrollActive = true;
     clearTimeout(userScrollTimer);
@@ -163,18 +176,6 @@
     const el = scrollContainer;
     if (!el) return;
 
-    const sync = () => {
-      metrics = {
-        scrollTop: el.scrollTop,
-        scrollLeft: el.scrollLeft,
-        scrollHeight: el.scrollHeight,
-        scrollWidth: el.scrollWidth,
-        clientHeight: el.clientHeight,
-        clientWidth: el.clientWidth,
-      };
-      containerRect = el.getBoundingClientRect();
-    };
-
     const handleScroll = () => {
       sync();
       show(userScrollActive || dragAxis !== null ? 'user' : 'auto');
@@ -192,8 +193,6 @@
     el.addEventListener('wheel', handleUserInput, { passive: true });
     el.addEventListener('touchmove', handleUserInput, { passive: true });
 
-    sync();
-
     return () => {
       el.removeEventListener('scroll', handleScroll);
       el.removeEventListener('wheel', handleUserInput);
@@ -202,6 +201,11 @@
       clearTimeout(hideTimer);
       clearTimeout(userScrollTimer);
     };
+  });
+
+  $effect(() => {
+    void editor?.presentationGeometryRevision;
+    sync();
   });
 
   function startDrag(axis: 'x' | 'y', e: PointerEvent): ScrollDragSession | null {

--- a/apps/website/src/lib/editor-ffi/components/ViewportOverlay.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ViewportOverlay.svelte
@@ -1,17 +1,29 @@
 <script lang="ts" module>
   import { createStableContext } from '@typie/ui/context/stable';
+  import type { Editor } from '../editor.svelte';
 
   class ViewportOverlayContext {
     #frame: number | null = null;
-    change = $state(0);
+    #editor: Editor | undefined;
+    #change = $state(0);
 
     requestSync = () => {
       if (this.#frame !== null) return;
       this.#frame = requestAnimationFrame(() => {
         this.#frame = null;
-        this.change += 1;
+        this.#change += 1;
       });
     };
+
+    constructor(editor: Editor | undefined) {
+      this.#editor = editor;
+    }
+
+    // Presentation updates are already frame-coalesced, so consumers observe them directly.
+    get change(): number {
+      void this.#editor?.presentationGeometryRevision;
+      return this.#change;
+    }
 
     destroy(): void {
       if (this.#frame === null) return;
@@ -38,7 +50,7 @@
   let { children }: Props = $props();
 
   const { editor } = getEditorContext();
-  const overlay = setViewportOverlayContext(new ViewportOverlayContext());
+  const overlay = setViewportOverlayContext(new ViewportOverlayContext(editor));
 
   $effect(() => {
     if (!editor) return;


### PR DESCRIPTION
- `ViewportOverlay`가 `presentationGeometryRevision`을 직접 관찰해 geometry 변경을 같은 프레임에 반영합니다.
- presentation geometry가 바뀌면 scrollbar의 DOM metrics를 다시 측정합니다.
- scroll/resize 이벤트의 기존 frame coalescing은 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>