### PR TITLE
줌 보정 중 스크롤 진행률 표시 숨김

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewport.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewport.kt
@@ -216,7 +216,7 @@ internal class EditorViewportState(initialScrollOffset: Offset = Offset.Zero) {
 
     setScrollOffset(
       nextScrollOffset = resolvedScrollOffset,
-      isAutoScroll = false,
+      isAutoScroll = true,
       emitScrollEvent = true,
     )
   }
@@ -279,7 +279,7 @@ internal class EditorViewportState(initialScrollOffset: Offset = Offset.Zero) {
     retainedTransformScrollTarget = null
     setScrollOffset(
       nextScrollOffset = retainedScrollTarget.coerceToBounds(),
-      isAutoScroll = false,
+      isAutoScroll = true,
       emitScrollEvent = true,
     )
     return true

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportStateTest.kt
@@ -175,7 +175,7 @@ class EditorViewportStateTest {
 
     assertEquals(Offset(x = 100f, y = 100f), state.scrollOffset)
     assertEquals(1, state.lastScrollRevision)
-    assertFalse(state.lastScrollWasAuto)
+    assertTrue(state.lastScrollWasAuto)
 
     state.endTransform()
     state.updateMeasuredBounds(
@@ -185,6 +185,7 @@ class EditorViewportStateTest {
 
     assertEquals(Offset(x = 180f, y = 240f), state.scrollOffset)
     assertEquals(2, state.lastScrollRevision)
+    assertTrue(state.lastScrollWasAuto)
 
     state.updateMeasuredBounds(
       viewportSize = Size(width = 100f, height = 100f),

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarsDesktopTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
@@ -79,6 +80,45 @@ class EditorScrollbarsDesktopTest {
       assertEquals(20f, placement.width, absoluteTolerance = 0.01f)
       assertEquals(32f, placement.height, absoluteTolerance = 0.01f)
     }
+  }
+
+  @Test
+  fun zoomOwnedScrollKeepsThePercentageIndicatorHidden() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val viewportState = EditorViewportState()
+
+    setContent {
+      CompositionLocalProvider(LocalAppColors provides LightColors) {
+        ScrollbarLayoutFrame(
+          viewportState = viewportState,
+          contentSize = Size(width = 100f, height = 300f),
+        ) {
+          EditorScrollbars(
+            viewportState = viewportState,
+            visibleArea = VisibleArea,
+            layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 100f),
+            pageSizes = emptyList(),
+            displayZoom = 1f,
+            modifier = Modifier.fillMaxSize(),
+          )
+        }
+      }
+    }
+    mainClock.advanceTimeBy(32L)
+
+    runOnIdle { viewportState.scrollToY(100f) }
+    mainClock.advanceTimeBy(32L)
+    onNodeWithText("50%").assertIsDisplayed()
+
+    runOnIdle {
+      viewportState.scrollToTransformTarget(
+        offset = Offset(x = 0f, y = 120f),
+        retainUntilMeasuredBounds = false,
+      )
+    }
+    mainClock.advanceTimeBy(332L)
+
+    onNodeWithText("60%").assertDoesNotExist()
   }
 
   @Test

--- a/apps/website/src/lib/editor-ffi/components/Scrollbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Scrollbar.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { pointerCapture } from '@typie/ui/actions';
+  import { untrack } from 'svelte';
   import { getEditorContext } from '../editor.svelte';
   import type { Size } from '@typie/editor-ffi/browser';
 
   const HIDE_DELAY = 1000;
-  const USER_SCROLL_WINDOW_MS = 220;
   const MIN_THUMB_SIZE = 30;
   const TRACK_PADDING = 2;
   const INDICATOR_HEIGHT = 24;
@@ -97,8 +97,6 @@
 
   let dragAxis = $state<'x' | 'y' | null>(null);
   let hoverAxis = $state<'x' | 'y' | null>(null);
-  let userScrollActive = $state(false);
-  let userScrollTimer: ReturnType<typeof setTimeout> | undefined;
 
   let mode = $state<'hidden' | 'user' | 'auto'>('hidden');
   let hideTimer: ReturnType<typeof setTimeout> | undefined;
@@ -158,12 +156,6 @@
     containerRect = scrollContainer.getBoundingClientRect();
   }
 
-  function markUserScroll() {
-    userScrollActive = true;
-    clearTimeout(userScrollTimer);
-    userScrollTimer = setTimeout(() => (userScrollActive = false), USER_SCROLL_WINDOW_MS);
-  }
-
   function show(next: 'user' | 'auto') {
     mode = next;
     clearTimeout(hideTimer);
@@ -176,31 +168,23 @@
     const el = scrollContainer;
     if (!el) return;
 
-    const handleScroll = () => {
-      sync();
-      show(userScrollActive || dragAxis !== null ? 'user' : 'auto');
-    };
-
-    const handleUserInput = () => {
-      markUserScroll();
-      show('user');
-    };
-
     const resizeObserver = new ResizeObserver(sync);
     resizeObserver.observe(el);
 
-    el.addEventListener('scroll', handleScroll);
-    el.addEventListener('wheel', handleUserInput, { passive: true });
-    el.addEventListener('touchmove', handleUserInput, { passive: true });
-
     return () => {
-      el.removeEventListener('scroll', handleScroll);
-      el.removeEventListener('wheel', handleUserInput);
-      el.removeEventListener('touchmove', handleUserInput);
       resizeObserver.disconnect();
       clearTimeout(hideTimer);
-      clearTimeout(userScrollTimer);
     };
+  });
+
+  $effect(() => {
+    const scroll = ctx.scroll;
+    const revision = scroll?.lastScrollRevision ?? 0;
+    const isAuto = scroll?.lastScrollWasAuto ?? true;
+    if (revision === 0) return;
+
+    sync();
+    untrack(() => show(isAuto ? 'auto' : 'user'));
   });
 
   $effect(() => {
@@ -215,7 +199,6 @@
     ctx.scroll?.cancel();
 
     dragAxis = axis;
-    markUserScroll();
     show('user');
 
     const geometryetry = axis === 'y' ? y : x;
@@ -230,7 +213,6 @@
 
   function moveDrag(session: ScrollDragSession, e: PointerEvent) {
     if (!scrollContainer || dragAxis !== session.axis) return;
-    markUserScroll();
     const position = session.axis === 'y' ? e.clientY : e.clientX;
     const delta = ((position - session.startPointer) / session.trackMinusThumb) * session.maxScroll;
     if (session.axis === 'y') scrollContainer.scrollTop = session.startScroll + delta;
@@ -253,7 +235,6 @@
     e.preventDefault();
     e.stopPropagation();
     ctx.scroll?.cancel();
-    markUserScroll();
     show('user');
 
     const track = e.currentTarget as HTMLElement;

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -1340,6 +1340,44 @@ describe('web editor frame synchronization', () => {
     expectActualCanvas(editor, 0);
   });
 
+  it('keeps the scrollbar thumb synchronized without showing scroll progress for zoom correction', async () => {
+    const { editor, scrollRoot } = await mountEditor(longDoc(), { withZoom: true });
+    await waitForPresentation(editor);
+
+    scrollRoot.scrollTop = scrollRoot.scrollHeight / 3;
+    scrollRoot.dispatchEvent(new Event('scroll'));
+    await tick();
+
+    const verticalScrollbar = document.querySelector<HTMLElement>('[role="scrollbar"]:not([aria-orientation])');
+    const thumb = verticalScrollbar?.querySelector<HTMLElement>('[role="slider"]');
+    const indicator = verticalScrollbar?.previousElementSibling as HTMLElement | null;
+    expect(verticalScrollbar).not.toBeNull();
+    expect(thumb).not.toBeNull();
+    expect(indicator?.textContent).toMatch(/^\d+%$/);
+    if (!thumb || !indicator) throw new Error('Expected the vertical scrollbar thumb and indicator');
+    await expect.poll(() => Number.parseFloat(getComputedStyle(indicator).opacity)).toBeGreaterThan(0.99);
+
+    const scrollTopBeforeZoom = scrollRoot.scrollTop;
+    const zoomBefore = editor.displayZoom;
+    const viewportRect = scrollRoot.getBoundingClientRect();
+    scrollRoot.dispatchEvent(
+      new WheelEvent('wheel', {
+        deltaY: -24,
+        metaKey: navigator.platform.toUpperCase().includes('MAC'),
+        ctrlKey: !navigator.platform.toUpperCase().includes('MAC'),
+        clientX: viewportRect.left + viewportRect.width / 2,
+        clientY: viewportRect.top + viewportRect.height / 2,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    await expect.poll(() => editor.displayZoom).toBeGreaterThan(zoomBefore);
+    await expect.poll(() => Math.abs(scrollRoot.scrollTop - scrollTopBeforeZoom)).toBeGreaterThan(0.5);
+    await expect.poll(() => Number(thumb.getAttribute('aria-valuenow'))).toBeCloseTo(scrollRoot.scrollTop);
+    await expect.poll(() => Number.parseFloat(getComputedStyle(indicator).opacity)).toBeLessThan(0.01);
+  });
+
   it('delays continuous reflow until the render commit and replaces it coherently', async () => {
     const { editor, scrollRoot } = await mountEditor(continuousDoc('continuous zoom '.repeat(40)), { withZoom: true });
     await waitForPresentation(editor);

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -839,6 +839,8 @@ describe('EditorScrollScope', () => {
     setScrollTop(10);
     scope.observeViewportScroll();
 
+    expect(scope.lastScrollRevision).toBe(1);
+    expect(scope.lastScrollWasAuto).toBe(false);
     expect(measureTrack).toHaveBeenCalledOnce();
     expect(editor.clientToLocal).not.toHaveBeenCalled();
     expect(measureFirstPage).not.toHaveBeenCalled();
@@ -910,6 +912,8 @@ describe('EditorScrollScope', () => {
     scope.attachViewportAnchorAt({ page: 0, x: 200, y: 200 });
     scope.observeViewportScroll();
 
+    expect(scope.lastScrollRevision).toBe(1);
+    expect(scope.lastScrollWasAuto).toBe(true);
     expect(scope.prepareViewportAnchorPublication(candidate)).toMatchObject({
       type: 'ready',
       targetScrollLeft: 300,

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -168,6 +168,8 @@ export class EditorScrollScope {
   #contentBottomOverflow = $state(0);
 
   visibleArea = $state<EditorVisibleArea>(DEFAULT_VISIBLE_AREA);
+  lastScrollRevision = $state(0);
+  lastScrollWasAuto = $state(false);
 
   bottomPadding = $derived.by(() => {
     void this.#editor.viewport.height;
@@ -424,13 +426,13 @@ export class EditorScrollScope {
     const hasExpectedScroll = this.#expectedScrollLeft !== null || this.#expectedScrollTop !== null;
     const expectedLeftMatches = this.#expectedScrollLeft === null || Math.abs(scrollLeft - this.#expectedScrollLeft) <= 1;
     const expectedTopMatches = this.#expectedScrollTop === null || Math.abs(scrollTop - this.#expectedScrollTop) <= 1;
-    if (hasExpectedScroll && expectedLeftMatches && expectedTopMatches) {
-      this.#expectedScrollLeft = null;
-      this.#expectedScrollTop = null;
-      return;
-    }
+    const matchesExpectedScroll = hasExpectedScroll && expectedLeftMatches && expectedTopMatches;
     this.#expectedScrollLeft = null;
     this.#expectedScrollTop = null;
+    this.lastScrollWasAuto = matchesExpectedScroll;
+    this.lastScrollRevision += 1;
+    if (matchesExpectedScroll) return;
+
     if (this.#smoothMotion) this.cancel();
     this.#viewportAnchor.finishRevealConvergence();
 


### PR DESCRIPTION
- Web ScrollScope가 expected scroll과 direct scroll 판정을 스크롤바에 전달하도록 했습니다.
- Web 스크롤바의 wheel/touch 타이밍 기반 판정을 제거했습니다.
- Web과 Compose에서 줌에 따른 스크롤 보정을 auto scroll로 처리합니다.
- auto scroll 중에는 진행률 표시를 숨기되, 스크롤바 thumb 위치는 계속 동기화합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>