### PR TITLE
웹 에디터 줌 + 포커스 시 캔버스 렌더링 수정

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/Page.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Page.svelte
@@ -48,6 +48,7 @@
     style:height={`${cssHeight}px`}
     style:transform={displayZoom === 1 ? undefined : `scale(${displayZoom})`}
     style:transform-origin={displayZoom === 1 ? undefined : 'top left'}
+    style:will-change={pagePresented && displayZoom !== 1 ? 'transform' : undefined}
     class={css({
       position: 'relative',
       isolation: 'isolate',


### PR DESCRIPTION
## 문제

웹 에디터를 100%가 아닌 배율로 표시할 때 본문을 클릭해 커서를 만들면 캔버스 전체의 텍스트가 다르게 렌더링되는 문제가 있었습니다.

캔버스 backing pixels는 포커스 전후 동일했지만, transform이 적용된 페이지의 화면 합성 결과가 포커스 시 변경되고 있었습니다.

## 변경

- 표시 중인 페이지가 100%가 아닌 배율로 transform될 때 `will-change: transform`을 적용했습니다.
- 표시되지 않는 페이지와 100% 배율에서는 적용하지 않아 compositor hint의 범위를 제한했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>