### PR TITLE
에디터 줌 elastic bounds

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomMotion.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomMotion.kt
@@ -1,0 +1,87 @@
+package co.typie.editor
+
+import kotlin.math.abs
+import kotlin.math.exp
+import kotlin.math.ln
+
+internal object EditorZoomMotionTuning {
+  const val ElasticExtentRatio = 1.25
+  const val ElasticResistance = 0.55
+  const val MaximumMotionSeconds = 0.24
+  const val SpringAngularFrequency = 24.0
+  const val SettleEpsilon = 0.0005
+}
+
+internal data class EditorZoomMotionFrame(val displayZoom: Float, val finished: Boolean)
+
+internal fun elasticEditorDisplayZoom(
+  rawZoom: Float,
+  bounds: ClosedFloatingPointRange<Float>,
+): Float? {
+  if (!rawZoom.isValidZoom || !bounds.isValidZoomBounds) return null
+  val rawLog = ln(rawZoom.toDouble())
+  val minimumLog = ln(bounds.start.toDouble())
+  val maximumLog = ln(bounds.endInclusive.toDouble())
+  val elasticExtent = ln(EditorZoomMotionTuning.ElasticExtentRatio)
+  val displayLog =
+    when {
+      rawLog > maximumLog -> maximumLog + rubberBandDistance(rawLog - maximumLog, elasticExtent)
+      rawLog < minimumLog -> minimumLog - rubberBandDistance(minimumLog - rawLog, elasticExtent)
+      else -> rawLog
+    }
+  return exp(displayLog).toFloat()
+}
+
+internal class EditorZoomMotion(displayZoom: Float, bounds: ClosedFloatingPointRange<Float>) {
+  private var elapsedSeconds = 0.0
+  private val initialLogZoom: Double
+  private val targetLogZoom: Double
+
+  private var frame: EditorZoomMotionFrame
+
+  init {
+    require(displayZoom.isValidZoom && bounds.isValidZoomBounds && displayZoom !in bounds) {
+      "Zoom recovery requires an out-of-bounds display zoom"
+    }
+    initialLogZoom = ln(displayZoom.toDouble())
+    targetLogZoom =
+      ln(
+        if (displayZoom < bounds.start) bounds.start.toDouble() else bounds.endInclusive.toDouble()
+      )
+    frame = EditorZoomMotionFrame(displayZoom = displayZoom, finished = false)
+  }
+
+  fun advance(deltaSeconds: Double): EditorZoomMotionFrame {
+    if (!deltaSeconds.isFinite() || deltaSeconds <= 0.0 || frame.finished) return frame
+    elapsedSeconds += deltaSeconds
+    val logZoom = springLogZoom(elapsedSeconds)
+    val finished =
+      elapsedSeconds >= EditorZoomMotionTuning.MaximumMotionSeconds || isSettled(logZoom)
+    frame =
+      EditorZoomMotionFrame(
+        displayZoom = exp(if (finished) targetLogZoom else logZoom).toFloat(),
+        finished = finished,
+      )
+    return frame
+  }
+
+  private fun springLogZoom(elapsed: Double): Double {
+    val displacement = initialLogZoom - targetLogZoom
+    val angularFrequency = EditorZoomMotionTuning.SpringAngularFrequency
+    val decay = exp(-angularFrequency * elapsed)
+    return targetLogZoom + displacement * (1.0 + angularFrequency * elapsed) * decay
+  }
+
+  private fun isSettled(logZoom: Double): Boolean =
+    abs(logZoom - targetLogZoom) <= EditorZoomMotionTuning.SettleEpsilon
+}
+
+private fun rubberBandDistance(distance: Double, extent: Double): Double =
+  (extent * EditorZoomMotionTuning.ElasticResistance * distance) /
+    (extent + EditorZoomMotionTuning.ElasticResistance * distance)
+
+private val Float.isValidZoom: Boolean
+  get() = isFinite() && this > 0f
+
+private val ClosedFloatingPointRange<Float>.isValidZoomBounds: Boolean
+  get() = start.isValidZoom && endInclusive.isValidZoom && endInclusive >= start

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomState.kt
@@ -40,6 +40,14 @@ internal class EditorZoomController(
   val isZoomEnabled: Boolean
     get() = initializedLayoutKey != null
 
+  val indicatorZoom: Float
+    get() =
+      if (isZoomEnabled) {
+        clampDocumentZoom(displayZoom, computeDocumentZoomBounds(currentLayoutSpec))
+      } else {
+        1f
+      }
+
   private var initializedLayoutKey: String? = null
   private var currentLayoutSpec: EditorDocumentLayoutSpec = EditorDocumentLayoutSpec.Continuous(0f)
   private var currentViewportWidth: Float = 0f
@@ -91,6 +99,32 @@ internal class EditorZoomController(
     )
   }
 
+  fun setGestureDisplayZoom(
+    rawZoom: Float,
+    snapZoom: Float? = null,
+    layoutSpec: EditorDocumentLayoutSpec,
+    viewportWidth: Float,
+  ): Boolean {
+    currentLayoutSpec = layoutSpec
+    currentViewportWidth = viewportWidth
+    val displayZoom =
+      snapZoom?.takeIf { it.isFinite() && it > 0f }
+        ?: elasticEditorDisplayZoom(rawZoom, computeDocumentZoomBounds(layoutSpec))
+        ?: return false
+    return setResolvedDisplayZoom(displayZoom = displayZoom, commitRender = false)
+  }
+
+  fun setMotionDisplayZoom(
+    displayZoom: Float,
+    layoutSpec: EditorDocumentLayoutSpec,
+    viewportWidth: Float,
+  ): Boolean {
+    if (!displayZoom.isFinite() || displayZoom <= 0f) return false
+    currentLayoutSpec = layoutSpec
+    currentViewportWidth = viewportWidth
+    return setResolvedDisplayZoom(displayZoom = displayZoom, commitRender = false)
+  }
+
   fun commitRenderZoom() {
     requestRenderZoomCommit()
   }
