### PR TITLE
프리즘 리뷰 카드 모드 전환 안정화

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardColumn.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardColumn.svelte
@@ -66,7 +66,8 @@
   let heightOverrides: Record<string, number> = {};
   let suppressUntil = 0;
   let settleTimer: ReturnType<typeof setTimeout> | undefined;
-  let previousActive: string | null = null;
+  // 새로 마운트된 컬럼은 현재 활성 높이로 처음 그려진다 — 이미 펼쳐진 카드를 토글로 다시 예측하지 않는다.
+  let previousActive = margin.activeId;
   // relayout은 여러 경로에서 반복되므로 준비된 활성만 한 번 소비하고, mode 변화로 같은 활성을 다시 등록하지 않는다.
   let pendingRevealSequence: number | null = null;
   let revealedSequence = 0;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardPopover.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardPopover.svelte
@@ -64,13 +64,6 @@
     placement: 'right-start',
     // 본문↔카드 간격은 컬럼 모드와 같은 수를 쓴다 — 모드가 바뀐다고 거리가 달라질 이유가 없다
     offset: COLUMN_GAP,
-    onClickOutside: (event: Event) => {
-      // 원고는 바깥이 아니다 — 피드백을 띄워 놓고 그 대목을 고치는 것이 이 모드의 쓰임이다.
-      // 레일·룰러도 마찬가지로 갈아타기이지 떠나기가 아니다(에디터 영역 밖으로 옮겨져도 걸리도록 표지로도 본다)
-      if (event.target instanceof Node && ctx.editor?.scrollContainerEl?.contains(event.target)) return;
-      if (event.target instanceof Element && event.target.closest('[data-prism-margin-activator]')) return;
-      margin.activate(null);
-    },
     middleware: [
       // 세로는 스크롤러가 경계다 — 그래야 툴바 위로 올라가지 않는다
       shift({

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismOverviewRuler.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismOverviewRuler.svelte
@@ -81,7 +81,6 @@
         style:top={`${mark.ratio * 100}%`}
         class={css(markRecipe.raw({ tone: mark.tone, active: margin.activeId === mark.itemId }))}
         aria-label={labelOf(mark.itemId)}
-        data-prism-margin-activator
         onclick={() => margin.activate(mark.itemId)}
         title={labelOf(mark.itemId)}
         type="button"

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismRail.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismRail.svelte
@@ -113,7 +113,6 @@
       }),
     )}
     aria-label={labelOf(rail)}
-    data-prism-margin-activator
     data-selected={active ? '' : undefined}
     onclick={() => margin.activate(rail.itemId)}
     type="button"


### PR DESCRIPTION
## 문제

- 피드백 popover가 외부 클릭을 활성 해제로 처리해, popover에서 column으로 전환할 때 활성 카드가 풀렸습니다.
- 활성 카드가 펼쳐진 채 column이 처음 마운트되면 이를 새로운 펼침 동작으로 다시 계산해, 스크롤 콘텐츠 높이가 과하게 커졌다가 되돌아왔습니다.

## 수정

- 피드백 popover의 외부 클릭 활성 해제를 제거했습니다.
- column의 최초 활성 상태를 현재 활성 카드로 초기화해 높이 이중 예측을 막았습니다.
- 더 이상 사용되지 않는 `data-prism-margin-activator` 속성을 제거했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>