@@ -127,9 +161,13 @@ internal class EditorZoomController(
 
     val resolvedZoom =
       resolveDisplayZoom(zoom = zoom, layoutSpec = layoutSpec, viewportWidth = viewportWidth)
-    val changed = zoomDiffers(displayZoom, resolvedZoom)
+    return setResolvedDisplayZoom(displayZoom = resolvedZoom, commitRender = commitRender)
+  }
+
+  private fun setResolvedDisplayZoom(displayZoom: Float, commitRender: Boolean): Boolean {
+    val changed = zoomDiffers(this.displayZoom, displayZoom)
     if (changed) {
-      displayZoom = resolvedZoom
+      this.displayZoom = displayZoom
     }
 
     if (commitRender) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -138,22 +138,6 @@ internal class EditorInteractionController(
 
   fun onPinchEnd(): Boolean = gestures.endPinch(context = this)
 
-  fun endPinchAndResumeViewportPan(
-    change: PointerInputChange,
-    position: Offset,
-    driver: EditorPanGestureDriver,
-  ): Boolean {
-    if (!ensurePointerInputEnabled()) {
-      return false
-    }
-    return gestures.endPinchAndResumeViewportPan(
-      change = change,
-      position = position,
-      driver = driver,
-      context = this,
-    )
-  }
-
   fun beginIndirectZoom(): Boolean =
     if (ensurePointerInputEnabled()) {
       gestures.beginIndirectZoom(context = this)
@@ -188,6 +172,10 @@ internal class EditorInteractionController(
 
   fun endIndirectZoom() {
     gestures.endIndirectZoom(context = this)
+  }
+
+  fun interruptZoomForDirectPan() {
+    semantics.viewportZoom.interruptForDirectPan()
   }
 
   fun onLongPressTimer(pointerId: Long, position: Offset, nowMillis: Long): Boolean =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -378,20 +378,6 @@ internal class EditorInteractionGestures(
     return ended
   }
 
-  fun endPinchAndResumeViewportPan(
-    change: PointerInputChange,
-    position: Offset,
-    driver: EditorPanGestureDriver,
-    context: EditorGestureContext,
-  ): Boolean {
-    if (!pinch.isPinching) {
-      return false
-    }
-    endPinch(context = context)
-    pan.resume(change = change, position = position, driver = driver)
-    return true
-  }
-
   fun beginIndirectZoom(context: EditorGestureContext): Boolean {
     if (!context.mode.canApply(EditorInteractionEvent.ViewportZoomStart)) {
       return false
@@ -435,7 +421,7 @@ internal class EditorInteractionGestures(
     )
 
   fun endIndirectZoom(context: EditorGestureContext) {
-    context.semantics.viewportZoom.end()
+    context.semantics.viewportZoom.release()
     context.applyModeEvent(EditorInteractionEvent.ViewportZoomEnd)
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -55,6 +55,7 @@ internal class EditorInteractionScope(
   private val semantics =
     EditorInteractionSemantics(
       effects = this,
+      coroutineScope = coroutineScope,
       contextMenuStateProvider = {
         checkNotNull(uiState) { "Editor interaction scope has no UI state" }.contextMenu
       },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionSemantics.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionSemantics.kt
@@ -14,10 +14,12 @@ import co.typie.editor.interaction.semantics.EditorSelectionHapticSemantic
 import co.typie.editor.interaction.semantics.EditorTableColumnResizeSemantic
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemantic
 import co.typie.editor.runtime.EditorContextMenuState
+import kotlinx.coroutines.CoroutineScope
 
 internal class EditorInteractionSemantics(
   effects: EditorInteractionEffects,
   contextMenuStateProvider: () -> EditorContextMenuState,
+  coroutineScope: CoroutineScope? = null,
   val pointSelection: EditorPointSelectionSemantic =
     EditorPointSelectionSemantic(effects = effects),
   val contextMenu: EditorContextMenuSemantic =
@@ -27,7 +29,7 @@ internal class EditorInteractionSemantics(
   val interactiveHit: EditorInteractiveHitSemantic = EditorInteractiveHitSemantic(),
   val longPress: EditorLongPressSemantic = EditorLongPressSemantic(),
   val selectionExpansion: EditorSelectionExpansionSemantic = EditorSelectionExpansionSemantic(),
-  val viewportZoom: EditorViewportZoomSemantic = EditorViewportZoomSemantic(),
+  val viewportZoom: EditorViewportZoomSemantic = EditorViewportZoomSemantic(coroutineScope),
   val magnifier: EditorMagnifierSemantic = EditorMagnifierSemantic(),
   val edgeAutoScroll: EditorEdgeAutoScrollSemantic = EditorEdgeAutoScrollSemantic(),
   val tableColumnResize: EditorTableColumnResizeSemantic = EditorTableColumnResizeSemantic(),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 private const val EditorTapSlopDp = 8f
-private const val WheelBurstGapMs = 56L
+private const val WheelBurstGapMs = 32L
 
 private enum class EditorDirectPointerAdmission {
   Document,
@@ -289,22 +289,8 @@ private class EditorInteractionsNode(
       finishReleasedPointers(pointerEvent)
       return
     }
-    if (pressedTouchChanges.size == 1) {
-      val survivor = pressedTouchChanges.single()
-      val rootPosition = positionInRoot(survivor.position)
-      if (
-        interactionController.endPinchAndResumeViewportPan(
-          change = survivor,
-          position = rootPosition,
-          driver = scrollDriver,
-        )
-      ) {
-        singlePointerStreams += survivor.id.value
-        consumeEditorChanges(pointerEvent)
-        finishReleasedPointers(pointerEvent)
-        return
-      }
-    } else if (interactionController.onPinchEnd()) {
+    if (interactionController.onPinchEnd()) {
+      suppressUntilAllUp = pressedTouchChanges.isNotEmpty()
       consumeEditorChanges(pointerEvent)
       finishReleasedPointers(pointerEvent)
       return
@@ -541,7 +527,8 @@ private class EditorInteractionsNode(
 
   private fun resolvePinchSample(changes: List<PointerInputChange>): EditorPinchSample? =
     resolveEditorPinchSample(
-      positionsInRoot = changes.map { change -> positionInRoot(change.position) }
+      positionsInRoot = changes.map { change -> positionInRoot(change.position) },
+      timestampMillis = changes.maxOfOrNull(PointerInputChange::uptimeMillis) ?: 0L,
     )
 
   private fun positionInRoot(position: Offset): Offset =
@@ -650,6 +637,7 @@ private class EditorInteractionsNode(
     val zoomModified = pointerEvent.keyboardModifiers.isEditorIndirectZoomModifierPressed()
     if (!zoomModified) {
       finishWheelZoom()
+      interactionController.interruptZoomForDirectPan()
       if (scrollDriver.launchPointerSignalScroll(scrollDelta = scrollDelta, density = density)) {
         onViewportIndirectInput()
         pointerEvent.changes.forEach(PointerInputChange::consume)
@@ -719,6 +707,9 @@ private class EditorInteractionsNode(
     if (!canAcceptIndirectInput() && !yieldPendingPhysicalPointerToIndirectInput()) {
       pointerEvent.changes.forEach(PointerInputChange::consume)
       return
+    }
+    if (pointerEvent.type == PointerEventType.PanStart) {
+      interactionController.interruptZoomForDirectPan()
     }
     if (pointerEvent.type == PointerEventType.PanMove) {
       val panOffset =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorPinchSample.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorPinchSample.kt
@@ -2,9 +2,16 @@ package co.typie.editor.interaction
 
 import androidx.compose.ui.geometry.Offset
 
-internal data class EditorPinchSample(val focalInRootPx: Offset, val distancePx: Float)
+internal data class EditorPinchSample(
+  val focalInRootPx: Offset,
+  val distancePx: Float,
+  val timestampMillis: Long = 0L,
+)
 
-internal fun resolveEditorPinchSample(positionsInRoot: List<Offset>): EditorPinchSample? {
+internal fun resolveEditorPinchSample(
+  positionsInRoot: List<Offset>,
+  timestampMillis: Long = 0L,
+): EditorPinchSample? {
   if (positionsInRoot.size != 2) {
     return null
   }
@@ -13,5 +20,6 @@ internal fun resolveEditorPinchSample(positionsInRoot: List<Offset>): EditorPinc
   return EditorPinchSample(
     focalInRootPx = (first + second) / 2f,
     distancePx = (first - second).getDistance(),
+    timestampMillis = timestampMillis,
   )
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPanGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPanGesture.kt
@@ -63,11 +63,6 @@ internal class EditorPanGesture {
     return true
   }
 
-  fun resume(change: PointerInputChange, position: Offset, driver: EditorPanGestureDriver) {
-    reset()
-    prepare(change = change, position = position, startKind = StartKind.Resumed, driver = driver)
-  }
-
   fun update(change: PointerInputChange, position: Offset, context: EditorGestureContext): Boolean {
     val current = session?.takeIf { it.pointerId == change.id.value } ?: return false
     val pressed = change.pressed
@@ -175,6 +170,7 @@ internal class EditorPanGesture {
     if (!context.mode.canApply(EditorInteractionEvent.PanStart)) {
       return false
     }
+    context.semantics.viewportZoom.interruptForDirectPan()
     if (!current.driverStarted) {
       if (!current.driver.start()) {
         return false
@@ -218,7 +214,6 @@ internal class EditorPanGesture {
 
   private enum class StartKind {
     Fresh,
-    Resumed,
     ScrollCatch,
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPinchGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorPinchGesture.kt
@@ -31,12 +31,12 @@ internal class EditorPinchGesture {
     }
 
     isPinching = false
-    context.semantics.viewportZoom.end()
+    context.semantics.viewportZoom.release()
     return true
   }
 
   fun cancel(context: EditorGestureContext) {
-    context.semantics.viewportZoom.end()
+    context.semantics.viewportZoom.cancel()
     reset()
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
@@ -1,21 +1,35 @@
 package co.typie.editor.interaction.semantics
 
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.geometry.Offset
 import co.typie.editor.EditorViewportAnchor
 import co.typie.editor.EditorZoomController
+import co.typie.editor.EditorZoomMotion
+import co.typie.editor.EditorZoomMotionFrame
+import co.typie.editor.EditorZoomMotionTuning
 import co.typie.editor.EditorZoomSnapKey
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.documentZoomWidth
-import co.typie.editor.clampDocumentZoom
+import co.typie.editor.clampDocumentLayoutZoom
 import co.typie.editor.computeDocumentZoomBounds
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.interaction.EditorPinchSample
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.editor.viewport.resolveZoomAnchorDisplayPosition
+import kotlin.math.abs
 import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.time.TimeSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+private const val DirectSnapVelocityThreshold = 0.18
 
 private const val PointerSignalZoomDivisor = 240f
+private val ZoomTimeOrigin = TimeSource.Monotonic.markNow()
 
 internal data class EditorViewportZoomSemanticConfig(
   val layoutSpec: EditorDocumentLayoutSpec,
@@ -32,95 +46,107 @@ internal data class EditorViewportZoomSemanticConfig(
     },
 )
 
-internal class EditorViewportZoomSemantic {
+internal class EditorViewportZoomSemantic(
+  private val coroutineScope: CoroutineScope? = null,
+  private val nowMillis: () -> Long = { ZoomTimeOrigin.elapsedNow().inWholeMilliseconds },
+) {
   private var config: EditorViewportZoomSemanticConfig? = null
   private var transformActive = false
   private var pinchSession: PinchSession? = null
   private var indirectZoomActive = false
-  private var indirectRawZoom: Float? = null
+  private var indirectSession: IndirectSession? = null
+  private var motionJob: Job? = null
+  private var activeMotion: ActiveMotion? = null
+  private var lastSnapKey: EditorZoomSnapKey? = null
 
   fun configure(config: EditorViewportZoomSemanticConfig?) {
-    if (config?.isUsable != true && (transformActive || hasActiveZoom)) {
-      end()
+    val previous = this.config
+    val ownerChanged =
+      previous != null &&
+        config != null &&
+        (previous.zoomController !== config.zoomController ||
+          previous.viewportState !== config.viewportState ||
+          previous.layoutSpec != config.layoutSpec)
+    if ((config?.isUsable != true || ownerChanged) && hasInteraction) {
+      abortForConfigurationChange(previous)
     }
     this.config = config
   }
 
   fun beginPinch(sample: EditorPinchSample): Boolean {
     val currentConfig = config?.takeIf { it.isUsable } ?: return false
-    if (!sample.isUsable) {
-      return false
-    }
-    val nextAnchor = currentConfig.resolveAnchor(sample.focalInRootPx) ?: return false
+    if (!sample.isUsable) return false
+    stopMotion(commitRender = false)
+    val anchor = currentConfig.resolveAnchor(sample.focalInRootPx) ?: return false
     val startZoom = currentConfig.zoomController.displayZoom
-    val startAnchorDisplayPosition =
-      currentConfig.resolveAnchorDisplayPosition(anchor = nextAnchor, displayZoom = startZoom)
+    val anchorDisplayPosition =
+      currentConfig.resolveAnchorDisplayPosition(anchor = anchor, displayZoom = startZoom)
         ?: return false
-
     beginTransform(currentConfig)
+    val focal = currentConfig.toRootDp(sample.focalInRootPx)
     pinchSession =
       PinchSession(
-        anchor = nextAnchor,
+        anchor = anchor,
         startSample = sample,
-        startScrollOffset = currentConfig.viewportState.scrollOffset,
-        startDisplayZoom = startZoom,
-        startAnchorDisplayPosition = startAnchorDisplayPosition,
+        startScrollOffset = currentConfig.viewportState.effectiveTransformScrollTarget,
+        startRawZoom = startZoom,
+        startAnchorDisplayPosition = anchorDisplayPosition,
+        startFocal = focal,
         pageSizes = currentConfig.pageSizes,
         lastSample = sample,
+        rawZoom = startZoom,
       )
+    lastSnapKey = currentConfig.zoomController.resolveSnapKey(startZoom)
     return true
   }
 
   fun updatePinch(sample: EditorPinchSample): Boolean {
     val currentConfig = config?.takeIf { it.isUsable } ?: return false
     var session = pinchSession ?: return false
-    if (!sample.isUsable) {
-      return false
-    }
+    if (!sample.isUsable) return false
     if (currentConfig.pageSizes !== session.pageSizes) {
       session = currentConfig.rebasePinchSession(session) ?: return false
       pinchSession = session
     }
 
+    val rawZoom = session.startRawZoom * (sample.distancePx / session.startSample.distancePx)
     val previousZoom = currentConfig.zoomController.displayZoom
     val nextZoom =
-      setZoom(
+      setGestureZoom(
         config = currentConfig,
-        zoom = session.startDisplayZoom * (sample.distancePx / session.startSample.distancePx),
+        rawZoom = rawZoom,
+        previousRawZoom = session.rawZoom,
+        previousTimestampMillis = session.lastSample.timestampMillis,
+        timestampMillis = sample.timestampMillis,
       )
-    val nextAnchorDisplayPosition =
+    val anchorDisplayPosition =
       currentConfig.resolveAnchorDisplayPosition(anchor = session.anchor, displayZoom = nextZoom)
         ?: return false
-    val focalDelta =
-      (sample.focalInRootPx - session.startSample.focalInRootPx) / currentConfig.density
+    val focal = currentConfig.toRootDp(sample.focalInRootPx)
     val targetScrollOffset =
-      session.startScrollOffset + (nextAnchorDisplayPosition - session.startAnchorDisplayPosition) -
-        focalDelta
+      session.startScrollOffset + (anchorDisplayPosition - session.startAnchorDisplayPosition) -
+        (focal - session.startFocal)
     currentConfig.viewportState.scrollToTransformTarget(
       offset = targetScrollOffset,
       retainUntilMeasuredBounds = previousZoom != nextZoom,
     )
-    currentConfig.onAttachViewportAnchor(
-      session.anchor,
-      nextAnchorDisplayPosition,
-      targetScrollOffset,
-    )
-    pinchSession = session.copy(lastSample = sample)
+    currentConfig.onAttachViewportAnchor(session.anchor, anchorDisplayPosition, targetScrollOffset)
+    pinchSession = session.copy(lastSample = sample, rawZoom = rawZoom)
     return true
   }
 
   fun beginIndirect(): Boolean {
     val currentConfig = config?.takeIf { it.isUsable } ?: return false
+    stopMotion(commitRender = false)
     beginTransform(currentConfig)
     indirectZoomActive = true
-    indirectRawZoom = null
+    indirectSession = null
+    lastSnapKey = currentConfig.zoomController.resolveSnapKey()
     return true
   }
 
   fun updateIndirectScroll(focalInRootPx: Offset, normalizedDelta: Float): Boolean {
-    if (!normalizedDelta.isFinite() || normalizedDelta == 0f) {
-      return false
-    }
+    if (!normalizedDelta.isFinite() || normalizedDelta == 0f) return false
     return updateIndirectScale(
       focalInRootPx = focalInRootPx,
       scaleFactor = exp((-normalizedDelta / PointerSignalZoomDivisor).toDouble()).toFloat(),
@@ -129,69 +155,100 @@ internal class EditorViewportZoomSemantic {
 
   fun updateIndirectScale(focalInRootPx: Offset, scaleFactor: Float): Boolean {
     val currentConfig = config?.takeIf { it.isUsable } ?: return false
-    if (!indirectZoomActive || !isValidScaleUpdate(focalInRootPx, scaleFactor)) {
-      return false
-    }
-    if (scaleFactor == 1f) {
-      return true
+    if (!indirectZoomActive || !isValidScaleUpdate(focalInRootPx, scaleFactor)) return false
+    if (scaleFactor == 1f) return true
+    val timestampMillis = nowMillis()
+    var session =
+      indirectSession
+        ?: currentConfig.createIndirectSession(focalInRootPx, timestampMillis)
+        ?: return false
+    if (currentConfig.pageSizes !== session.pageSizes) {
+      session = currentConfig.createIndirectSession(focalInRootPx, timestampMillis) ?: return false
     }
 
-    val viewportState = currentConfig.viewportState
-    val effectiveScrollTarget = viewportState.effectiveTransformScrollTarget
-    val unappliedScrollDelta = effectiveScrollTarget - viewportState.scrollOffset
-    val editorRect = currentConfig.uiState.editorRectInRoot() ?: return false
-    val focalInEditor =
-      currentConfig.toEditorDp(focalInRootPx - editorRect.topLeft) + unappliedScrollDelta
+    val rawZoom = session.rawZoom * scaleFactor
     val previousZoom = currentConfig.zoomController.displayZoom
-    val anchor =
-      currentConfig
-        .resolveViewportTransform(displayZoom = previousZoom)
-        .resolveAnchor(focalX = focalInEditor.x, focalY = focalInEditor.y) ?: return false
-    val previousAnchorDisplayPosition =
-      currentConfig.resolveAnchorDisplayPosition(anchor = anchor, displayZoom = previousZoom)
-        ?: return false
-    val baseZoom = indirectRawZoom ?: previousZoom
-    val nextRawZoom =
-      clampDocumentZoom(
-        zoom = baseZoom * scaleFactor,
-        bounds = computeDocumentZoomBounds(currentConfig.layoutSpec),
+    val nextZoom =
+      setGestureZoom(
+        config = currentConfig,
+        rawZoom = rawZoom,
+        previousRawZoom = session.rawZoom,
+        previousTimestampMillis = session.lastTimestampMillis,
+        timestampMillis = timestampMillis,
       )
-    indirectRawZoom = nextRawZoom
-
-    val nextZoom = setZoom(config = currentConfig, zoom = nextRawZoom)
-    val nextAnchorDisplayPosition =
-      currentConfig.resolveAnchorDisplayPosition(anchor = anchor, displayZoom = nextZoom)
+    val anchorDisplayPosition =
+      currentConfig.resolveAnchorDisplayPosition(anchor = session.anchor, displayZoom = nextZoom)
         ?: return false
+    val focal = currentConfig.toRootDp(focalInRootPx)
     val targetScrollOffset =
-      effectiveScrollTarget + (nextAnchorDisplayPosition - previousAnchorDisplayPosition)
-    viewportState.scrollToTransformTarget(
+      session.startScrollOffset + (anchorDisplayPosition - session.startAnchorDisplayPosition) -
+        (focal - session.startFocal)
+    currentConfig.viewportState.scrollToTransformTarget(
       offset = targetScrollOffset,
       retainUntilMeasuredBounds = previousZoom != nextZoom,
     )
-    currentConfig.onAttachViewportAnchor(anchor, nextAnchorDisplayPosition, targetScrollOffset)
+    currentConfig.onAttachViewportAnchor(session.anchor, anchorDisplayPosition, targetScrollOffset)
+    indirectSession =
+      session.copy(
+        lastTimestampMillis = maxOf(session.lastTimestampMillis, timestampMillis),
+        rawZoom = rawZoom,
+      )
     return true
   }
 
-  fun end() {
-    if (hasActiveZoom) {
-      config?.zoomController?.commitRenderZoom()
+  fun release() {
+    val currentConfig = config?.takeIf { it.isUsable }
+    val seed = currentConfig?.createMotionSeed()
+    clearDirectSessions()
+    if (currentConfig == null || seed == null) {
+      finishWithoutMotion(currentConfig)
+      return
     }
-    pinchSession = null
-    indirectZoomActive = false
-    indirectRawZoom = null
-    if (transformActive) {
-      config?.viewportState?.endTransform()
-      transformActive = false
+    finishOrRecover(config = currentConfig, seed = seed)
+  }
+
+  private fun releaseForDirectPan() {
+    val currentConfig = config?.takeIf { it.isUsable }
+    val seed = currentConfig?.createMotionSeed()
+    clearDirectSessions()
+    if (currentConfig != null && seed != null) {
+      finishOrRecover(config = currentConfig, seed = seed, allowConcurrentPan = true)
+    } else {
+      finishInteraction(currentConfig)
+    }
+  }
+
+  fun interruptForDirectPan() {
+    if (pinchSession != null || indirectZoomActive) {
+      releaseForDirectPan()
+      return
+    }
+    val currentConfig = config?.takeIf { it.isUsable } ?: return
+    val active = activeMotion ?: return
+    active.allowConcurrentPan = true
+    endTransform(currentConfig)
+  }
+
+  fun cancel() {
+    if (pinchSession == null && !indirectZoomActive) return
+    val currentConfig = config?.takeIf { it.isUsable }
+    val seed = currentConfig?.createMotionSeed()
+    clearDirectSessions()
+    stopMotion(commitRender = false)
+    if (currentConfig != null && seed != null) {
+      finishOrRecover(config = currentConfig, seed = seed)
+    } else {
+      finishWithoutMotion(currentConfig)
     }
   }
 
   fun reset() {
-    end()
+    abortForConfigurationChange(config)
     config = null
   }
 
-  private val hasActiveZoom: Boolean
-    get() = pinchSession != null || indirectZoomActive
+  private val hasInteraction: Boolean
+    get() = pinchSession != null || indirectZoomActive || activeMotion != null || transformActive
 
   private fun beginTransform(config: EditorViewportZoomSemanticConfig) {
     if (!transformActive) {
@@ -200,24 +257,230 @@ internal class EditorViewportZoomSemantic {
     }
   }
 
-  private fun setZoom(config: EditorViewportZoomSemanticConfig, zoom: Float): Float {
-    val previousZoom = config.zoomController.displayZoom
-    val previousSnap = config.zoomController.resolveSnapKey(previousZoom)
-    val changed =
-      config.zoomController.setDisplayZoom(
-        zoom = zoom,
+  private fun endTransform(config: EditorViewportZoomSemanticConfig) {
+    if (transformActive) {
+      config.viewportState.endTransform()
+      transformActive = false
+    }
+  }
+
+  private fun clearDirectSessions() {
+    pinchSession = null
+    indirectZoomActive = false
+    indirectSession = null
+  }
+
+  private fun setGestureZoom(
+    config: EditorViewportZoomSemanticConfig,
+    rawZoom: Float,
+    previousRawZoom: Float,
+    previousTimestampMillis: Long?,
+    timestampMillis: Long,
+  ): Float {
+    val snapCandidate =
+      clampDocumentLayoutZoom(
+        zoom = rawZoom,
         layoutSpec = config.layoutSpec,
         viewportWidth = config.viewportWidth,
       )
-    val nextZoom = config.zoomController.displayZoom
-    if (changed) {
+    val bounds = computeDocumentZoomBounds(config.layoutSpec)
+    val snapCandidateKey =
+      if (rawZoom in bounds) config.zoomController.resolveSnapKey(snapCandidate) else null
+    val rawVelocity =
+      instantaneousLogZoomVelocity(
+        previousZoom = previousRawZoom,
+        zoom = rawZoom,
+        previousTimestampMillis = previousTimestampMillis,
+        timestampMillis = timestampMillis,
+      )
+    val nextSnap = snapCandidateKey?.takeIf {
+      it == lastSnapKey || abs(rawVelocity) < DirectSnapVelocityThreshold
+    }
+    config.zoomController.setGestureDisplayZoom(
+      rawZoom = rawZoom,
+      snapZoom = snapCandidate.takeIf { nextSnap != null },
+      layoutSpec = config.layoutSpec,
+      viewportWidth = config.viewportWidth,
+    )
+    maybeSendZoomSnapHaptic(
+      previousSnap = lastSnapKey,
+      nextSnap = nextSnap,
+      haptic = config.onZoomSnap,
+    )
+    lastSnapKey = nextSnap
+    return config.zoomController.displayZoom
+  }
+
+  private fun finishOrRecover(
+    config: EditorViewportZoomSemanticConfig,
+    seed: MotionSeed,
+    allowConcurrentPan: Boolean = false,
+  ) {
+    stopMotion(commitRender = false)
+    val durationScale = motionDurationScale()
+    val bounds = computeDocumentZoomBounds(config.layoutSpec)
+    val displayZoom = config.zoomController.displayZoom
+    if (displayZoom in bounds) {
+      finishInteraction(config)
+      return
+    }
+    val motion = EditorZoomMotion(displayZoom = displayZoom, bounds = bounds)
+    val active =
+      ActiveMotion(
+        configOwner = config.zoomController,
+        layoutSpec = config.layoutSpec,
+        anchor = seed.anchor,
+        startScrollOffset = seed.scrollOffset,
+        startAnchorDisplayPosition = seed.anchorDisplayPosition,
+        lastAppliedScrollOffset = config.viewportState.scrollOffset,
+        motion = motion,
+        allowConcurrentPan = allowConcurrentPan,
+      )
+    activeMotion = active
+    if (allowConcurrentPan) endTransform(config) else beginTransform(config)
+
+    if (coroutineScope == null || durationScale == 0.0) {
+      applyMotionFrame(active, motion.advance(EditorZoomMotionTuning.MaximumMotionSeconds))
+      finishMotion(active)
+      return
+    }
+    motionJob = coroutineScope.launch {
+      var previousFrameNanos: Long? = null
+      while (activeMotion === active) {
+        val frameNanos = withFrameNanos { it }
+        val elapsedSeconds =
+          previousFrameNanos?.let { previous ->
+            (frameNanos - previous) / 1_000_000_000.0 / durationScale
+          } ?: (1.0 / 60.0 / durationScale)
+        previousFrameNanos = frameNanos
+        val frame = active.motion.advance(elapsedSeconds)
+        if (!applyMotionFrame(active, frame) || frame.finished) break
+      }
+      finishMotion(active)
+    }
+  }
+
+  private fun applyMotionFrame(active: ActiveMotion, frame: EditorZoomMotionFrame): Boolean {
+    val currentConfig = config?.takeIf { it.isUsable } ?: return false
+    if (
+      activeMotion !== active ||
+        currentConfig.zoomController !== active.configOwner ||
+        currentConfig.layoutSpec != active.layoutSpec
+    ) {
+      return false
+    }
+    if (active.allowConcurrentPan) {
+      active.startScrollOffset +=
+        currentConfig.viewportState.scrollOffset - active.lastAppliedScrollOffset
+    }
+    val anchorDisplayPosition =
+      currentConfig.resolveAnchorDisplayPosition(
+        anchor = active.anchor,
+        displayZoom = frame.displayZoom,
+      ) ?: return false
+    val targetScrollOffset =
+      active.startScrollOffset + (anchorDisplayPosition - active.startAnchorDisplayPosition)
+    val previousZoom = currentConfig.zoomController.displayZoom
+    if (
+      !currentConfig.zoomController.setMotionDisplayZoom(
+        displayZoom = frame.displayZoom,
+        layoutSpec = currentConfig.layoutSpec,
+        viewportWidth = currentConfig.viewportWidth,
+      ) && previousZoom != frame.displayZoom
+    ) {
+      return false
+    }
+    currentConfig.viewportState.scrollToTransformTarget(
+      offset = targetScrollOffset,
+      retainUntilMeasuredBounds = previousZoom != frame.displayZoom,
+    )
+    currentConfig.onAttachViewportAnchor(active.anchor, anchorDisplayPosition, targetScrollOffset)
+    active.lastAppliedScrollOffset = currentConfig.viewportState.scrollOffset
+    val nextSnap = currentConfig.zoomController.resolveSnapKey(frame.displayZoom)
+    if (frame.finished) {
+      currentConfig.onZoomSnap()
+    } else {
       maybeSendZoomSnapHaptic(
-        previousSnap = previousSnap,
-        nextSnap = config.zoomController.resolveSnapKey(nextZoom),
-        haptic = config.onZoomSnap,
+        previousSnap = lastSnapKey,
+        nextSnap = nextSnap,
+        haptic = currentConfig.onZoomSnap,
       )
     }
-    return nextZoom
+    lastSnapKey = nextSnap
+    return true
+  }
+
+  private fun finishMotion(active: ActiveMotion) {
+    if (activeMotion !== active) return
+    activeMotion = null
+    motionJob = null
+    finishInteraction(config)
+  }
+
+  private fun stopMotion(commitRender: Boolean) {
+    activeMotion = null
+    motionJob?.cancel()
+    motionJob = null
+    if (commitRender) config?.zoomController?.commitRenderZoom()
+  }
+
+  private fun finishInteraction(config: EditorViewportZoomSemanticConfig?) {
+    config?.zoomController?.commitRenderZoom()
+    if (config != null) endTransform(config) else transformActive = false
+  }
+
+  private fun finishWithoutMotion(config: EditorViewportZoomSemanticConfig?) {
+    config
+      ?.zoomController
+      ?.setDisplayZoom(
+        zoom = config.zoomController.displayZoom,
+        layoutSpec = config.layoutSpec,
+        viewportWidth = config.viewportWidth,
+      )
+    finishInteraction(config)
+  }
+
+  private fun abortForConfigurationChange(config: EditorViewportZoomSemanticConfig?) {
+    clearDirectSessions()
+    stopMotion(commitRender = false)
+    if (config?.isUsable == true) {
+      config.zoomController.setDisplayZoom(
+        zoom = config.zoomController.displayZoom,
+        layoutSpec = config.layoutSpec,
+        viewportWidth = config.viewportWidth,
+      )
+      config.zoomController.commitRenderZoom()
+      endTransform(config)
+    } else {
+      transformActive = false
+    }
+  }
+
+  private fun motionDurationScale(): Double {
+    val scale = coroutineScope?.coroutineContext?.get(MotionDurationScale)?.scaleFactor ?: 1f
+    return scale.takeIf { it.isFinite() && it >= 0f }?.toDouble() ?: 1.0
+  }
+
+  private fun EditorViewportZoomSemanticConfig.createMotionSeed(): MotionSeed? {
+    val anchor =
+      when {
+        pinchSession != null -> {
+          val session = pinchSession ?: return null
+          session.anchor
+        }
+        indirectSession != null -> {
+          val session = indirectSession ?: return null
+          session.anchor
+        }
+        else -> return null
+      }
+    val anchorDisplayPosition =
+      resolveAnchorDisplayPosition(anchor, zoomController.displayZoom) ?: return null
+    return MotionSeed(
+      anchor = anchor,
+      scrollOffset = viewportState.effectiveTransformScrollTarget,
+      anchorDisplayPosition = anchorDisplayPosition,
+    )
   }
 }
 
@@ -225,10 +488,39 @@ private data class PinchSession(
   val anchor: EditorViewportAnchor,
   val startSample: EditorPinchSample,
   val startScrollOffset: Offset,
-  val startDisplayZoom: Float,
+  val startRawZoom: Float,
   val startAnchorDisplayPosition: Offset,
+  val startFocal: Offset,
   val pageSizes: List<PageSize>,
   val lastSample: EditorPinchSample,
+  val rawZoom: Float,
+)
+
+private data class IndirectSession(
+  val anchor: EditorViewportAnchor,
+  val startScrollOffset: Offset,
+  val startAnchorDisplayPosition: Offset,
+  val startFocal: Offset,
+  val pageSizes: List<PageSize>,
+  val lastTimestampMillis: Long,
+  val rawZoom: Float,
+)
+
+private data class MotionSeed(
+  val anchor: EditorViewportAnchor,
+  val scrollOffset: Offset,
+  val anchorDisplayPosition: Offset,
+)
+
+private data class ActiveMotion(
+  val configOwner: EditorZoomController,
+  val layoutSpec: EditorDocumentLayoutSpec,
+  val anchor: EditorViewportAnchor,
+  var startScrollOffset: Offset,
+  val startAnchorDisplayPosition: Offset,
+  var lastAppliedScrollOffset: Offset,
+  val motion: EditorZoomMotion,
+  var allowConcurrentPan: Boolean,
 )
 
 private fun EditorViewportZoomSemanticConfig.rebasePinchSession(
@@ -236,16 +528,62 @@ private fun EditorViewportZoomSemanticConfig.rebasePinchSession(
 ): PinchSession? {
   val anchor = resolveAnchor(session.lastSample.focalInRootPx) ?: return null
   val displayZoom = zoomController.displayZoom
-  val anchorDisplayPosition =
-    resolveAnchorDisplayPosition(anchor = anchor, displayZoom = displayZoom) ?: return null
+  val anchorDisplayPosition = resolveAnchorDisplayPosition(anchor, displayZoom) ?: return null
   return PinchSession(
     anchor = anchor,
     startSample = session.lastSample,
-    startScrollOffset = viewportState.scrollOffset,
-    startDisplayZoom = displayZoom,
+    startScrollOffset = viewportState.effectiveTransformScrollTarget,
+    startRawZoom = displayZoom,
     startAnchorDisplayPosition = anchorDisplayPosition,
+    startFocal = toRootDp(session.lastSample.focalInRootPx),
     pageSizes = pageSizes,
     lastSample = session.lastSample,
+    rawZoom = displayZoom,
+  )
+}
+
+private fun instantaneousLogZoomVelocity(
+  previousZoom: Float,
+  zoom: Float,
+  previousTimestampMillis: Long?,
+  timestampMillis: Long,
+): Double {
+  if (!previousZoom.isFinite() || previousZoom <= 0f || !zoom.isFinite() || zoom <= 0f) {
+    return Double.POSITIVE_INFINITY
+  }
+  if (previousZoom == zoom) return 0.0
+  if (previousTimestampMillis == null) return Double.POSITIVE_INFINITY
+  val elapsedSeconds = (timestampMillis - previousTimestampMillis) / 1000.0
+  return if (elapsedSeconds.isFinite() && elapsedSeconds > 0.0) {
+    ln(zoom.toDouble() / previousZoom) / elapsedSeconds
+  } else {
+    Double.POSITIVE_INFINITY
+  }
+}
+
+private fun EditorViewportZoomSemanticConfig.createIndirectSession(
+  focalInRootPx: Offset,
+  timestampMillis: Long,
+): IndirectSession? {
+  val viewportState = viewportState
+  val effectiveScrollTarget = viewportState.effectiveTransformScrollTarget
+  val unappliedScrollDelta = effectiveScrollTarget - viewportState.scrollOffset
+  val editorRect = uiState.editorRectInRoot() ?: return null
+  val focalInEditor = toEditorDp(focalInRootPx - editorRect.topLeft) + unappliedScrollDelta
+  val displayZoom = zoomController.displayZoom
+  val anchor =
+    resolveViewportTransform(displayZoom = displayZoom)
+      .resolveAnchor(focalX = focalInEditor.x, focalY = focalInEditor.y) ?: return null
+  val anchorDisplayPosition = resolveAnchorDisplayPosition(anchor, displayZoom) ?: return null
+  val focal = toRootDp(focalInRootPx)
+  return IndirectSession(
+    anchor = anchor,
+    startScrollOffset = effectiveScrollTarget,
+    startAnchorDisplayPosition = anchorDisplayPosition,
+    startFocal = focal,
+    pageSizes = pageSizes,
+    lastTimestampMillis = timestampMillis,
+    rawZoom = displayZoom,
   )
 }
 
@@ -263,12 +601,11 @@ private val EditorPinchSample.isUsable: Boolean
       distancePx.isFinite() &&
       distancePx > 0f
 
-private fun isValidScaleUpdate(focalInRootPx: Offset, scaleFactor: Float): Boolean {
-  if (!focalInRootPx.x.isFinite() || !focalInRootPx.y.isFinite()) {
-    return false
-  }
-  return scaleFactor.isFinite() && scaleFactor > 0f
-}
+private fun isValidScaleUpdate(focalInRootPx: Offset, scaleFactor: Float): Boolean =
+  focalInRootPx.x.isFinite() &&
+    focalInRootPx.y.isFinite() &&
+    scaleFactor.isFinite() &&
+    scaleFactor > 0f
 
 private fun EditorViewportZoomSemanticConfig.resolveAnchor(
   focalInRootPx: Offset
@@ -294,24 +631,19 @@ private fun EditorViewportZoomSemanticConfig.resolveAnchorDisplayPosition(
 
 private fun EditorViewportZoomSemanticConfig.resolveViewportTransform(displayZoom: Float?) =
   uiState.resolveViewportTransform(pageSizes = pageSizes).let { transform ->
-    if (displayZoom == null) {
-      transform
-    } else {
-      transform.copy(displayZoom = displayZoom)
-    }
+    if (displayZoom == null) transform else transform.copy(displayZoom = displayZoom)
   }
 
 private fun EditorViewportZoomSemanticConfig.toEditorDp(focalPx: Offset): Offset =
   Offset(x = focalPx.x / density, y = focalPx.y / density)
+
+private fun EditorViewportZoomSemanticConfig.toRootDp(focalInRootPx: Offset): Offset =
+  Offset(x = focalInRootPx.x / density, y = focalInRootPx.y / density)
 
 private fun maybeSendZoomSnapHaptic(
   previousSnap: EditorZoomSnapKey?,
   nextSnap: EditorZoomSnapKey?,
   haptic: () -> Unit,
 ) {
-  if (nextSnap == null || nextSnap == previousSnap) {
-    return
-  }
-
-  haptic()
+  if (nextSnap != null && nextSnap != previousSnap) haptic()
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomOverlay.kt
@@ -38,6 +38,7 @@ internal fun EditorZoomOverlay(modifier: Modifier = Modifier) {
   val zoomController = LocalEditorZoomController.current
   val enabled = zoomController.isZoomEnabled
   val displayZoom = zoomController.displayZoom
+  val indicatorZoom = zoomController.indicatorZoom
 
   var visible by remember { mutableStateOf(false) }
   var lastZoom by remember { mutableStateOf<Float?>(null) }
@@ -78,7 +79,7 @@ internal fun EditorZoomOverlay(modifier: Modifier = Modifier) {
       animationSpec = tween(durationMillis = ZoomOverlayFadeMs),
       label = "editor-zoom-overlay-alpha",
     )
-  val zoomPercent = (displayZoom * 100f).toInt()
+  val zoomPercent = (indicatorZoom * 100f).toInt()
 
   Box(modifier = modifier.graphicsLayer { this.alpha = alpha }) {
     Box(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomMotionTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomMotionTest.kt
@@ -1,0 +1,45 @@
+package co.typie.editor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EditorZoomMotionTest {
+  private val bounds = 0.2f..2f
+
+  @Test
+  fun `rubber band overzoom keeps moving without a nearby second wall`() {
+    assertEquals(1.5f, elasticEditorDisplayZoom(1.5f, bounds))
+    assertEquals(2f, elasticEditorDisplayZoom(2f, bounds))
+
+    val first = requireNotNull(elasticEditorDisplayZoom(2.1f, bounds))
+    val second = requireNotNull(elasticEditorDisplayZoom(2.2f, bounds))
+    assertTrue(first > 2f)
+    assertTrue(first < 2.1f)
+    assertTrue(second > first)
+    assertTrue(second < 2.2f)
+    assertTrue(
+      requireNotNull(elasticEditorDisplayZoom(100f, bounds)) <
+        bounds.endInclusive * EditorZoomMotionTuning.ElasticExtentRatio
+    )
+  }
+
+  @Test
+  fun `direct overzoom recovers to the normal bound`() {
+    val motion = createMotion(displayZoom = 2.08f)
+
+    assertTrue(motion.advance(1.0 / 60.0).displayZoom < 2.08f)
+    assertEquals(2f, motion.advance(1.0).displayZoom, 0.0001f)
+  }
+
+  @Test
+  fun `direct underzoom recovers to the normal bound`() {
+    val motion = createMotion(displayZoom = 0.18f)
+
+    assertTrue(motion.advance(1.0 / 60.0).displayZoom > 0.18f)
+    assertEquals(0.2f, motion.advance(1.0).displayZoom, 0.0001f)
+  }
+
+  private fun createMotion(displayZoom: Float): EditorZoomMotion =
+    EditorZoomMotion(displayZoom = displayZoom, bounds = bounds)
+}

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomStateTest.kt
@@ -5,6 +5,7 @@ import co.typie.editor.body.resolveBaseBottomSpace
 import co.typie.editor.body.resolveContinuousLayoutViewportWidth
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
@@ -99,6 +100,29 @@ class EditorZoomControllerTest {
 
     assertEquals(1f, state.displayZoom, 0.0001f)
     assertEquals(1f, state.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `direct gesture zoom rubber bands beyond bounds while programmatic zoom stays clamped`() {
+    val state = EditorZoomController()
+    val layout =
+      EditorDocumentLayoutSpec.Paginated(
+        pageWidth = 720f,
+        pageHeight = 960f,
+        pageMarginTop = 72f,
+        pageMarginBottom = 72f,
+        pageMarginLeft = 64f,
+        pageMarginRight = 64f,
+      )
+    state.syncLayout(layoutSpec = layout, viewportWidth = 720f)
+
+    state.setGestureDisplayZoom(rawZoom = 2.2f, layoutSpec = layout, viewportWidth = 720f)
+    assertTrue(state.displayZoom > 2f)
+    assertTrue(state.displayZoom < 2.2f)
+    assertEquals(2f, state.indicatorZoom, 0.0001f)
+
+    state.setDisplayZoom(zoom = state.displayZoom, layoutSpec = layout, viewportWidth = 720f)
+    assertEquals(2f, state.displayZoom, 0.0001f)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
@@ -16,6 +16,212 @@ import kotlin.test.assertTrue
 
 class EditorViewportZoomSemanticTest {
   @Test
+  fun `slow pinch detents at a snap point while hard bounds remain elastic`() {
+    val fixture = Fixture()
+    fixture.zoomController.setDisplayZoom(
+      zoom = 0.95f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+    )
+    fixture.uiState.updateDisplayZoom(0.95f)
+    val start =
+      EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f, timestampMillis = 0L)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(
+      fixture.semantic.updatePinch(
+        start.copy(distancePx = 100f * (0.99f / 0.95f), timestampMillis = 250L)
+      )
+    )
+    assertEquals(1f, fixture.zoomController.displayZoom, 0.0001f)
+
+    assertTrue(
+      fixture.semantic.updatePinch(
+        start.copy(distancePx = 100f * (2.2f / 0.95f), timestampMillis = 500L)
+      )
+    )
+    assertTrue(fixture.zoomController.displayZoom > 2f)
+    assertTrue(fixture.zoomController.displayZoom < 2.2f)
+
+    fixture.semantic.release()
+    assertEquals(2f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(2f, fixture.zoomController.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `fast pinch crosses a snap point without capture`() {
+    val fixture = Fixture()
+    fixture.zoomController.setDisplayZoom(
+      zoom = 0.95f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+    )
+    fixture.uiState.updateDisplayZoom(0.95f)
+    val start =
+      EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f, timestampMillis = 0L)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(
+      fixture.semantic.updatePinch(
+        start.copy(distancePx = 100f * (0.99f / 0.95f), timestampMillis = 50L)
+      )
+    )
+
+    assertEquals(0.99f, fixture.zoomController.displayZoom, 0.0001f)
+  }
+
+  @Test
+  fun `release from a direct detent stays settled`() {
+    val fixture = Fixture()
+    fixture.zoomController.setDisplayZoom(
+      zoom = 0.95f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+    )
+    fixture.uiState.updateDisplayZoom(0.95f)
+    val start =
+      EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f, timestampMillis = 0L)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(
+      fixture.semantic.updatePinch(
+        start.copy(distancePx = 100f * (0.99f / 0.95f), timestampMillis = 250L)
+      )
+    )
+    fixture.semantic.release()
+
+    assertEquals(1f, fixture.zoomController.displayZoom, 0.0001f)
+  }
+
+  @Test
+  fun `fast in-range pinch stops at the released zoom`() {
+    val fixture = Fixture()
+    val start =
+      EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f, timestampMillis = 0L)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(fixture.semantic.updatePinch(start.copy(distancePx = 120f, timestampMillis = 16L)))
+    fixture.semantic.release()
+
+    assertEquals(1.2f, fixture.zoomController.displayZoom, 0.0001f)
+  }
+
+  @Test
+  fun `overshoot recovery sends one zoom snap haptic`() {
+    val fixture = Fixture()
+    val start =
+      EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f, timestampMillis = 0L)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(fixture.semantic.updatePinch(start.copy(distancePx = 220f, timestampMillis = 250L)))
+    assertTrue(fixture.zoomController.displayZoom > 2f)
+    assertEquals(0, fixture.zoomSnapCount)
+
+    fixture.semantic.release()
+
+    assertEquals(2f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(1, fixture.zoomSnapCount)
+  }
+
+  @Test
+  fun `tiny overshoot recovers to the exact bound with one haptic`() {
+    val fixture = Fixture()
+    val start =
+      EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f, timestampMillis = 0L)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(
+      fixture.semantic.updatePinch(start.copy(distancePx = 200.1f, timestampMillis = 250L))
+    )
+    assertTrue(fixture.zoomController.displayZoom > 2f)
+
+    fixture.semantic.release()
+
+    assertEquals(2f, fixture.zoomController.displayZoom)
+    assertEquals(1, fixture.zoomSnapCount)
+  }
+
+  @Test
+  fun `first indirect update does not assume a slow velocity`() {
+    val fixture = Fixture()
+    fixture.zoomController.setDisplayZoom(
+      zoom = 0.95f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+    )
+    fixture.uiState.updateDisplayZoom(0.95f)
+
+    assertTrue(fixture.semantic.beginIndirect())
+    assertTrue(
+      fixture.semantic.updateIndirectScale(
+        focalInRootPx = Offset(80f, 150f),
+        scaleFactor = 0.99f / 0.95f,
+      )
+    )
+
+    assertEquals(0.99f, fixture.zoomController.displayZoom, 0.0001f)
+  }
+
+  @Test
+  fun `overzoom stays elastic when the fit detent equals the hard bound`() {
+    val fixture =
+      Fixture(
+        viewportWidth = 1000f,
+        documentLayoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 400f),
+      )
+    fixture.zoomController.setDisplayZoom(
+      zoom = 2f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+    )
+    fixture.uiState.updateDisplayZoom(2f)
+    val start =
+      EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f, timestampMillis = 0L)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(fixture.semantic.updatePinch(start.copy(distancePx = 110f, timestampMillis = 250L)))
+
+    assertTrue(fixture.zoomController.displayZoom > 2f)
+    assertTrue(fixture.zoomController.displayZoom < 2.2f)
+    assertEquals(0, fixture.zoomSnapCount)
+
+    fixture.semantic.release()
+
+    assertEquals(2f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(1, fixture.zoomSnapCount)
+  }
+
+  @Test
+  fun `direct pan interruption ends transform while recovering overzoom`() {
+    val fixture = Fixture()
+    val start = EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f)
+
+    assertTrue(fixture.semantic.beginPinch(start))
+    assertTrue(fixture.semantic.updatePinch(start.copy(distancePx = 220f)))
+    fixture.semantic.interruptForDirectPan()
+
+    assertEquals(false, fixture.viewportState.isTransforming)
+    assertEquals(2f, fixture.zoomController.displayZoom, 0.0001f)
+  }
+
+  @Test
+  fun `cancelling indirect zoom before its first sample does not strand overzoom`() {
+    val fixture = Fixture()
+    fixture.zoomController.setGestureDisplayZoom(
+      rawZoom = 2.2f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+    )
+    assertTrue(fixture.zoomController.displayZoom > 2f)
+
+    assertTrue(fixture.semantic.beginIndirect())
+    fixture.semantic.cancel()
+
+    assertEquals(2f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(false, fixture.viewportState.isTransforming)
+  }
+
+  @Test
   fun `pinch zoom keeps the anchor under the focal point`() {
     val fixture = Fixture()
 
@@ -27,7 +233,7 @@ class EditorViewportZoomSemanticTest {
     assertEquals(1.5f, fixture.zoomController.displayZoom, 0.0001f)
     assertEquals(Offset(40f, 75f), fixture.viewportState.scrollOffset)
 
-    fixture.semantic.end()
+    fixture.semantic.release()
     assertEquals(false, fixture.viewportState.isTransforming)
     assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom, 0.0001f)
   }
@@ -46,10 +252,10 @@ class EditorViewportZoomSemanticTest {
     assertTrue(fixture.semantic.updatePinch(start.copy(distancePx = 75f)))
 
     assertEquals(0.75f, fixture.zoomController.displayZoom, 0.0001f)
-    assertEquals(1f, fixture.zoomController.renderZoom, 0.0001f)
+    assertEquals(0.75f, fixture.zoomController.renderZoom, 0.0001f)
     assertTrue(fixture.attachedAnchors.isNotEmpty())
 
-    fixture.semantic.end()
+    fixture.semantic.release()
     assertEquals(0.75f, fixture.zoomController.renderZoom, 0.0001f)
   }
 
@@ -146,7 +352,7 @@ class EditorViewportZoomSemanticTest {
     assertEquals(1f, fixture.zoomController.displayZoom, 0.0001f)
     assertEquals(Offset(x = 100f, y = 80f), fixture.viewportState.scrollOffset)
 
-    fixture.semantic.end()
+    fixture.semantic.release()
     fixture.viewportState.updateMeasuredBounds(
       viewportSize = Size(width = 100f, height = 120f),
       contentSize = Size(width = 500f, height = 500f),
@@ -172,7 +378,7 @@ class EditorViewportZoomSemanticTest {
     assertEquals(1.5f, fixture.zoomController.displayZoom, 0.0001f)
     assertEquals(Offset(40f, 75f), fixture.viewportState.scrollOffset)
 
-    fixture.semantic.end()
+    fixture.semantic.release()
     assertEquals(false, fixture.viewportState.isTransforming)
     assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom, 0.0001f)
   }
@@ -236,7 +442,9 @@ class EditorViewportZoomSemanticTest {
     assertTrue(
       fixture.semantic.updateIndirectScroll(Offset(300f, 0f), normalizedDeltaForOneAndHalfZoom)
     )
-    assertEquals(2f, fixture.zoomController.displayZoom, 0.0001f)
+    val overzoom = fixture.zoomController.displayZoom
+    assertTrue(overzoom > 2f)
+    assertTrue(overzoom < 2.25f)
     assertEquals(Offset.Zero, fixture.viewportState.scrollOffset)
 
     fixture.viewportState.updateMeasuredBounds(
@@ -244,7 +452,7 @@ class EditorViewportZoomSemanticTest {
       contentSize = Size(width = 1440f, height = 2000f),
     )
 
-    assertEquals(Offset(300f, 0f), fixture.viewportState.scrollOffset)
+    assertEquals(Offset(300f * (overzoom - 1f), 0f), fixture.viewportState.scrollOffset)
   }
 
   @Test
@@ -260,7 +468,7 @@ class EditorViewportZoomSemanticTest {
     assertEquals(1.5f, fixture.zoomController.displayZoom, 0.0001f)
     assertEquals(Offset(40f, 75f), fixture.viewportState.scrollOffset)
 
-    fixture.semantic.end()
+    fixture.semantic.release()
     assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom, 0.0001f)
   }
 
@@ -285,6 +493,9 @@ class EditorViewportZoomSemanticTest {
     val layoutSpec = documentLayoutSpec
     val attachedAnchors =
       mutableListOf<Triple<co.typie.editor.EditorViewportAnchor, Offset, Offset>>()
+    var zoomSnapCount = 0
+      private set
+
     val zoomController = EditorZoomController()
     val viewportState =
       EditorViewportState().apply {
@@ -333,7 +544,7 @@ class EditorViewportZoomSemanticTest {
           pageSizes = pageSizes,
           viewportWidth = viewportWidth,
           density = 1f,
-          onZoomSnap = {},
+          onZoomSnap = { zoomSnapCount += 1 },
           onAttachViewportAnchor = { anchor, displayPosition, scrollOffset ->
             attachedAnchors += Triple(anchor, displayPosition, scrollOffset)
           },

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -1215,36 +1215,38 @@ class EditorInteractionsDesktopTest {
     }
 
   @Test
-  fun `surviving pinch pointer resumes normal nested pan without touch slop`() = runComposeUiTest {
+  fun `surviving pinch pointer stays zoom owned until all pointers are up`() = runComposeUiTest {
     val fixture = Fixture()
     setEditorContent(fixture)
 
     onNodeWithTag(EditorTag).performTouchInput {
       down(pointerId = 0, position = Offset(100f, 100f))
       down(pointerId = 1, position = Offset(200f, 100f))
-      updatePointerTo(pointerId = 0, position = Offset(50f, 100f))
-      updatePointerTo(pointerId = 1, position = Offset(250f, 100f))
+      updatePointerTo(pointerId = 0, position = Offset(80f, 100f))
+      updatePointerTo(pointerId = 1, position = Offset(220f, 100f))
       move()
-      up(pointerId = 1)
     }
+    val zoomBeforeRelease = fixture.zoomController.displayZoom
+
+    onNodeWithTag(EditorTag).performTouchInput { up(pointerId = 1) }
     assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertEquals(zoomBeforeRelease, fixture.zoomController.displayZoom, 0.0001f)
     assertTrue(fixture.touchPanDeltas.isEmpty())
 
     onNodeWithTag(EditorTag).performTouchInput {
-      moveTo(pointerId = 0, position = Offset(50f, 101f))
-      moveTo(pointerId = 0, position = Offset(50f, 102f))
+      moveTo(pointerId = 0, position = Offset(80f, 101f))
+      moveTo(pointerId = 0, position = Offset(80f, 102f))
     }
     waitForIdle()
 
-    assertEquals(EditorInteractionMode.Panning, fixture.controller.interactionMode)
-    assertEquals(listOf(Offset(x = 0f, y = 1f), Offset(x = 0f, y = 1f)), fixture.touchPanDeltas)
-    assertTrue(fixture.nestedScrollAvailable.isNotEmpty())
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+    assertTrue(fixture.touchPanDeltas.isEmpty())
+    assertTrue(fixture.nestedScrollAvailable.isEmpty())
 
     onNodeWithTag(EditorTag).performTouchInput { up(pointerId = 0) }
     waitForIdle()
     assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
-    assertTrue(fixture.flingVelocities.isNotEmpty())
-    assertTrue(fixture.flingVelocities.all { velocity -> velocity.y < 1_000f })
+    assertTrue(fixture.flingVelocities.isEmpty())
   }
 
   @Test

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
@@ -2,6 +2,7 @@ import { tick } from 'svelte';
 import {
   clampDocumentLayoutZoom,
   clampDocumentZoom,
+  computeDocumentFitWidthZoom,
   computeDocumentZoomBounds,
   computeInitialDocumentZoom,
   RENDER_ZOOM_DEBOUNCE_MS,
@@ -9,20 +10,37 @@ import {
   RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS,
   RENDER_ZOOM_SCALE_RATIO_THRESHOLD,
   renderZoomForDisplay,
+  resolveDirectDocumentZoom,
   zoomDiffers,
   zoomEquals,
 } from '$lib/editor-ffi/zoom';
+import { ZOOM_MAX_MOTION_SECONDS, ZoomMotion } from '$lib/editor-ffi/zoom-motion';
 import type { ScrollViewport } from '@typie/ui/utils';
 import type { Editor } from '$lib/editor-ffi/editor.svelte';
 import type { DocumentZoomLayout } from '$lib/editor-ffi/zoom';
 
-type ZoomAnchor = {
-  page: number;
-  x: number;
-  y: number;
-  focalX: number;
-  focalY: number;
+type ZoomAnchor = { page: number; x: number; y: number; focalX: number; focalY: number };
+type DirectZoomKind = 'touch' | 'wheel';
+type ZoomMotionPlayback = 'animated' | 'immediate';
+
+type DirectZoomSession = {
+  kind: DirectZoomKind;
+  layoutKey: string;
+  anchor: ZoomAnchor | null;
+  rawZoom: number;
+  snapZoom: number | null;
+  lastTimestampMs: number;
 };
+
+type ActiveZoomMotion = {
+  layoutKey: string;
+  anchor: ZoomAnchor | null;
+  motion: ZoomMotion;
+  lastTimestampMs: number;
+};
+
+const NOMINAL_MOTION_FRAME_MS = 1000 / 60;
+const DIRECT_SNAP_VELOCITY_THRESHOLD = 0.18;
 
 type EditorZoomControllerOptions = {
   editor: Editor;
@@ -33,15 +51,18 @@ type EditorZoomControllerOptions = {
 };
 
 export class EditorZoomController {
-  static readonly WHEEL_RAW_ZOOM_RESET_MS = 150;
+  static readonly WHEEL_RAW_ZOOM_RESET_MS = 32;
   static readonly KEYBOARD_ZOOM_STEP = 0.1;
 
   #initializedLayoutKey: string | null = null;
   #renderZoomTimer: ReturnType<typeof setTimeout> | null = null;
   #renderZoomMismatchStartedAt: number | null = null;
   #lastRenderZoomCommitAt = -Infinity;
-  #wheelRawZoomResetTimer: ReturnType<typeof setTimeout> | null = null;
-  #wheelRawZoom: number | null = null;
+  #wheelReleaseTimer: ReturnType<typeof setTimeout> | null = null;
+  #directSession: DirectZoomSession | null = null;
+  #activeMotion: ActiveZoomMotion | null = null;
+  #cancelAnimationFrame: (() => void) | null = null;
+  #applyQueue: Promise<unknown> = Promise.resolve();
   #options: EditorZoomControllerOptions;
 
   displayZoom = $state(1);
@@ -53,64 +74,50 @@ export class EditorZoomController {
 
   async #stepZoomByKeyboard(delta: number): Promise<void> {
     if (!this.#options.layout()) return;
-    const anchor = this.#createZoomAnchorFromViewportCenter();
-    const nextZoom = this.displayZoom + delta;
-    await this.#setZoomWithAnchor(nextZoom, anchor);
+    await this.#setZoomWithAnchor(this.displayZoom + delta, this.#createZoomAnchorFromViewportCenter());
   }
 
   #createZoomAnchorFromClient(clientX: number, clientY: number): ZoomAnchor | null {
     const viewport = this.#options.getScrollViewport();
-    if (!viewport) {
-      return null;
-    }
+    if (!viewport) return null;
     const resolved = this.#options.editor.clientToLocal(clientX, clientY);
-    if (!resolved) {
-      return null;
-    }
+    if (!resolved) return null;
     const rect = viewport.getRect();
-    return {
-      ...resolved,
-      focalX: clientX - rect.left,
-      focalY: clientY - rect.top,
-    };
+    return { ...resolved, focalX: clientX - rect.left, focalY: clientY - rect.top };
   }
 
   #createZoomAnchorFromViewportCenter(): ZoomAnchor | null {
     const viewport = this.#options.getScrollViewport();
-    if (!viewport) {
-      return null;
-    }
+    if (!viewport) return null;
     const rect = viewport.getRect();
-    const clientX = rect.left + (rect.right - rect.left) / 2;
-    const clientY = rect.top + (rect.bottom - rect.top) / 2;
-    return this.#createZoomAnchorFromClient(clientX, clientY);
+    return this.#createZoomAnchorFromClient(rect.left + (rect.right - rect.left) / 2, rect.top + (rect.bottom - rect.top) / 2);
   }
 
-  async #setZoomWithAnchor(nextZoom: number, anchor: ZoomAnchor | null, source: 'wheel' | 'programmatic' = 'programmatic'): Promise<void> {
-    const previousZoom = this.displayZoom;
-    this.setZoom(nextZoom, { source });
-    if (!anchor || zoomEquals(previousZoom, this.displayZoom)) {
-      return;
-    }
+  #resolveFocalInViewport(clientX: number, clientY: number): { x: number; y: number } | null {
+    const rect = this.#options.getScrollViewport()?.getRect();
+    const x = rect ? clientX - rect.left : clientX;
+    const y = rect ? clientY - rect.top : clientY;
+    return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : null;
+  }
+
+  async #setZoomWithAnchor(nextZoom: number, anchor: ZoomAnchor | null): Promise<void> {
+    this.setZoom(nextZoom);
     await this.#syncZoomAnchor(anchor, this.displayZoom);
   }
 
-  #scheduleWheelRawZoomReset(): void {
-    if (this.#wheelRawZoomResetTimer) {
-      clearTimeout(this.#wheelRawZoomResetTimer);
+  #clearWheelReleaseTimer(): void {
+    if (this.#wheelReleaseTimer) {
+      clearTimeout(this.#wheelReleaseTimer);
+      this.#wheelReleaseTimer = null;
     }
-    this.#wheelRawZoomResetTimer = setTimeout(() => {
-      this.#wheelRawZoomResetTimer = null;
-      this.#wheelRawZoom = null;
-    }, EditorZoomController.WHEEL_RAW_ZOOM_RESET_MS);
   }
 
-  #resetWheelRawZoom(): void {
-    if (this.#wheelRawZoomResetTimer) {
-      clearTimeout(this.#wheelRawZoomResetTimer);
-      this.#wheelRawZoomResetTimer = null;
-    }
-    this.#wheelRawZoom = null;
+  #scheduleWheelRelease(): void {
+    this.#clearWheelReleaseTimer();
+    this.#wheelReleaseTimer = setTimeout(() => {
+      this.#wheelReleaseTimer = null;
+      void this.releaseDirectZoom('wheel');
+    }, EditorZoomController.WHEEL_RAW_ZOOM_RESET_MS);
   }
 
   #clearRenderZoomTimer(): void {
@@ -137,81 +144,156 @@ export class EditorZoomController {
       this.#renderZoomMismatchStartedAt = null;
       return;
     }
-
     const now = Date.now();
     this.#renderZoomMismatchStartedAt ??= now;
     const minimumIntervalDeadline = this.#lastRenderZoomCommitAt + RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS;
     const quietDeadline = now + RENDER_ZOOM_DEBOUNCE_MS;
     const maximumDelayDeadline = this.#renderZoomMismatchStartedAt + RENDER_ZOOM_MAX_COMMIT_DELAY_MS;
     const scaleRatio = Math.max(this.displayZoom / this.renderZoom, this.renderZoom / this.displayZoom);
-
     const requestedDeadline =
       final || scaleRatio >= RENDER_ZOOM_SCALE_RATIO_THRESHOLD ? now : Math.min(quietDeadline, maximumDelayDeadline);
     const deadline = Math.max(requestedDeadline, minimumIntervalDeadline);
-
     const delay = Math.max(0, deadline - now);
     if (delay === 0) {
       this.#commitLatestRenderZoom(now);
-      return;
+    } else {
+      this.#renderZoomTimer = setTimeout(() => this.#commitLatestRenderZoom(Date.now()), delay);
     }
-    this.#renderZoomTimer = setTimeout(() => {
-      this.#commitLatestRenderZoom(Date.now());
-    }, delay);
   }
 
-  async #syncZoomAnchor(anchor: ZoomAnchor, zoom: number): Promise<void> {
+  async #syncZoomAnchor(anchor: ZoomAnchor | null, zoom: number, isCurrent: () => boolean = () => true): Promise<boolean> {
+    if (!anchor) return isCurrent();
     const viewport = this.#options.getScrollViewport();
-    if (!viewport) {
-      return;
-    }
-
+    if (!viewport) return false;
     const pageCount = this.#options.editor.pageSizes.length;
-    if (pageCount === 0) {
-      return;
-    }
-
-    const page = Math.max(0, Math.min(anchor.page, pageCount - 1));
-    const pageEl = this.#options.editor.pageEls[page];
-    if (!pageEl) {
-      return;
-    }
-
+    if (pageCount === 0 || anchor.page < 0 || anchor.page >= pageCount) return false;
     await tick();
-
+    if (!isCurrent()) return false;
+    const pageEl = this.#options.editor.pageEls[anchor.page];
+    if (!pageEl) return false;
     const pageRect = pageEl.getBoundingClientRect();
     const scrollRect = viewport.getRect();
-
-    const targetClientX = scrollRect.left + anchor.focalX;
-    const targetClientY = scrollRect.top + anchor.focalY;
-    const anchoredClientX = pageRect.left + anchor.x * zoom;
-    const anchoredClientY = pageRect.top + anchor.y * zoom;
-
-    const deltaX = anchoredClientX - targetClientX;
-    const deltaY = anchoredClientY - targetClientY;
-    if (Math.abs(deltaX) > 0.5 || Math.abs(deltaY) > 0.5) {
-      viewport.scrollBy(deltaX, deltaY);
-    }
+    const deltaX = pageRect.left + anchor.x * zoom - (scrollRect.left + anchor.focalX);
+    const deltaY = pageRect.top + anchor.y * zoom - (scrollRect.top + anchor.focalY);
+    if (![deltaX, deltaY].every(Number.isFinite)) return false;
+    if (Math.abs(deltaX) > 0.5 || Math.abs(deltaY) > 0.5) viewport.scrollBy(deltaX, deltaY);
     this.#options.attachViewportAnchor?.(anchor);
+    return true;
+  }
+
+  #enqueueResolvedZoom(zoom: number, resolveAnchor: () => ZoomAnchor | null, isCurrent: () => boolean): Promise<boolean> {
+    const apply = async (): Promise<boolean> => {
+      if (!isCurrent()) return false;
+      if (zoomDiffers(this.displayZoom, zoom)) this.displayZoom = zoom;
+      this.#scheduleRenderZoom();
+      return this.#syncZoomAnchor(resolveAnchor(), zoom, isCurrent);
+    };
+    const result = this.#applyQueue.then(apply);
+    this.#applyQueue = result.catch(() => false);
+    return result;
+  }
+
+  #stopMotion(): void {
+    this.#cancelAnimationFrame?.();
+    this.#cancelAnimationFrame = null;
+    this.#activeMotion = null;
+  }
+
+  #cancelInteractiveMotion(): void {
+    this.#clearWheelReleaseTimer();
+    this.#directSession = null;
+    this.#stopMotion();
+  }
+
+  async #finishOrRecover(session: DirectZoomSession, playback: ZoomMotionPlayback = 'animated'): Promise<void> {
+    const layout = this.#options.layout();
+    if (!layout || layoutKey(layout) !== session.layoutKey) {
+      this.#scheduleRenderZoom(true);
+      return;
+    }
+    const bounds = computeDocumentZoomBounds(layout);
+    if (this.displayZoom >= bounds.min && this.displayZoom <= bounds.max) {
+      this.#scheduleRenderZoom(true);
+      return;
+    }
+    const motion = new ZoomMotion(this.displayZoom, bounds);
+    const anchor = session.anchor ? { ...session.anchor } : null;
+    const active: ActiveZoomMotion = {
+      layoutKey: session.layoutKey,
+      anchor,
+      motion,
+      lastTimestampMs: nowMilliseconds() - NOMINAL_MOTION_FRAME_MS,
+    };
+    this.#activeMotion = active;
+    if (playback === 'immediate') {
+      const frame = motion.advance(ZOOM_MAX_MOTION_SECONDS);
+      await this.#enqueueResolvedZoom(
+        frame.displayZoom,
+        () => active.anchor,
+        () => this.#activeMotion === active,
+      );
+      this.#finishMotion(active);
+    } else {
+      this.#scheduleMotionFrame();
+    }
+  }
+
+  #scheduleMotionFrame(): void {
+    this.#cancelAnimationFrame?.();
+    this.#cancelAnimationFrame = requestZoomAnimationFrame((timestampMs) => {
+      this.#cancelAnimationFrame = null;
+      void this.#advanceMotion(timestampMs);
+    });
+  }
+
+  async #advanceMotion(timestampMs: number): Promise<void> {
+    const active = this.#activeMotion;
+    if (!active) return;
+    const layout = this.#options.layout();
+    if (!layout || layoutKey(layout) !== active.layoutKey) {
+      this.#finishMotion(active);
+      return;
+    }
+    const frame = active.motion.advance(Math.max(0, timestampMs - active.lastTimestampMs) / 1000);
+    active.lastTimestampMs = timestampMs;
+    const applied = await this.#enqueueResolvedZoom(
+      frame.displayZoom,
+      () => active.anchor,
+      () => this.#activeMotion === active,
+    );
+    if (!applied || this.#activeMotion !== active || frame.finished) {
+      this.#finishMotion(active);
+    } else {
+      this.#scheduleMotionFrame();
+    }
+  }
+
+  #finishMotion(active: ActiveZoomMotion): void {
+    if (this.#activeMotion !== active) return;
+    this.#stopMotion();
+    this.#scheduleRenderZoom(true);
+  }
+
+  get hasActiveDirectZoom(): boolean {
+    return this.#directSession !== null;
+  }
+
+  get hasActiveMotion(): boolean {
+    return this.#activeMotion !== null;
   }
 
   destroy(): void {
+    this.#cancelInteractiveMotion();
     this.#clearRenderZoomTimer();
     this.#renderZoomMismatchStartedAt = null;
-    this.#resetWheelRawZoom();
   }
 
-  setZoom(nextZoom: number, { commitRender = false, source = 'programmatic' as 'wheel' | 'programmatic' } = {}): void {
-    if (source !== 'wheel') {
-      this.#resetWheelRawZoom();
-    }
-
+  setZoom(nextZoom: number, { commitRender = false } = {}): void {
+    this.#cancelInteractiveMotion();
     this.#clearRenderZoomTimer();
-
     const layout = this.#options.layout();
     if (!layout) {
-      if (zoomDiffers(this.displayZoom, 1)) {
-        this.displayZoom = 1;
-      }
+      if (zoomDiffers(this.displayZoom, 1)) this.displayZoom = 1;
       if (zoomDiffers(this.renderZoom, 1)) {
         this.renderZoom = 1;
         this.#lastRenderZoomCommitAt = Date.now();
@@ -219,96 +301,132 @@ export class EditorZoomController {
       this.#renderZoomMismatchStartedAt = null;
       return;
     }
-
     const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
-    const clamped = clampDocumentLayoutZoom({
-      zoom: nextZoom,
-      layout,
-      viewportWidth,
-    });
-    if (zoomDiffers(this.displayZoom, clamped)) {
-      this.displayZoom = clamped;
-    }
-
-    if (commitRender) {
-      this.#commitLatestRenderZoom(Date.now());
-      return;
-    }
-
-    this.#scheduleRenderZoom();
+    const clamped = clampDocumentLayoutZoom({ zoom: nextZoom, layout, viewportWidth });
+    if (zoomDiffers(this.displayZoom, clamped)) this.displayZoom = clamped;
+    if (commitRender) this.#commitLatestRenderZoom(Date.now());
+    else this.#scheduleRenderZoom();
   }
 
   syncInitialZoom(): void {
     const layout = this.#options.layout();
     const viewportWidth = this.#options.viewportWidth();
-
     if (!layout) {
       this.#initializedLayoutKey = null;
       this.setZoom(1, { commitRender: true });
       return;
     }
-
     if (viewportWidth <= 0) return;
-
-    const width = layout.type === 'continuous' ? layout.maxWidth : layout.pageWidth;
-    const key = `${layout.type}:${width}`;
+    const key = layoutKey(layout);
     if (this.#initializedLayoutKey === key) return;
-
     this.#initializedLayoutKey = key;
-    const initialZoom = computeInitialDocumentZoom(layout, viewportWidth);
-    this.setZoom(initialZoom, { commitRender: true });
+    this.setZoom(computeInitialDocumentZoom(layout, viewportWidth), { commitRender: true });
   }
 
   clampCurrentZoomToBounds(): void {
+    if (this.hasActiveDirectZoom || this.hasActiveMotion) return;
     const layout = this.#options.layout();
     if (!layout) return;
-
     const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
-    const clamped = clampDocumentLayoutZoom({
-      zoom: this.displayZoom,
-      layout,
-      viewportWidth,
-    });
-    if (zoomDiffers(clamped, this.displayZoom)) {
-      this.setZoom(clamped, { commitRender: true });
+    const clamped = clampDocumentLayoutZoom({ zoom: this.displayZoom, layout, viewportWidth });
+    if (zoomDiffers(clamped, this.displayZoom)) this.setZoom(clamped, { commitRender: true });
+  }
+
+  beginDirectZoom(kind: DirectZoomKind, clientX: number, clientY: number, timestampMs: number): boolean {
+    const layout = this.#options.layout();
+    const focal = this.#resolveFocalInViewport(clientX, clientY);
+    if (!layout || !focal) return false;
+    this.#cancelInteractiveMotion();
+    this.#directSession = {
+      kind,
+      layoutKey: layoutKey(layout),
+      anchor: this.#createZoomAnchorFromClient(clientX, clientY),
+      rawZoom: this.displayZoom,
+      snapZoom: resolveDirectSnapZoom(this.displayZoom, layout, this.#options.viewportWidth()),
+      lastTimestampMs: normalizeTimestamp(timestampMs),
+    };
+    return true;
+  }
+
+  async updateDirectZoom(kind: DirectZoomKind, rawZoom: number, clientX: number, clientY: number, timestampMs: number): Promise<boolean> {
+    const session = this.#directSession;
+    const layout = this.#options.layout();
+    const focal = this.#resolveFocalInViewport(clientX, clientY);
+    if (!layout || !focal || !session || session.kind !== kind || layoutKey(layout) !== session.layoutKey) return false;
+    const normalizedTimestamp = normalizeTimestamp(timestampMs);
+    const rawVelocity = instantaneousLogZoomVelocity(session.rawZoom, rawZoom, session.lastTimestampMs, normalizedTimestamp);
+    const snapCandidate = resolveDirectSnapZoom(rawZoom, layout, this.#options.viewportWidth());
+    const retainSnap = snapCandidate !== null && session.snapZoom !== null && zoomEquals(snapCandidate, session.snapZoom);
+    session.snapZoom =
+      snapCandidate !== null && (retainSnap || Math.abs(rawVelocity) < DIRECT_SNAP_VELOCITY_THRESHOLD) ? snapCandidate : null;
+    const displayZoom = session.snapZoom ?? resolveDirectDocumentZoom(rawZoom, layout);
+    if (!Number.isFinite(displayZoom)) return false;
+    session.rawZoom = rawZoom;
+    if (normalizedTimestamp > session.lastTimestampMs) session.lastTimestampMs = normalizedTimestamp;
+    if (session.anchor) {
+      session.anchor.focalX = focal.x;
+      session.anchor.focalY = focal.y;
     }
+    return this.#enqueueResolvedZoom(
+      displayZoom,
+      () => session.anchor,
+      () => this.#directSession === session,
+    );
+  }
+
+  async releaseDirectZoom(kind: DirectZoomKind): Promise<void> {
+    const session = this.#directSession;
+    if (!session || session.kind !== kind) return;
+    this.#clearWheelReleaseTimer();
+    await this.#applyQueue;
+    if (this.#directSession !== session) return;
+    this.#directSession = null;
+    const reduceMotion = prefersReducedMotion();
+    await this.#finishOrRecover(session, reduceMotion ? 'immediate' : 'animated');
+  }
+
+  cancelDirectZoom(kind?: DirectZoomKind): void {
+    if (kind && this.#directSession?.kind !== kind) return;
+    const current = this.#directSession;
+    this.#cancelInteractiveMotion();
+    if (current) void this.#finishOrRecover(current, prefersReducedMotion() ? 'immediate' : 'animated');
+    else this.#scheduleRenderZoom(true);
+  }
+
+  interruptForDirectPan(): void {
+    if (this.#directSession) {
+      const kind = this.#directSession.kind;
+      this.#directSession.anchor = null;
+      void this.releaseDirectZoom(kind);
+      return;
+    }
+    const active = this.#activeMotion;
+    const layout = this.#options.layout();
+    if (!active || !layout) return;
+    const bounds = computeDocumentZoomBounds(layout);
+    if (this.displayZoom >= bounds.min && this.displayZoom <= bounds.max) {
+      this.#stopMotion();
+      this.#scheduleRenderZoom(true);
+      return;
+    }
+    active.anchor = null;
   }
 
   async handleWheel(event: WheelEvent): Promise<void> {
-    const layout = this.#options.layout();
-    if (!layout) return;
-
+    if (!this.#options.layout()) return;
     const zoomDelta = Math.abs(event.deltaY) >= Math.abs(event.deltaX) ? event.deltaY : event.deltaX;
-    if (zoomDelta === 0) {
-      return;
-    }
-
+    if (zoomDelta === 0) return;
     if (!event.metaKey && !event.ctrlKey) {
+      this.interruptForDirectPan();
       return;
     }
-
-    if (event.cancelable) {
-      event.preventDefault();
-    }
-    this.#scheduleWheelRawZoomReset();
-
-    const bounds = computeDocumentZoomBounds(layout);
-    const wheelBaseZoom = this.#wheelRawZoom ?? this.displayZoom;
-    const nextRawZoom = clampDocumentZoom(wheelBaseZoom * Math.exp(-zoomDelta / 240), bounds);
-    this.#wheelRawZoom = nextRawZoom;
-
-    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
-    const nextZoom = clampDocumentLayoutZoom({
-      zoom: nextRawZoom,
-      layout,
-      viewportWidth,
-    });
-    if (zoomEquals(nextZoom, this.displayZoom)) {
-      return;
-    }
-
-    const anchor = this.#createZoomAnchorFromClient(event.clientX, event.clientY);
-    await this.#setZoomWithAnchor(nextZoom, anchor, 'wheel');
+    if (event.cancelable) event.preventDefault();
+    if (this.#directSession?.kind !== 'wheel' && !this.beginDirectZoom('wheel', event.clientX, event.clientY, event.timeStamp)) return;
+    const session = this.#directSession;
+    if (!session || session.kind !== 'wheel') return;
+    const nextRawZoom = session.rawZoom * Math.exp(-zoomDelta / 240);
+    this.#scheduleWheelRelease();
+    await this.updateDirectZoom('wheel', nextRawZoom, event.clientX, event.clientY, event.timeStamp);
   }
 
   async zoomInByKeyboard(): Promise<void> {
@@ -321,19 +439,54 @@ export class EditorZoomController {
 
   async resetByKeyboard(): Promise<void> {
     if (!this.#options.layout()) return;
-    const anchor = this.#createZoomAnchorFromViewportCenter();
-    await this.#setZoomWithAnchor(1, anchor);
+    await this.#setZoomWithAnchor(1, this.#createZoomAnchorFromViewportCenter());
   }
+}
 
-  async zoomToClientPoint(nextZoom: number, clientX: number, clientY: number): Promise<void> {
-    if (!this.#options.layout()) return;
+function layoutKey(layout: DocumentZoomLayout): string {
+  return layout.type === 'continuous' ? `continuous:${layout.maxWidth}` : `paginated:${layout.pageWidth}`;
+}
 
-    const anchor = this.#createZoomAnchorFromClient(clientX, clientY);
-    await this.#setZoomWithAnchor(nextZoom, anchor);
+function normalizeTimestamp(timestampMs: number): number {
+  return Number.isFinite(timestampMs) ? timestampMs : nowMilliseconds();
+}
+
+function instantaneousLogZoomVelocity(
+  previousZoom: number,
+  zoom: number,
+  previousTimestampMs: number | undefined,
+  timestampMs: number,
+): number {
+  if (!Number.isFinite(previousZoom) || previousZoom <= 0 || !Number.isFinite(zoom) || zoom <= 0) return Infinity;
+  if (zoomEquals(previousZoom, zoom)) return 0;
+  if (previousTimestampMs === undefined) return Infinity;
+  const elapsedSeconds = (timestampMs - previousTimestampMs) / 1000;
+  return Number.isFinite(elapsedSeconds) && elapsedSeconds > 0 ? Math.log(zoom / previousZoom) / elapsedSeconds : Infinity;
+}
+
+function resolveDirectSnapZoom(zoom: number, layout: DocumentZoomLayout, viewportWidth: number): number | null {
+  const resolvedViewportWidth = viewportWidth > 0 ? viewportWidth : 1;
+  const bounds = computeDocumentZoomBounds(layout);
+  if (!Number.isFinite(zoom) || zoom < bounds.min || zoom > bounds.max) return null;
+  const candidate = clampDocumentLayoutZoom({ zoom, layout, viewportWidth: resolvedViewportWidth });
+  const fitWidthZoom = computeDocumentFitWidthZoom(layout, resolvedViewportWidth);
+  const unitZoom = clampDocumentZoom(1, bounds);
+  return zoomEquals(candidate, fitWidthZoom) || zoomEquals(candidate, unitZoom) ? candidate : null;
+}
+
+function nowMilliseconds(): number {
+  return globalThis.performance?.now() ?? Date.now();
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function requestZoomAnimationFrame(callback: (timestampMs: number) => void): () => void {
+  if (typeof requestAnimationFrame === 'function') {
+    const id = requestAnimationFrame(callback);
+    return () => cancelAnimationFrame(id);
   }
-
-  commitRenderZoom(): void {
-    this.#resetWheelRawZoom();
-    this.#scheduleRenderZoom(true);
-  }
+  const id = setTimeout(() => callback(nowMilliseconds()), 16);
+  return () => clearTimeout(id);
 }

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
@@ -5,6 +5,7 @@ import {
   RENDER_ZOOM_SCALE_RATIO_THRESHOLD,
 } from '$lib/editor-ffi/zoom';
 import { EditorZoomController } from './editor-zoom.svelte';
+import type { ScrollViewport } from '@typie/ui/utils';
 import type { Editor } from '$lib/editor-ffi/editor.svelte';
 import type { DocumentZoomLayout } from '$lib/editor-ffi/zoom';
 
@@ -56,14 +57,15 @@ describe('EditorZoomController continuous timing', () => {
     expect(controller.renderZoom).toBe(0.9);
   });
 
-  it('commits continuous render zoom immediately at gesture end', () => {
+  it('commits continuous render zoom immediately at gesture end', async () => {
     vi.useFakeTimers();
     const controller = createController({ type: 'continuous', maxWidth: 600 });
 
-    controller.setZoom(0.8);
-    controller.commitRenderZoom();
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 0.9, 0, 0, 16);
+    await controller.releaseDirectZoom('touch');
 
-    expect(controller.renderZoom).toBe(0.8);
+    expect(controller.renderZoom).toBe(0.9);
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -130,14 +132,15 @@ describe('EditorZoomController continuous timing', () => {
     expect(controller.renderZoom).toBe(0.95);
   });
 
-  it('defers a gesture-end commit until the minimum interval after an intermediate commit', () => {
+  it('defers a gesture-end commit until the minimum interval after an intermediate commit', async () => {
     vi.useFakeTimers();
     const controller = createController({ type: 'continuous', maxWidth: 600 });
 
     controller.setZoom(1 / RENDER_ZOOM_SCALE_RATIO_THRESHOLD);
     const firstRenderZoom = controller.renderZoom;
-    controller.setZoom(1.1);
-    controller.commitRenderZoom();
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 1.1, 0, 0, 16);
+    await controller.releaseDirectZoom('touch');
 
     expect(controller.renderZoom).toBe(firstRenderZoom);
 
@@ -179,6 +182,164 @@ afterEach(() => {
   }
   controllers.length = 0;
   vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('EditorZoomController direct zoom detents', () => {
+  it('snaps slow direct input while keeping the raw gesture free to continue', async () => {
+    const controller = createController();
+    controller.setZoom(0.95, { commitRender: true });
+
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 0.99, 0, 0, 250);
+
+    expect(controller.displayZoom).toBe(1);
+
+    await controller.updateDirectZoom('touch', 0.97, 0, 0, 500);
+
+    expect(controller.displayZoom).toBe(0.97);
+  });
+
+  it('lets fast direct input cross a snap point without capture', async () => {
+    const controller = createController();
+    controller.setZoom(0.95, { commitRender: true });
+
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 0.99, 0, 0, 50);
+
+    expect(controller.displayZoom).toBe(0.99);
+  });
+
+  it('does not assume the first wheel event is slow without a timing baseline', async () => {
+    const controller = createController();
+    controller.setZoom(0.95, { commitRender: true });
+
+    await controller.handleWheel(
+      wheelEvent({
+        metaKey: true,
+        deltaY: -240 * Math.log(0.99 / 0.95),
+        timeStamp: 0,
+      }),
+    );
+
+    expect(controller.displayZoom).toBeCloseTo(0.99);
+  });
+
+  it('stays settled when direct input is released on a detent', async () => {
+    const controller = createController();
+    controller.setZoom(0.95, { commitRender: true });
+
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 0.99, 0, 0, 250);
+    await controller.releaseDirectZoom('touch');
+
+    expect(controller.displayZoom).toBe(1);
+    expect(controller.hasActiveMotion).toBe(false);
+  });
+
+  it('keeps overzoom elastic when the fit detent equals the hard bound', async () => {
+    const controller = createController({ type: 'continuous', maxWidth: 400 });
+    controller.setZoom(2, { commitRender: true });
+
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 2.2, 0, 0, 250);
+
+    expect(controller.displayZoom).toBeGreaterThan(2);
+    expect(controller.displayZoom).toBeLessThan(2.2);
+  });
+
+  it('settles overzoom immediately when reduced motion is requested', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: true })),
+    );
+    const controller = createController({ type: 'continuous', maxWidth: 400 });
+    controller.setZoom(2, { commitRender: true });
+
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 2.2, 0, 0, 16);
+    expect(controller.displayZoom).toBeGreaterThan(2);
+
+    await controller.releaseDirectZoom('touch');
+
+    expect(controller.displayZoom).toBe(2);
+    expect(controller.hasActiveMotion).toBe(false);
+  });
+
+  it('settles tiny overzoom at the exact bound', async () => {
+    vi.useFakeTimers();
+    const controller = createController({ type: 'continuous', maxWidth: 400 });
+    controller.setZoom(2, { commitRender: true });
+
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 2.001, 0, 0, 250);
+    expect(controller.displayZoom).toBeGreaterThan(2);
+
+    await controller.releaseDirectZoom('touch');
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(controller.displayZoom).toBe(2);
+    expect(controller.hasActiveMotion).toBe(false);
+  });
+
+  it('stops at the released in-range zoom', async () => {
+    vi.useFakeTimers();
+    const scrollBy = vi.fn();
+    const viewport = {
+      getRect: () => ({ left: 0, top: 0, right: 1000, bottom: 1000 }),
+      scrollBy,
+    };
+    const editor = {
+      clientToLocal: vi.fn(() => ({ page: 0, x: 100, y: 100 })),
+      pageSizes: [{ width: 1000, height: 1000 }],
+      pageEls: [{ getBoundingClientRect: () => ({ left: 0, top: 0 }) }],
+    } as unknown as Editor;
+    const controller = new EditorZoomController({
+      editor,
+      layout: () => defaultLayout,
+      viewportWidth: () => 1000,
+      getScrollViewport: () => viewport as unknown as ScrollViewport,
+    });
+    controllers.push(controller);
+
+    expect(controller.beginDirectZoom('touch', 100, 100, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 1.1, 120, 100, 16);
+    await controller.updateDirectZoom('touch', 1.2, 140, 100, 32);
+    const scrollCallsAtRelease = scrollBy.mock.calls.length;
+    await controller.releaseDirectZoom('touch');
+    await vi.advanceTimersByTimeAsync(17);
+
+    expect(controller.displayZoom).toBe(1.2);
+    expect(controller.hasActiveMotion).toBe(false);
+    expect(scrollBy).toHaveBeenCalledTimes(scrollCallsAtRelease);
+  });
+
+  it('drops a queued zoom anchor as soon as direct pan interrupts', async () => {
+    const scrollBy = vi.fn();
+    const viewport = {
+      getRect: () => ({ left: 0, top: 0, right: 1000, bottom: 1000 }),
+      scrollBy,
+    };
+    const editor = {
+      clientToLocal: vi.fn(() => ({ page: 0, x: 100, y: 100 })),
+      pageSizes: [{ width: 1000, height: 1000 }],
+      pageEls: [{ getBoundingClientRect: () => ({ left: 0, top: 0 }) }],
+    } as unknown as Editor;
+    const controller = new EditorZoomController({
+      editor,
+      layout: () => defaultLayout,
+      viewportWidth: () => 1000,
+      getScrollViewport: () => viewport as unknown as ScrollViewport,
+    });
+    controllers.push(controller);
+
+    expect(controller.beginDirectZoom('touch', 100, 100, 0)).toBe(true);
+    const pendingUpdate = controller.updateDirectZoom('touch', 1.2, 100, 100, 16);
+    controller.interruptForDirectPan();
+    await pendingUpdate;
+
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
 });
 
 describe('EditorZoomController.handleWheel', () => {
@@ -203,6 +364,36 @@ describe('EditorZoomController.handleWheel', () => {
 
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(controller.displayZoom).toBe(1);
+  });
+
+  it('does not retain the zoom anchor when an unmodified wheel starts panning', async () => {
+    vi.useFakeTimers();
+    const scrollBy = vi.fn();
+    const viewport = {
+      getRect: () => ({ left: 0, top: 0, right: 1000, bottom: 1000 }),
+      scrollBy,
+    };
+    const editor = {
+      clientToLocal: vi.fn(() => ({ page: 0, x: 100, y: 100 })),
+      pageSizes: [{ width: 1000, height: 1000 }],
+      pageEls: [{ getBoundingClientRect: () => ({ left: 0, top: 0 }) }],
+    } as unknown as Editor;
+    const controller = new EditorZoomController({
+      editor,
+      layout: () => ({ type: 'continuous', maxWidth: 400 }),
+      viewportWidth: () => 1000,
+      getScrollViewport: () => viewport as unknown as ScrollViewport,
+    });
+    controllers.push(controller);
+    controller.setZoom(2, { commitRender: true });
+
+    await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -20 }));
+    const scrollCallsBeforePan = scrollBy.mock.calls.length;
+    await controller.handleWheel(wheelEvent({ deltaY: 20, timeStamp: 16 }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(controller.displayZoom).toBe(2);
+    expect(scrollBy).toHaveBeenCalledTimes(scrollCallsBeforePan);
   });
 
   it.each([
@@ -251,22 +442,40 @@ describe('EditorZoomController.handleWheel', () => {
     expect(controller.displayZoom).toBeGreaterThan(1);
   });
 
-  it('rebases tiny wheel zoom after the quiet timeout', async () => {
+  it('commits the final render zoom after wheel input settles', async () => {
+    vi.useFakeTimers();
+    const controller = createController();
+
+    for (let index = 0; index < 6; index += 1) {
+      await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: index < 4 ? 8 : -8, timeStamp: index * 16 }));
+    }
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(controller.renderZoom).toBeCloseTo(controller.displayZoom);
+    expect(controller.hasActiveMotion).toBe(false);
+  });
+
+  it('settles a tiny wheel burst before the next burst starts', async () => {
     vi.useFakeTimers();
     const controller = createController();
 
     await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -3 }));
-    vi.advanceTimersByTime(EditorZoomController.WHEEL_RAW_ZOOM_RESET_MS);
+    expect(controller.hasActiveDirectZoom).toBe(true);
+    await vi.advanceTimersByTimeAsync(400);
+    expect(controller.displayZoom).toBe(1);
+    expect(controller.hasActiveDirectZoom).toBe(false);
+
     await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -3, timeStamp: EditorZoomController.WHEEL_RAW_ZOOM_RESET_MS }));
 
     expect(controller.displayZoom).toBe(1);
+    expect(controller.hasActiveDirectZoom).toBe(true);
   });
 
   it('cancels the raw wheel zoom reset when zoom is set programmatically', async () => {
     vi.useFakeTimers();
     const controller = createController();
     await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -3 }));
-    expect(vi.getTimerCount()).toBe(1);
+    expect(vi.getTimerCount()).toBeGreaterThanOrEqual(1);
 
     controller.setZoom(1, { commitRender: true });
 
@@ -277,7 +486,7 @@ describe('EditorZoomController.handleWheel', () => {
     vi.useFakeTimers();
     const controller = createController();
     await controller.handleWheel(wheelEvent({ metaKey: true, deltaY: -3 }));
-    expect(vi.getTimerCount()).toBe(1);
+    expect(vi.getTimerCount()).toBeGreaterThanOrEqual(1);
 
     controller.destroy();
 
@@ -304,7 +513,8 @@ describe('EditorZoomController.handleWheel', () => {
     await controller.handleWheel(event);
 
     expect(event.preventDefault).toHaveBeenCalledOnce();
-    expect(controller.displayZoom).toBe(2);
+    expect(controller.displayZoom).toBeGreaterThan(2);
+    expect(controller.displayZoom).toBeLessThan(2.1);
   });
 
   it('zooms from a non-cancelable modified event without preventing default', async () => {

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { IS_MAC } from '$lib/editor-ffi/constants';
+  import { resolveDocumentZoomIndicator } from '$lib/editor-ffi/zoom';
   import { EditorZoomController } from '../editor-zoom.svelte';
   import ZoomOverlay from './ZoomOverlay.svelte';
   import type { Snippet } from 'svelte';
@@ -25,12 +26,16 @@
     zoom: number;
     clientX: number;
     clientY: number;
+    timestampMs: number;
   };
+
+  type PinchContact = Pick<Touch, 'clientX' | 'clientY'>;
 
   let { editor, active = true, layout, viewportWidth, attachViewportAnchor, children }: Props = $props();
 
   let pinchSession = $state<PinchSession | null>(null);
   let pinchQueuedUpdate = $state<PinchUpdate | null>(null);
+  let suppressPinchUntilAllUp = false;
   let pinchFlushPromise: Promise<void> | null = null;
   const scrollContainer = $derived(editor.scrollContainerEl);
 
@@ -45,6 +50,7 @@
   const zoomEnabled = $derived(layout !== null);
   const displayZoom = $derived(zoomEnabled ? zoom.displayZoom : 1);
   const renderZoom = $derived(zoomEnabled ? zoom.renderZoom : 1);
+  const indicatorZoom = $derived(layout ? resolveDocumentZoomIndicator(displayZoom, layout) : 1);
 
   $effect(() => {
     editor.displayZoom = displayZoom;
@@ -112,11 +118,11 @@
     }
   };
 
-  function isTouchOnPage(touch: Touch): boolean {
+  function isTouchOnPage(touch: PinchContact): boolean {
     return editor.clientToLocal(touch.clientX, touch.clientY) !== null;
   }
 
-  function touchDistance(t1: Touch, t2: Touch): number {
+  function touchDistance(t1: PinchContact, t2: PinchContact): number {
     return Math.hypot(t1.clientX - t2.clientX, t1.clientY - t2.clientY);
   }
 
@@ -131,32 +137,36 @@
     while (pinchQueuedUpdate) {
       const next = pinchQueuedUpdate;
       pinchQueuedUpdate = null;
-      await zoom.zoomToClientPoint(next.zoom, next.clientX, next.clientY);
+      await zoom.updateDirectZoom('touch', next.zoom, next.clientX, next.clientY, next.timestampMs);
     }
   }
 
-  async function commitPinchZoom(): Promise<void> {
+  async function finishPinchZoom(): Promise<void> {
     await pinchFlushPromise;
-    zoom.commitRenderZoom();
+    await zoom.releaseDirectZoom('touch');
   }
 
-  function tryStartPinch(touches: TouchList): boolean {
-    if (!zoomEnabled || touches.length !== 2) {
-      return false;
-    }
+  function cancelPinchAndSuppressUntilAllUp(remainingTouches: number): void {
+    pinchSession = null;
+    pinchQueuedUpdate = null;
+    suppressPinchUntilAllUp = remainingTouches > 0;
+    zoom.cancelDirectZoom('touch');
+  }
 
-    const t1 = touches.item(0);
-    const t2 = touches.item(1);
-    if (!t1 || !t2) {
-      return false;
-    }
-
+  function tryStartPinchWithContacts(t1: PinchContact, t2: PinchContact, timestampMs: number): boolean {
+    if (!zoomEnabled) return false;
     if (!isTouchOnPage(t1) || !isTouchOnPage(t2)) {
       return false;
     }
 
     const startDistance = touchDistance(t1, t2);
     if (!Number.isFinite(startDistance) || startDistance <= 0) {
+      return false;
+    }
+
+    const clientX = (t1.clientX + t2.clientX) / 2;
+    const clientY = (t1.clientY + t2.clientY) / 2;
+    if (!zoom.beginDirectZoom('touch', clientX, clientY, timestampMs)) {
       return false;
     }
 
@@ -168,20 +178,46 @@
     return true;
   }
 
+  function tryStartPinch(touches: TouchList, timestampMs: number): boolean {
+    if (touches.length !== 2) return false;
+    const t1 = touches.item(0);
+    const t2 = touches.item(1);
+    return t1 !== null && t2 !== null && tryStartPinchWithContacts(t1, t2, timestampMs);
+  }
+
   function handleTouchStartForPinch(event: TouchEvent): void {
-    if (pinchSession || !zoomEnabled || event.touches.length !== 2) {
+    if (!zoomEnabled) {
       return;
     }
 
-    tryStartPinch(event.touches);
+    if (suppressPinchUntilAllUp) return;
+
+    if (pinchSession && event.touches.length > 2) {
+      cancelPinchAndSuppressUntilAllUp(event.touches.length);
+      return;
+    }
+
+    if (event.touches.length === 1) {
+      zoom.interruptForDirectPan();
+      return;
+    }
+
+    if (pinchSession || event.touches.length !== 2) return;
+
+    tryStartPinch(event.touches, event.timeStamp);
   }
 
   function handleTouchMoveForPinch(event: TouchEvent): void {
+    if (suppressPinchUntilAllUp) {
+      if (event.cancelable) event.preventDefault();
+      return;
+    }
+
     if (!zoomEnabled || event.touches.length !== 2) {
       return;
     }
 
-    if (!pinchSession && !tryStartPinch(event.touches)) {
+    if (!pinchSession && !tryStartPinch(event.touches, event.timeStamp)) {
       return;
     }
 
@@ -204,25 +240,29 @@
       zoom: pinchSession.startZoom * (distance / pinchSession.startDistance),
       clientX: (t1.clientX + t2.clientX) / 2,
       clientY: (t1.clientY + t2.clientY) / 2,
+      timestampMs: event.timeStamp,
     });
   }
 
   function handleTouchEndForPinch(event: TouchEvent): void {
-    if (event.touches.length < 2) {
-      pinchSession = null;
-      void commitPinchZoom();
+    if (suppressPinchUntilAllUp) {
+      if (event.touches.length === 0) suppressPinchUntilAllUp = false;
       return;
     }
 
-    if (event.touches.length === 2) {
-      pinchSession = null;
-      tryStartPinch(event.touches);
+    if (!pinchSession) return;
+    if (event.touches.length >= 2) {
+      cancelPinchAndSuppressUntilAllUp(event.touches.length);
+      return;
     }
+
+    pinchSession = null;
+    suppressPinchUntilAllUp = event.touches.length > 0;
+    void finishPinchZoom();
   }
 
-  function handleTouchCancelForPinch(): void {
-    pinchSession = null;
-    void commitPinchZoom();
+  function handleTouchCancelForPinch(event: TouchEvent): void {
+    cancelPinchAndSuppressUntilAllUp(event.touches.length);
   }
 
   $effect(() => {
@@ -241,8 +281,8 @@
     const handleTouchEnd = (event: Event) => {
       handleTouchEndForPinch(event as TouchEvent);
     };
-    const handleTouchCancel = () => {
-      handleTouchCancelForPinch();
+    const handleTouchCancel = (event: Event) => {
+      handleTouchCancelForPinch(event as TouchEvent);
     };
 
     target.addEventListener('wheel', handleWheelForZoom, { capture: true, passive: false });
@@ -252,6 +292,10 @@
     target.addEventListener('touchcancel', handleTouchCancel, { passive: true });
 
     return () => {
+      pinchSession = null;
+      pinchQueuedUpdate = null;
+      suppressPinchUntilAllUp = false;
+      zoom.cancelDirectZoom('touch');
       target.removeEventListener('wheel', handleWheelForZoom, { capture: true });
       target.removeEventListener('touchstart', handleTouchStart);
       target.removeEventListener('touchmove', handleTouchMove);
@@ -267,6 +311,8 @@
 
     pinchSession = null;
     pinchQueuedUpdate = null;
+    suppressPinchUntilAllUp = false;
+    zoom.cancelDirectZoom();
   });
 </script>
 
@@ -276,4 +322,4 @@
   {@render children?.()}
 </div>
 
-<ZoomOverlay {displayZoom} enabled={zoomEnabled} {scrollContainer} />
+<ZoomOverlay {displayZoom} enabled={zoomEnabled} {indicatorZoom} {scrollContainer} />

--- a/apps/website/src/lib/editor-ffi/components/ui/ZoomOverlay.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/ZoomOverlay.svelte
@@ -5,13 +5,14 @@
   type Props = {
     enabled: boolean;
     displayZoom: number;
+    indicatorZoom: number;
     scrollContainer?: HTMLElement;
   };
 
   const ZOOM_OVERLAY_VISIBLE_MS = 1000;
   const ZOOM_OVERLAY_FADE_MS = 180;
 
-  let { enabled, displayZoom, scrollContainer }: Props = $props();
+  let { enabled, displayZoom, indicatorZoom, scrollContainer }: Props = $props();
 
   let visible = $state(false);
   let hideTimer: ReturnType<typeof setTimeout> | null = null;
@@ -88,7 +89,7 @@
     };
   });
 
-  const zoomPercent = $derived(Math.round(displayZoom * 100));
+  const zoomPercent = $derived(Math.round(indicatorZoom * 100));
 </script>
 
 {#if enabled}

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -333,6 +333,16 @@ function dispatchEditorKey(editor: Editor, key: RepeatKey, init: KeyboardEventIn
   return beforeRevision;
 }
 
+function editorTouch(target: EventTarget, identifier: number, clientX: number, clientY: number): Touch {
+  return new Touch({ identifier, target, clientX, clientY });
+}
+
+function dispatchEditorTouch(target: HTMLElement, type: string, touches: Touch[]): TouchEvent {
+  const event = new TouchEvent(type, { touches, bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
 async function pressEditorKey(editor: Editor, key: 'Enter' | 'Backspace') {
   const beforeRevision = dispatchEditorKey(editor, key);
   await expect.poll(() => editor.appliedRevision).toBeGreaterThan(beforeRevision);
@@ -1324,7 +1334,7 @@ describe('web editor frame synchronization', () => {
       expectActualCanvas(editor, 0);
     }
 
-    await expect.poll(() => editor.renderZoom).toBeCloseTo(editor.displayZoom);
+    await expect.poll(() => Math.abs(editor.renderZoom - editor.displayZoom)).toBeLessThan(0.005);
     for (let frame = 0; frame < 60 && editor.published?.frames.get(0)?.canvas === displayed; frame += 1) {
       await nextAnimationFrame();
       const sample = readWebFrameSample(editor, scrollRoot, 0, 12 + frame, null);
@@ -1338,6 +1348,40 @@ describe('web editor frame synchronization', () => {
     expect(attachSurfaceSpy.mock.calls.filter(([page]) => page === 0).length).toBeGreaterThan(0);
     expect(editor.published?.frames.get(0)?.canvas.isConnected).toBe(true);
     expectActualCanvas(editor, 0);
+  });
+
+  it('stops zoom on the first pinch pointer release and keeps the survivor zoom-owned until all-up', async () => {
+    const { editor, scrollRoot } = await mountEditor(doc('touch zoom'), { withZoom: true });
+    await waitForPresentation(editor);
+    const pageRect = editor.pageEls[0]?.getBoundingClientRect();
+    if (!pageRect) throw new Error('Expected a mounted editor page');
+    const centerX = pageRect.left + pageRect.width / 2;
+    const centerY = pageRect.top + 60;
+
+    dispatchEditorTouch(scrollRoot, 'touchstart', [
+      editorTouch(scrollRoot, 0, centerX - 30, centerY),
+      editorTouch(scrollRoot, 1, centerX + 30, centerY),
+    ]);
+    await nextAnimationFrame();
+    const survivor = editorTouch(scrollRoot, 0, centerX - 36, centerY);
+    dispatchEditorTouch(scrollRoot, 'touchmove', [survivor, editorTouch(scrollRoot, 1, centerX + 36, centerY)]);
+    await nextAnimationFrame();
+    const zoomAtRelease = editor.displayZoom;
+
+    dispatchEditorTouch(scrollRoot, 'touchend', [survivor]);
+    const survivorMove = dispatchEditorTouch(scrollRoot, 'touchmove', [editorTouch(scrollRoot, 0, centerX - 38, centerY)]);
+
+    expect(survivorMove.defaultPrevented).toBe(true);
+    await nextAnimationFrame();
+    await nextAnimationFrame();
+    expect(editor.displayZoom).toBeCloseTo(zoomAtRelease);
+
+    dispatchEditorTouch(scrollRoot, 'touchend', []);
+    const nextTouch = editorTouch(scrollRoot, 2, centerX, centerY);
+    dispatchEditorTouch(scrollRoot, 'touchstart', [nextTouch]);
+    const nextMove = dispatchEditorTouch(scrollRoot, 'touchmove', [editorTouch(scrollRoot, 2, centerX, centerY + 2)]);
+    expect(nextMove.defaultPrevented).toBe(false);
+    dispatchEditorTouch(scrollRoot, 'touchend', []);
   });
 
   it('keeps the scrollbar thumb synchronized without showing scroll progress for zoom correction', async () => {

--- a/apps/website/src/lib/editor-ffi/zoom-motion.test.ts
+++ b/apps/website/src/lib/editor-ffi/zoom-motion.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { elasticDisplayZoom, ZOOM_ELASTIC_EXTENT_RATIO, ZoomMotion } from './zoom-motion';
+
+const bounds = { min: 0.2, max: 2 };
+
+describe('elasticDisplayZoom', () => {
+  it('preserves the normal range and compresses overzoom without a nearby second wall', () => {
+    expect(elasticDisplayZoom(1.5, bounds)).toBe(1.5);
+    expect(elasticDisplayZoom(2, bounds)).toBe(2);
+
+    const first = elasticDisplayZoom(2.1, bounds) ?? 0;
+    const second = elasticDisplayZoom(2.2, bounds) ?? 0;
+    expect(first).toBeGreaterThan(2);
+    expect(first).toBeLessThan(2.1);
+    expect(second).toBeGreaterThan(first);
+    expect(second).toBeLessThan(2.2);
+    expect(elasticDisplayZoom(100, bounds)).toBeLessThan(bounds.max * ZOOM_ELASTIC_EXTENT_RATIO);
+  });
+});
+
+describe('ZoomMotion', () => {
+  it('recovers direct overzoom to the normal bound', () => {
+    const motion = createMotion(2.08);
+
+    expect(motion.advance(1 / 60).displayZoom).toBeLessThan(2.08);
+    expect(motion.advance(1).displayZoom).toBe(2);
+  });
+
+  it('recovers direct underzoom to the normal bound', () => {
+    const motion = createMotion(0.18);
+
+    expect(motion.advance(1 / 60).displayZoom).toBeGreaterThan(0.18);
+    expect(motion.advance(1).displayZoom).toBe(0.2);
+  });
+});
+
+function createMotion(displayZoom: number): ZoomMotion {
+  return new ZoomMotion(displayZoom, bounds);
+}

--- a/apps/website/src/lib/editor-ffi/zoom-motion.ts
+++ b/apps/website/src/lib/editor-ffi/zoom-motion.ts
@@ -1,0 +1,83 @@
+export const ZOOM_ELASTIC_EXTENT_RATIO = 1.25;
+export const ZOOM_ELASTIC_RESISTANCE = 0.55;
+export const ZOOM_MAX_MOTION_SECONDS = 0.24;
+export const ZOOM_SPRING_ANGULAR_FREQUENCY = 24;
+export const ZOOM_SETTLE_EPSILON = 0.0005;
+
+export type ZoomMotionBounds = { min: number; max: number };
+
+export type ZoomMotionFrame = {
+  displayZoom: number;
+  finished: boolean;
+};
+
+export function elasticDisplayZoom(rawZoom: number, bounds: ZoomMotionBounds): number | null {
+  if (!isValidZoom(rawZoom) || !isValidBounds(bounds)) return null;
+
+  const rawLog = Math.log(rawZoom);
+  const minimumLog = Math.log(bounds.min);
+  const maximumLog = Math.log(bounds.max);
+  const elasticExtent = Math.log(ZOOM_ELASTIC_EXTENT_RATIO);
+  const displayLog =
+    rawLog > maximumLog
+      ? maximumLog + rubberBandDistance(rawLog - maximumLog, elasticExtent)
+      : rawLog < minimumLog
+        ? minimumLog - rubberBandDistance(minimumLog - rawLog, elasticExtent)
+        : rawLog;
+  return Math.exp(displayLog);
+}
+
+export class ZoomMotion {
+  #elapsedSeconds = 0;
+  #frame: ZoomMotionFrame;
+  #initialLogZoom: number;
+  #targetLogZoom: number;
+
+  constructor(displayZoom: number, bounds: ZoomMotionBounds) {
+    if (!isValidZoom(displayZoom) || !isValidBounds(bounds) || (displayZoom >= bounds.min && displayZoom <= bounds.max)) {
+      throw new Error('Zoom recovery requires an out-of-bounds display zoom');
+    }
+
+    this.#initialLogZoom = Math.log(displayZoom);
+    this.#targetLogZoom = Math.log(displayZoom < bounds.min ? bounds.min : bounds.max);
+    this.#frame = {
+      displayZoom,
+      finished: false,
+    };
+  }
+
+  #springLogZoom(elapsed: number): number {
+    const displacement = this.#initialLogZoom - this.#targetLogZoom;
+    const angularFrequency = ZOOM_SPRING_ANGULAR_FREQUENCY;
+    const decay = Math.exp(-angularFrequency * elapsed);
+    return this.#targetLogZoom + displacement * (1 + angularFrequency * elapsed) * decay;
+  }
+
+  #isSettled(logZoom: number): boolean {
+    return Math.abs(logZoom - this.#targetLogZoom) <= ZOOM_SETTLE_EPSILON;
+  }
+
+  advance(deltaSeconds: number): ZoomMotionFrame {
+    if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0 || this.#frame.finished) return this.#frame;
+    this.#elapsedSeconds += deltaSeconds;
+    const logZoom = this.#springLogZoom(this.#elapsedSeconds);
+    const finished = this.#elapsedSeconds >= ZOOM_MAX_MOTION_SECONDS || this.#isSettled(logZoom);
+    this.#frame = {
+      displayZoom: Math.exp(finished ? this.#targetLogZoom : logZoom),
+      finished,
+    };
+    return this.#frame;
+  }
+}
+
+function rubberBandDistance(distance: number, extent: number): number {
+  return (extent * ZOOM_ELASTIC_RESISTANCE * distance) / (extent + ZOOM_ELASTIC_RESISTANCE * distance);
+}
+
+function isValidZoom(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function isValidBounds(bounds: ZoomMotionBounds): boolean {
+  return isValidZoom(bounds.min) && isValidZoom(bounds.max) && bounds.max >= bounds.min;
+}

--- a/apps/website/src/lib/editor-ffi/zoom.test.ts
+++ b/apps/website/src/lib/editor-ffi/zoom.test.ts
@@ -5,6 +5,8 @@ import {
   computeDocumentZoomBounds,
   resolveContinuousLayoutViewportWidth,
   resolveContinuousViewPadding,
+  resolveDirectDocumentZoom,
+  resolveDocumentZoomIndicator,
 } from './zoom';
 
 describe('continuous document zoom policy', () => {
@@ -34,5 +36,16 @@ describe('continuous document zoom policy', () => {
     expect(resolveContinuousViewPadding(1.5)).toBe(30);
     expect(resolveContinuousViewPadding(0.5)).toBe(10);
     expect(resolveContinuousViewPadding(NaN)).toBe(20);
+  });
+
+  it('keeps snapping out of direct input and rubber bands past hard bounds', () => {
+    expect(resolveDirectDocumentZoom(0.79, layout)).toBe(0.79);
+    expect(resolveDirectDocumentZoom(2.2, layout)).toBeGreaterThan(2);
+    expect(resolveDirectDocumentZoom(2.2, layout)).toBeLessThan(2.2);
+  });
+
+  it('reports only the normal range to the zoom indicator', () => {
+    expect(resolveDocumentZoomIndicator(2.08, layout)).toBe(2);
+    expect(resolveDocumentZoomIndicator(0.1, layout)).toBe(computeDocumentZoomBounds(layout).min);
   });
 });

--- a/apps/website/src/lib/editor-ffi/zoom.ts
+++ b/apps/website/src/lib/editor-ffi/zoom.ts
@@ -1,5 +1,6 @@
 import { clamp } from '@typie/ui/utils';
 import { CONTINUOUS_VIEW_PADDING } from './constants';
+import { elasticDisplayZoom } from './zoom-motion';
 
 export const MIN_DOCUMENT_DISPLAY_WIDTH = 100;
 export const MAX_DOCUMENT_ZOOM = 2;
@@ -77,6 +78,15 @@ export function clampDocumentLayoutZoom({
   }
 
   return snapped ?? clamped;
+}
+
+export function resolveDirectDocumentZoom(zoom: number, layout: DocumentZoomLayout): number {
+  const bounds = computeDocumentZoomBounds(layout);
+  return elasticDisplayZoom(zoom, bounds) ?? bounds.min;
+}
+
+export function resolveDocumentZoomIndicator(displayZoom: number, layout: DocumentZoomLayout): number {
+  return clampDocumentZoom(displayZoom, computeDocumentZoomBounds(layout));
 }
 
 export function resolveContinuousLayoutViewportWidth({


### PR DESCRIPTION
## 요약

Web과 앱의 트랙패드 및 터치 직접 줌에서 최소·최대 배율에 닿는 감각을 탄성 있게 개선합니다.

## 변경 사항

- 직접 줌 입력이 정상 범위를 넘어가면 저항을 적용해 한계보다 약간 더 확대하거나 축소해 보여줍니다.
- 입력이 끝나면 오버슈트된 배율을 정확한 최소·최대 배율로 자연스럽게 복귀시킵니다.
- 줌 indicator에는 오버슈트된 값이 아닌 정상 범위의 배율을 표시합니다.
- 기존 스냅 지점은 유지하되, 느린 조절은 스냅되고 빠른 조절은 지점에 붙잡히지 않고 통과하도록 합니다.
- 앱에서는 오버슈트가 정상 범위로 복귀할 때 스냅과 동일한 햅틱 피드백을 제공합니다.
- 터치 핀치 중 한 손가락을 먼저 떼더라도 남은 손가락이 즉시 단일 포인터 스크롤로 전환되지 않도록 합니다.
- 줌 직후 pan을 시작할 때 이전 줌 초점 보정이 뒤늦게 스크롤에 개입하지 않도록 입력 소유권을 정리합니다.
- 직접 줌 중에도 렌더링 배율이 기존 debounce 주기에 따라 갱신되도록 해 표시 배율의 화질을 따라가게 합니다.
- 모션 감소 설정에서는 오버슈트 복귀를 즉시 완료합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>