### PR TITLE
reduced motion 처리를 공용화

### DIFF
--- a/apps/desktop/src/renderer/chrome/TabStrip.svelte
+++ b/apps/desktop/src/renderer/chrome/TabStrip.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { entityIconMap, getEntityIconColor } from '@typie/ui/constants';
+  import { prefersReducedMotion } from '@typie/ui/state/reduced-motion';
   import { untrack } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
   import EllipsisIcon from '~icons/lucide/ellipsis';
@@ -14,7 +15,6 @@
 
   const isMac = window.shell.platform === 'darwin';
   const extraIcons = new Map([['file-x', FileXIcon]]);
-  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
   const CLOSE_MS = 160;
   const SETTLE_MIN_MS = 80;
   const SETTLE_MAX_MS = 200;
@@ -72,7 +72,7 @@
   $effect(() => {
     const ids = new Set(tabs.map((tab) => tab.id));
     const added = tabs.filter((tab) => !knownIds.has(tab.id));
-    if (knownIds.size > 0 && added.length === 1 && !reduceMotion.matches) {
+    if (knownIds.size > 0 && added.length === 1 && !prefersReducedMotion.current) {
       const id = added[0].id;
       entering = id;
       const sibling = tabs.find((tab) => tab.id !== id);
@@ -117,7 +117,7 @@
 
   const startClose = (id: string) => {
     if (!closable || closing.includes(id)) return;
-    if (reduceMotion.matches) {
+    if (prefersReducedMotion.current) {
       window.shell.closeTab?.(id);
       return;
     }
@@ -193,7 +193,7 @@
         if (drag?.id === id && drag.committed) releaseDrag();
       }, COMMIT_TIMEOUT_MS);
     };
-    if (reduceMotion.matches) {
+    if (prefersReducedMotion.current) {
       commit();
       return;
     }

--- a/apps/desktop/src/renderer/chrome/UpdateButton.svelte
+++ b/apps/desktop/src/renderer/chrome/UpdateButton.svelte
@@ -2,6 +2,7 @@
   // cspell:ignore onrestart
 
   import { css } from '@typie/styled-system/css';
+  import { prefersReducedMotion } from '@typie/ui/state/reduced-motion';
   import { cubicOut } from 'svelte/easing';
   import { fade, scale } from 'svelte/transition';
   import CircleArrowUpIcon from '~icons/lucide/circle-arrow-up';
@@ -9,9 +10,10 @@
   type Props = { onrestart: () => void };
   let { onrestart }: Props = $props();
 
-  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
   const enter = (node: Element) =>
-    reduceMotion.matches ? fade(node, { duration: 150 }) : scale(node, { duration: 180, start: 0.95, opacity: 0, easing: cubicOut });
+    prefersReducedMotion.current
+      ? fade(node, { duration: 150 })
+      : scale(node, { duration: 180, start: 0.95, opacity: 0, easing: cubicOut });
 </script>
 
 <button

--- a/apps/eval/src/routes/sessions/[id]/ConclusionDrawer.svelte
+++ b/apps/eval/src/routes/sessions/[id]/ConclusionDrawer.svelte
@@ -2,7 +2,7 @@
   import { css, cva } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { Icon } from '@typie/ui/components';
-  import { MediaQuery } from 'svelte/reactivity';
+  import { prefersReducedMotion } from '@typie/ui/state';
   import IconX from '~icons/lucide/x';
   import { anchorQuote } from '$lib/feedback/anchors.ts';
   import { VERDICT_POINTS, verdictLabel } from '$lib/feedback/verdicts.ts';
@@ -53,8 +53,6 @@
     onClose,
     onActivate,
   }: Props = $props();
-
-  const reducedMotion = new MediaQuery('(prefers-reduced-motion: reduce)', false);
 
   const understandingLines = $derived((conclusion.understanding ?? '').split('\n').filter((line) => line.trim().length > 0));
   // 진전 서술은 재리뷰 회차에만 온다 — 1회차·구 데이터는 필드가 없어 섹션 자체가 서지 않는다.
@@ -186,7 +184,7 @@
 
 <div class={css(rootRecipe.raw({ open }))} aria-hidden={!open} inert={!open}>
   <button
-    class={css(scrimRecipe.raw({ open, instant: reducedMotion.current }))}
+    class={css(scrimRecipe.raw({ open, instant: prefersReducedMotion.current }))}
     aria-label="총평 닫기"
     onclick={onClose}
     type="button"
@@ -223,7 +221,7 @@
     <span class={css({ fontSize: '10px', fontWeight: 'semibold', color: 'text.bright', letterSpacing: '[0.04em]' })}>ESC</span>
   </button>
 
-  <section class={css(drawerRecipe.raw({ open, instant: reducedMotion.current }))} aria-label="편집자의 총평">
+  <section class={css(drawerRecipe.raw({ open, instant: prefersReducedMotion.current }))} aria-label="편집자의 총평">
     <div
       class={flex({
         align: 'center',
@@ -264,7 +262,7 @@
 
     <div class={css({ flexGrow: '1', minHeight: '0', overflowY: 'auto' })}>
       <div
-        class={css(letterRecipe.raw({ open, instant: reducedMotion.current }), {
+        class={css(letterRecipe.raw({ open, instant: prefersReducedMotion.current }), {
           maxWidth: '660px',
           marginX: 'auto',
           paddingX: '20px',

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/MacOsMotionDurationScale.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/MacOsMotionDurationScale.kt
@@ -1,0 +1,91 @@
+package co.typie
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.MotionDurationScale
+import androidx.compose.ui.window.ApplicationScope
+import androidx.compose.ui.window.awaitApplication
+import com.sun.jna.NativeLibrary
+import com.sun.jna.Pointer
+import java.awt.AWTEvent
+import java.awt.Toolkit
+import java.awt.event.AWTEventListener
+import java.awt.event.WindowEvent
+import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
+
+internal fun runDesktopApplication(content: @Composable ApplicationScope.() -> Unit) {
+  val motionDurationScale = MacOsMotionDurationScale()
+  try {
+    runBlocking(motionDurationScale) { awaitApplication(content) }
+  } finally {
+    motionDurationScale.close()
+  }
+  exitProcess(0)
+}
+
+private class MacOsMotionDurationScale : MotionDurationScale, AutoCloseable {
+  private var durationScale by mutableFloatStateOf(resolveDurationScale())
+  private var listening = false
+  private val activationListener = AWTEventListener { event ->
+    if (event.id == WindowEvent.WINDOW_ACTIVATED) {
+      durationScale = resolveDurationScale()
+    }
+  }
+
+  override val scaleFactor: Float
+    get() = durationScale
+
+  init {
+    if (MacOsReducedMotion.isSupported) {
+      runCatching {
+          Toolkit.getDefaultToolkit()
+            .addAWTEventListener(activationListener, AWTEvent.WINDOW_EVENT_MASK)
+        }
+        .onSuccess { listening = true }
+    }
+  }
+
+  override fun close() {
+    if (!listening) return
+    runCatching { Toolkit.getDefaultToolkit().removeAWTEventListener(activationListener) }
+    listening = false
+  }
+
+  private fun resolveDurationScale(): Float =
+    if (MacOsReducedMotion.shouldReduceMotion()) 0f else 1f
+}
+
+private object MacOsReducedMotion {
+  val isSupported: Boolean = System.getProperty("os.name").startsWith("Mac", ignoreCase = true)
+
+  fun shouldReduceMotion(): Boolean {
+    if (!isSupported) return false
+
+    return runCatching {
+        NativeLibrary.getInstance("AppKit")
+        val objectiveC = NativeLibrary.getInstance("objc")
+        val getClass = objectiveC.getFunction("objc_getClass")
+        val registerSelector = objectiveC.getFunction("sel_registerName")
+        val sendMessage = objectiveC.getFunction("objc_msgSend")
+        fun selector(name: String) =
+          registerSelector.invoke(Pointer::class.java, arrayOf(name)) as Pointer
+
+        val workspaceClass =
+          getClass.invoke(Pointer::class.java, arrayOf("NSWorkspace")) as? Pointer
+            ?: return@runCatching false
+        val workspace =
+          sendMessage.invoke(
+            Pointer::class.java,
+            arrayOf(workspaceClass, selector("sharedWorkspace")),
+          ) as? Pointer ?: return@runCatching false
+
+        sendMessage.invokeInt(
+          arrayOf(workspace, selector("accessibilityDisplayShouldReduceMotion"))
+        ) != 0
+      }
+      .getOrDefault(false)
+  }
+}

--- a/apps/mobile/compose/src/desktopMain/kotlin/co/typie/Main.kt
+++ b/apps/mobile/compose/src/desktopMain/kotlin/co/typie/Main.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
-import androidx.compose.ui.window.application
 import co.typie.dev.DesktopDebugKeyboard
 import co.typie.dev.NetworkPreset
 import co.typie.dev.NetworkSimulator
@@ -142,7 +141,7 @@ fun main() {
     prefs.getBoolean("hardwareKeyboardConnected", false)
   )
 
-  application {
+  runDesktopApplication {
     var usePhysicalScale by remember { mutableStateOf(preferPhysical) }
     val windowState = remember {
       WindowState(size = if (preferPhysical) physicalSize else pointAccurateSize)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorScrollbarsDesktopTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -120,6 +121,43 @@ class EditorScrollbarsDesktopTest {
 
     onNodeWithText("60%").assertDoesNotExist()
   }
+
+  @Test
+  fun zeroMotionScaleSettlesTheIndicatorWithoutShorteningItsDwell() =
+    runComposeUiTest(effectContext = TestMotionDurationScale(0f)) {
+      mainClock.autoAdvance = false
+      val viewportState = EditorViewportState()
+
+      setContent {
+        CompositionLocalProvider(LocalAppColors provides LightColors) {
+          ScrollbarLayoutFrame(
+            viewportState = viewportState,
+            contentSize = Size(width = 100f, height = 300f),
+          ) {
+            EditorScrollbars(
+              viewportState = viewportState,
+              visibleArea = VisibleArea,
+              layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 100f),
+              pageSizes = emptyList(),
+              displayZoom = 1f,
+              modifier = Modifier.fillMaxSize(),
+            )
+          }
+        }
+      }
+      mainClock.advanceTimeByFrame()
+
+      runOnIdle { viewportState.scrollToY(100f) }
+      mainClock.advanceTimeByFrame()
+      onNodeWithText("50%").assertIsDisplayed()
+
+      mainClock.advanceTimeBy(299L)
+      onNodeWithText("50%").assertIsDisplayed()
+
+      mainClock.advanceTimeBy(1L)
+      mainClock.advanceTimeByFrame()
+      onNodeWithText("50%").assertDoesNotExist()
+    }
 
   @Test
   fun remeasurementResolvesBothAxisReservationsFromOneFrame() = runComposeUiTest {
@@ -329,6 +367,8 @@ class EditorScrollbarsDesktopTest {
     const val VerticalThumbTag = "vertical-scrollbar-thumb"
     val VisibleArea = EditorVisibleArea(viewport = Size(width = 100f, height = 100f))
   }
+
+  private class TestMotionDurationScale(override val scaleFactor: Float) : MotionDurationScale
 }
 
 @Composable

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/skeleton/SkeletonDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/skeleton/SkeletonDesktopTest.kt
@@ -1,0 +1,72 @@
+package co.typie.ui.skeleton
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.MotionDurationScale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SkeletonDesktopTest {
+  @Test
+  fun motionScaleStopsAndRestartsTheSkeletonShimmer() {
+    val motionScale = TestMotionDurationScale(1f)
+
+    runComposeUiTest(effectContext = motionScale) {
+      mainClock.autoAdvance = false
+      setContent {
+        Skeleton(
+          enabled = true,
+          colors = SkeletonColors(bone = Color.Red, highlight = Color.Blue),
+        ) {
+          SkeletonBone(Modifier.size(40.dp).testTag(SkeletonTag), RectangleShape)
+        }
+      }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeByFrame()
+
+      val animatedStart = onNodeWithTag(SkeletonTag).captureToImage().centerColor()
+      mainClock.advanceTimeBy(200L)
+      val animatedEnd = onNodeWithTag(SkeletonTag).captureToImage().centerColor()
+      assertNotEquals(animatedStart, animatedEnd)
+
+      runOnIdle { motionScale.scaleFactor = 0f }
+      mainClock.advanceTimeByFrame()
+      val reducedStart = onNodeWithTag(SkeletonTag).captureToImage().centerColor()
+      mainClock.advanceTimeBy(400L)
+      val reducedEnd = onNodeWithTag(SkeletonTag).captureToImage().centerColor()
+      assertEquals(reducedStart, reducedEnd)
+
+      runOnIdle { motionScale.scaleFactor = 1f }
+      mainClock.advanceTimeByFrame()
+      val resumedStart = onNodeWithTag(SkeletonTag).captureToImage().centerColor()
+      mainClock.advanceTimeBy(200L)
+      val resumedEnd = onNodeWithTag(SkeletonTag).captureToImage().centerColor()
+      assertNotEquals(resumedStart, resumedEnd)
+    }
+  }
+
+  private class TestMotionDurationScale(initialScaleFactor: Float) : MotionDurationScale {
+    override var scaleFactor by mutableFloatStateOf(initialScaleFactor)
+  }
+
+  private companion object {
+    const val SkeletonTag = "skeleton"
+  }
+}
+
+private fun androidx.compose.ui.graphics.ImageBitmap.centerColor(): Color =
+  toPixelMap()[width / 2, height / 2]

--- a/apps/website/src/lib/editor-ffi/components/Scrollbar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Scrollbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { pointerCapture } from '@typie/ui/actions';
+  import { prefersReducedMotion } from '@typie/ui/state';
   import { untrack } from 'svelte';
   import { getEditorContext } from '../editor.svelte';
   import type { Size } from '@typie/editor-ffi/browser';
@@ -258,12 +259,14 @@
     style:left={!isVertical && containerRect ? `${containerRect.left}px` : undefined}
     style:height={isVertical && containerRect ? `${containerRect.height - (x.canScroll ? 12 : 0)}px` : '12px'}
     style:width={!isVertical && containerRect ? `${containerRect.width - (y.canScroll ? 12 : 0)}px` : '12px'}
+    style:transition-duration={prefersReducedMotion.current ? '0ms' : undefined}
     class={css({
       pointerEvents: 'auto',
       position: 'fixed',
       zIndex: '10',
       transition: 'opacity',
       transitionDuration: '300ms',
+      _motionReduce: { transitionDuration: '0ms' },
       opacity: isVisible || isDraggingThis ? (isUserMode ? '100' : '65') : '0',
     })}
     aria-controls="scroll-content"
@@ -290,6 +293,7 @@
       style:bottom={isVertical ? undefined : '2px'}
       style:height={isVertical ? `${geometry.thumbSize}px` : '8px'}
       style:width={isVertical ? '8px' : `${geometry.thumbSize}px`}
+      style:transition-duration={prefersReducedMotion.current ? '0ms' : undefined}
       class={css({
         position: 'absolute',
         cursor: 'pointer',
@@ -304,6 +308,7 @@
             : 'surface.inverse/22',
         _hover: { backgroundColor: 'surface.inverse/80' },
         _active: { backgroundColor: 'surface.inverse/80' },
+        _motionReduce: { transition: '[none]' },
       })}
       aria-valuemax={geometry.maxScroll}
       aria-valuemin={0}
@@ -324,6 +329,7 @@
   <div
     style:top="{indicatorTop}px"
     style:right="{indicatorRight}px"
+    style:transition-duration={prefersReducedMotion.current ? '0ms' : undefined}
     class={css({
       pointerEvents: 'none',
       position: 'fixed',
@@ -338,6 +344,7 @@
       fontVariantNumeric: 'tabular-nums',
       transition: 'opacity',
       transitionDuration: '300ms',
+      _motionReduce: { transitionDuration: '0ms' },
       opacity: isVisible && isUserMode ? '100' : '0',
     })}
   >

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -1,4 +1,5 @@
 import { tryAppContext } from '@typie/ui/context';
+import { prefersReducedMotion } from '@typie/ui/state';
 import { untrack } from 'svelte';
 import { CURSOR_VISIBLE_MARGIN, PAGE_GAP } from './constants';
 import { pageRectsToRevealTargetSpan, resolveCachedPageSpans, roundToScale, selectionHeadRect } from './geometry';
@@ -93,12 +94,8 @@ function sanitizeTypewriterPosition(position: number | undefined): number {
   return typeof position === 'number' && Number.isFinite(position) ? Math.max(0, Math.min(1, position)) : 0.5;
 }
 
-function prefersReducedMotion(): boolean {
-  return globalThis.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
-}
-
 export function isInstantReveal(request: Pick<EditorBringIntoViewRequest, 'behavior'> | null): boolean {
-  return request !== null && (request.behavior === 'instant' || (request.behavior === 'smooth' && prefersReducedMotion()));
+  return request !== null && (request.behavior === 'instant' || (request.behavior === 'smooth' && prefersReducedMotion.current));
 }
 
 function createBringIntoViewRequest({ target, policy, behavior = 'instant' }: EditorScrollIntoViewOptions): EditorBringIntoViewRequest {

--- a/apps/website/src/lib/note/NotePresence.svelte
+++ b/apps/website/src/lib/note/NotePresence.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { prefersReducedMotion } from '@typie/ui/state';
   import { onDestroy } from 'svelte';
   import type { Snippet } from 'svelte';
   import type { NotePresence } from './note-list-state.svelte';
@@ -37,7 +38,7 @@
     let exitTimer: ReturnType<typeof setTimeout> | null = null;
     let completionTimer: ReturnType<typeof setTimeout> | null = null;
     let cancelled = false;
-    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    const reducedMotion = prefersReducedMotion.current;
 
     transitioning = null;
 

--- a/apps/website/src/lib/reduced-motion-presentations-test-root.svelte
+++ b/apps/website/src/lib/reduced-motion-presentations-test-root.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import { Scrollbar } from '@typie/ui/components';
+  import { setupAppContext } from '@typie/ui/context';
+  import { setupPaneGroup } from '../routes/website/(dashboard)/[slug]/@pane/context.svelte';
+  import PaneSkeleton from '../routes/website/(dashboard)/[slug]/@pane/PaneSkeleton.svelte';
+  import EditorScrollbar from './editor-ffi/components/Scrollbar.svelte';
+  import { setupEditorContext } from './editor-ffi/editor.svelte';
+  import type { Pane } from '../routes/website/(dashboard)/[slug]/@pane/types';
+  import type { Editor } from './editor-ffi/editor.svelte';
+  import type { EditorScrollScope } from './editor-ffi/scroll.svelte';
+
+  const app = setupAppContext('reduced-motion-presentations-test');
+  app.preference.current.defaultPrimaryToolbar = 'insert';
+
+  const paneGroup = setupPaneGroup('reduced-motion-presentations-test', {
+    userId: 'reduced-motion-presentations-test',
+    navigate: () => null,
+    onSiteChange: () => null,
+  });
+  const entityPane: Pane = { id: 'entity-pane', type: 'pane', kind: 'entity', slug: 'document' };
+  const homePane: Pane = { id: 'home-pane', type: 'pane', kind: 'home' };
+  paneGroup.state.current.toolbarExpandedByPaneId[entityPane.id] = false;
+
+  const editorContext = setupEditorContext();
+  let sharedScrollContainer = $state<HTMLDivElement>();
+  let editorScrollContainer = $state<HTMLDivElement>();
+
+  $effect(() => {
+    if (!editorScrollContainer) return;
+    editorContext.editor = {
+      scrollContainerEl: editorScrollContainer,
+      rootAttrs: { layout_mode: { type: 'continuous', max_width: 600 } },
+      pageSizes: [],
+      pageEls: {},
+      presentationGeometryRevision: 0,
+      safeDisplayZoom: () => 1,
+    } as unknown as Editor;
+    editorContext.scroll = {
+      cancel: () => null,
+      lastScrollRevision: 1,
+      lastScrollWasAuto: false,
+    } as unknown as EditorScrollScope;
+  });
+</script>
+
+<div style="position: relative; width: 120px; height: 160px" data-testid="shared-scrollbar">
+  <div
+    bind:this={sharedScrollContainer}
+    id="reduced-motion-shared-scroll"
+    style="width: 100%; height: 100%; overflow-y: auto; scrollbar-width: none"
+  >
+    <div style="height: 480px"></div>
+  </div>
+  <Scrollbar
+    controls="reduced-motion-shared-scroll"
+    label="공유 스크롤바"
+    orientation="vertical"
+    scrollContainer={sharedScrollContainer}
+    size="md"
+  />
+</div>
+
+<div style="position: relative; width: 120px; height: 160px" data-testid="editor-scrollbar">
+  <div bind:this={editorScrollContainer} style="width: 100%; height: 100%; overflow-y: auto; scrollbar-width: none">
+    <div style="height: 480px"></div>
+  </div>
+  <EditorScrollbar />
+</div>
+
+<div style="width: 800px; height: 800px" data-testid="entity-skeleton">
+  <PaneSkeleton pane={entityPane} />
+</div>
+
+<div style="width: 800px; height: 800px" data-testid="home-skeleton">
+  <PaneSkeleton pane={homePane} />
+</div>

--- a/apps/website/src/lib/reduced-motion-presentations.browser.test.ts
+++ b/apps/website/src/lib/reduced-motion-presentations.browser.test.ts
@@ -1,0 +1,123 @@
+import '../app.css';
+
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ReducedMotionPresentationsTestRoot from './reduced-motion-presentations-test-root.svelte';
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+const reducedMotion = vi.hoisted(() => {
+  let matches = false;
+  const listeners = new Set<EventListenerOrEventListenerObject>();
+  const mediaQuery = {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => listeners.add(listener),
+    removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => listeners.delete(listener),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: () => true,
+  } satisfies MediaQueryList;
+
+  vi.stubGlobal('matchMedia', (query: string) => {
+    if (query === mediaQuery.media) return mediaQuery;
+    return {
+      ...mediaQuery,
+      matches: false,
+      media: query,
+    } satisfies MediaQueryList;
+  });
+
+  return {
+    reset() {
+      matches = false;
+    },
+    set(next: boolean) {
+      matches = next;
+      const event = new Event('change');
+      for (const listener of listeners) {
+        if (typeof listener === 'function') listener(event);
+        else listener.handleEvent(event);
+      }
+    },
+  };
+});
+
+let component: ReturnType<typeof mount> | undefined;
+
+const frame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+const animatedDescendant = (root: HTMLElement | null) =>
+  root ? [...root.querySelectorAll<HTMLElement>('*')].find((element) => getComputedStyle(element).animationName !== 'none') : undefined;
+
+const presentationElements = () => {
+  const sharedRoot = document.querySelector<HTMLElement>('[data-testid="shared-scrollbar"]');
+  const editorRoot = document.querySelector<HTMLElement>('[data-testid="editor-scrollbar"]');
+  const sharedTrack = sharedRoot?.querySelector<HTMLElement>('[role="scrollbar"]');
+  const editorTrack = editorRoot?.querySelector<HTMLElement>('[role="scrollbar"]');
+  const editorIndicator = editorTrack?.previousElementSibling as HTMLElement | null;
+  const entitySkeleton = document.querySelector<HTMLElement>('[data-testid="entity-skeleton"]');
+  const homeSkeleton = document.querySelector<HTMLElement>('[data-testid="home-skeleton"]');
+  const entityAnimated = animatedDescendant(entitySkeleton ?? null);
+  const homeAnimated = animatedDescendant(homeSkeleton ?? null);
+
+  if (!sharedTrack || !editorTrack || !editorIndicator || !entityAnimated || !homeAnimated) {
+    throw new Error(
+      `Expected reduced-motion presentation fixtures: ${JSON.stringify({
+        editorIndicator: Boolean(editorIndicator),
+        editorTrack: Boolean(editorTrack),
+        entityAnimated: Boolean(entityAnimated),
+        homeAnimated: Boolean(homeAnimated),
+        sharedTrack: Boolean(sharedTrack),
+      })}`,
+    );
+  }
+  return { editorIndicator, editorTrack, entityAnimated, homeAnimated, sharedTrack };
+};
+
+beforeEach(async () => {
+  reducedMotion.reset();
+  localStorage.clear();
+  component = mount(ReducedMotionPresentationsTestRoot, { target: document.body });
+  await tick();
+  await frame();
+  await expect.poll(() => document.querySelectorAll('[role="scrollbar"]').length).toBe(2);
+});
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  document.body.replaceChildren();
+});
+
+describe('reduced-motion presentations', () => {
+  it('keeps the existing interpolation with normal motion', () => {
+    const elements = presentationElements();
+
+    expect(getComputedStyle(elements.sharedTrack).transitionDuration).not.toBe('0s');
+    expect(getComputedStyle(elements.editorTrack).transitionDuration).not.toBe('0s');
+    expect(getComputedStyle(elements.editorIndicator).transitionDuration).not.toBe('0s');
+    expect(getComputedStyle(elements.entityAnimated).animationName).not.toBe('none');
+    expect(getComputedStyle(elements.homeAnimated).animationName).not.toBe('none');
+  });
+
+  it('settles mounted scrollbars and skeletons when reduced motion turns on', async () => {
+    const before = presentationElements();
+    const entityBounds = before.entityAnimated.getBoundingClientRect();
+    const homeBounds = before.homeAnimated.getBoundingClientRect();
+
+    reducedMotion.set(true);
+    await tick();
+    await frame();
+
+    expect(getComputedStyle(before.sharedTrack).transitionDuration).toBe('0s');
+    expect(getComputedStyle(before.editorTrack).transitionDuration).toBe('0s');
+    expect(getComputedStyle(before.editorIndicator).transitionDuration).toBe('0s');
+    expect(getComputedStyle(before.entityAnimated).animationName).toBe('none');
+    expect(getComputedStyle(before.homeAnimated).animationName).toBe('none');
+    expect(before.entityAnimated.getBoundingClientRect()).toEqual(entityBounds);
+    expect(before.homeAnimated.getBoundingClientRect()).toEqual(homeBounds);
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
@@ -8,6 +8,7 @@
   import { Button, Icon, Menu, MenuItem } from '@typie/ui/components';
   import { getAppContext, getThemeContext } from '@typie/ui/context';
   import { Dialog, Toast } from '@typie/ui/notification';
+  import { prefersReducedMotion } from '@typie/ui/state';
   import { tick, untrack } from 'svelte';
   import ArchiveIcon from '~icons/lucide/archive';
   import ArchiveRestoreIcon from '~icons/lucide/archive-restore';
@@ -961,6 +962,7 @@
             destination={indicatorDestination}
             phase={indicatorPhase}
             prismEnabled={app.preference.current.prismWelcomeObjectEnabled}
+            reducedMotion={prefersReducedMotion.current}
             rowSpinnerPlaybackStartedAt={indicatorSpinnerPlaybackStartedAt}
             themeVariant={theme.currentThemeVariant}
             {welcomeAdmission}

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelIndicator.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelIndicator.svelte
@@ -2,6 +2,7 @@
   import themeData from '@typie/assets/theme.json' with { type: 'json' };
   import { PRISM_ICON_DURATION_SECONDS } from '@typie/prism-ui';
   import { token } from '@typie/styled-system/tokens';
+  import { prefersReducedMotion } from '@typie/ui/state';
   import { onDestroy, onMount, untrack } from 'svelte';
   import PrismIcon from '~icons/typie/prism';
   import PrismObject from '$lib/prism-ui/PrismObject.svelte';
@@ -34,9 +35,7 @@
     destination,
     phase,
     prismEnabled = true,
-    reducedMotion = typeof window !== 'undefined' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    reducedMotion = untrack(() => prefersReducedMotion.current),
     rowSpinnerPlaybackStartedAt,
     themeVariant,
     welcomeAdmission = true,

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.svelte
@@ -7,7 +7,7 @@
   import { SvelteMap } from 'svelte/reactivity';
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import { parseMarkdown } from './lib/markdown.ts';
-  import { pop, rise } from './lib/motion.ts';
+  import { pop, reducedMotion, rise } from './lib/motion.ts';
   import { PacedText } from './lib/paced-text.svelte.ts';
   import { foldToolCalls } from './lib/tool-calls.ts';
   import { labelForRequest } from './lib/tool-labels.ts';
@@ -134,7 +134,7 @@
   const MAX_FRAME_MS = 100;
   const BOTTOM_FOLLOW_TOLERANCE_PX = 8;
 
-  const reduceMotion = typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const reduceMotion = reducedMotion();
   const newPaced = () => new PacedText({ instant: reduceMotion });
 
   let container = $state<HTMLElement>();

--- a/apps/website/src/routes/website/(dashboard)/@prism/lib/motion.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/lib/motion.ts
@@ -1,3 +1,4 @@
+import { prefersReducedMotion } from '@typie/ui/state';
 import { quintOut } from 'svelte/easing';
 import { fade, fly, scale, slide } from 'svelte/transition';
 import type { TransitionConfig } from 'svelte/transition';
@@ -9,7 +10,7 @@ export const PRISM_VISIBILITY_MOTION = {
   easing: 'cubic-bezier(0.32, 0.72, 0, 1)',
 } as const;
 
-export const reducedMotion = (): boolean => typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+export const reducedMotion = (): boolean => prefersReducedMotion.current;
 
 const cubic = (at: number, first: number, second: number): number => {
   const c = 3 * first;

--- a/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewPassage.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewPassage.svelte
@@ -12,7 +12,7 @@
   import { graphql } from '$mearie';
   import { backoffDelay } from '../lib/backoff.ts';
   import { parseMarkdown } from '../lib/markdown.ts';
-  import { expand, fadeIn, fadeOut, rise } from '../lib/motion.ts';
+  import { expand, fadeIn, fadeOut, reducedMotion, rise } from '../lib/motion.ts';
   import { PacedText } from '../lib/paced-text.svelte.ts';
   import PrismMarkdown from '../PrismMarkdown.svelte';
   import PrismToolCalls from '../PrismToolCalls.svelte';
@@ -240,7 +240,7 @@
   const tierLabel = $derived(header?.tier ?? (tier === null ? null : (TIER_OPTIONS.find((option) => option.tier === tier)?.label ?? null)));
   const result = $derived(round === null ? null : describeResult(round));
 
-  const reduceMotion = typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const reduceMotion = reducedMotion();
 
   let firstPaint = $state(true);
 

--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityName.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityName.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { hoverIntent } from '@typie/ui/actions';
+  import { prefersReducedMotion as reducedMotionPreference } from '@typie/ui/state';
   import { onDestroy, onMount } from 'svelte';
   import { advanceEntityNameMotion } from './entity-name-motion';
 
@@ -21,12 +22,12 @@
   let overflowLeft = $state(false);
   let overflowRight = $state(false);
   let fogTransitionReady = $state(false);
-  let prefersReducedMotion = $state(false);
+  const prefersReducedMotion = $derived(reducedMotionPreference.current);
   let animationFrame: number | undefined;
   let fogTransitionFrame: number | undefined;
   let fogTransitionScheduled = false;
   let hovered = false;
-  let hoverReady = false;
+  let hoverReady = $state(false);
   let motionPosition = 0;
   let motionVelocity = 0;
   let previousFrameTime: number | undefined;
@@ -126,6 +127,11 @@
     }
   });
 
+  $effect(() => {
+    if (!prefersReducedMotion || !hoverReady || !viewport) return;
+    settleAt(viewport, Math.max(0, viewport.scrollWidth - viewport.clientWidth));
+  });
+
   onMount(() => {
     const hoverTarget = viewport?.closest<HTMLElement>('[role="treeitem"]');
     const hoverIntentAction = hoverTarget
@@ -145,23 +151,11 @@
           },
         })
       : undefined;
-    const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const updateReducedMotion = () => {
-      prefersReducedMotion = reducedMotionQuery.matches;
-      const element = viewport;
-      if (!prefersReducedMotion || !hoverReady || !element) return;
-
-      settleAt(element, Math.max(0, element.scrollWidth - element.clientWidth));
-    };
-
-    reducedMotionQuery.addEventListener('change', updateReducedMotion);
-    updateReducedMotion();
     updateOverflow();
 
     return () => {
       if (fogTransitionFrame !== undefined) window.cancelAnimationFrame(fogTransitionFrame);
       hoverIntentAction?.destroy?.();
-      reducedMotionQuery.removeEventListener('change', updateReducedMotion);
     };
   });
 

--- a/apps/website/src/routes/website/(dashboard)/@tree/entity-name.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@tree/entity-name.browser.test.ts
@@ -16,9 +16,10 @@ const wait = (duration: number) => new Promise<void>((resolve) => setTimeout(res
 const maskAlpha = (element: HTMLElement, edge: 'leading' | 'trailing') =>
   Number(getComputedStyle(element).getPropertyValue(`--entity-name-${edge}-mask-alpha`));
 
-const mockReducedMotion = (reducedMotion: boolean) => {
+const reducedMotionPreference = vi.hoisted(() => {
   const eventTarget = new EventTarget();
   const query = '(prefers-reduced-motion: reduce)';
+  let reducedMotion = false;
   const mediaQuery = {
     get matches() {
       return reducedMotion;
@@ -34,10 +35,17 @@ const mockReducedMotion = (reducedMotion: boolean) => {
 
   vi.spyOn(window, 'matchMedia').mockReturnValue(mediaQuery);
 
-  return (next: boolean) => {
-    reducedMotion = next;
-    mediaQuery.dispatchEvent(new MediaQueryListEvent('change', { matches: next, media: query }));
+  return {
+    set(next: boolean) {
+      reducedMotion = next;
+      mediaQuery.dispatchEvent(new MediaQueryListEvent('change', { matches: next, media: query }));
+    },
   };
+});
+
+const mockReducedMotion = (reducedMotion: boolean) => {
+  reducedMotionPreference.set(reducedMotion);
+  return reducedMotionPreference.set;
 };
 
 const mountName = async (name: string, width: number) => {
@@ -70,6 +78,7 @@ afterEach(async () => {
   vi.useRealTimers();
   if (component) await unmount(component);
   component = undefined;
+  reducedMotionPreference.set(false);
   vi.restoreAllMocks();
   document.body.replaceChildren();
 });
@@ -264,7 +273,7 @@ describe('entity tree name overflow', () => {
 
     vi.useFakeTimers();
     enter(target);
-    await vi.advanceTimersByTimeAsync(399);
+    await vi.advanceTimersByTimeAsync(199);
     expect(viewport.scrollLeft).toBe(0);
 
     await vi.advanceTimersByTimeAsync(1);

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneSkeleton.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneSkeleton.svelte
@@ -2,6 +2,7 @@
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { getAppContext } from '@typie/ui/context';
+  import { prefersReducedMotion } from '@typie/ui/state';
   import { CONTINUOUS_MIN_WIDTH, CONTINUOUS_VIEW_PADDING } from '$lib/editor-ffi/constants';
   import { otherToolbarKind, readPrimaryToolbar } from '../v2/toolbar-kind';
   import { getPaneGroup } from './context.svelte';
@@ -87,7 +88,7 @@
   const bar = css({
     backgroundColor: 'surface.muted',
     borderRadius: '4px',
-    animation: 'pulse 2s ease-in-out infinite',
+    animation: '[var(--pane-skeleton-motion, pulse 2s ease-in-out infinite)]',
     flexShrink: '0',
   });
 
@@ -118,7 +119,10 @@
 </script>
 
 {#if pane.kind === 'entity'}
-  <div class={flex({ flexDirection: 'column', size: 'full' })}>
+  <div
+    style:--pane-skeleton-motion={prefersReducedMotion.current ? 'none' : undefined}
+    class="skeleton-motion {flex({ flexDirection: 'column', size: 'full' })}"
+  >
     <!-- Header (36px): breadcrumb ... controls close -->
     <div
       class={flex({
@@ -273,7 +277,12 @@
           >
             {#each linesBefore as line, i (i)}
               <div style:height="1lh" class={flex({ alignItems: 'center' })}>
-                <div style:width={line.width} style:height="16px" style:animation={line.animation} class={textLine}></div>
+                <div
+                  style:width={line.width}
+                  style:height="16px"
+                  style:--pane-skeleton-line-animation={line.animation}
+                  class={textLine}
+                ></div>
               </div>
             {/each}
             <!-- Image placeholder -->
@@ -283,12 +292,17 @@
                 borderRadius: '8px',
                 width: 'full',
                 height: '320px',
-                animation: 'pulse 2s ease-in-out infinite',
+                animation: '[var(--pane-skeleton-motion, pulse 2s ease-in-out infinite)]',
               })}
             ></div>
             {#each linesAfter as line, i (i)}
               <div style:height="1lh" class={flex({ alignItems: 'center' })}>
-                <div style:width={line.width} style:height="16px" style:animation={line.animation} class={textLine}></div>
+                <div
+                  style:width={line.width}
+                  style:height="16px"
+                  style:--pane-skeleton-line-animation={line.animation}
+                  class={textLine}
+                ></div>
               </div>
             {/each}
           </div>
@@ -314,7 +328,10 @@
   </div>
 {:else if pane.kind === 'home'}
   <!-- Home skeleton: centered like the actual HomePane layout -->
-  <div class={css({ width: 'full', height: 'full', overflow: 'auto' })}>
+  <div
+    style:--pane-skeleton-motion={prefersReducedMotion.current ? 'none' : undefined}
+    class="skeleton-motion {css({ width: 'full', height: 'full', overflow: 'auto' })}"
+  >
     <div
       class={flex({
         flexDirection: 'column',
@@ -344,7 +361,7 @@
               padding: '12px',
               borderRadius: '8px',
               backgroundColor: 'surface.subtle',
-              animation: 'pulse 2s ease-in-out infinite',
+              animation: '[var(--pane-skeleton-motion, pulse 2s ease-in-out infinite)]',
             })}
           >
             <div class={flex({ flexDirection: 'column', gap: '4px' })}>
@@ -370,3 +387,19 @@
 {:else}
   {unreachable(pane)}
 {/if}
+
+<style>
+  :global(.skeleton-motion) {
+    --pane-skeleton-line-animation: none;
+  }
+
+  :global(.skeleton-motion) :global([style*='--pane-skeleton-line-animation']) {
+    animation: var(--pane-skeleton-motion, var(--pane-skeleton-line-animation));
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.skeleton-motion) {
+      --pane-skeleton-motion: none;
+    }
+  }
+</style>

--- a/apps/website/src/vitest-setup.ts
+++ b/apps/website/src/vitest-setup.ts
@@ -1,5 +1,22 @@
 import { vi } from 'vitest';
 
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => null,
+      removeEventListener: () => null,
+      addListener: () => null,
+      removeListener: () => null,
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
 vi.mock('$lib/editor-ffi/surface-probe', () => ({
   probeAttach: vi.fn(),
   probeDetach: vi.fn(),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,7 @@
     "./form": "./src/form/index.ts",
     "./notification": "./src/notification/index.ts",
     "./state": "./src/state/index.ts",
+    "./state/reduced-motion": "./src/state/reduced-motion.svelte.ts",
     "./transitions": "./src/transitions/index.ts",
     "./utils": "./src/utils/index.ts",
     "./styles.css": "./styles/index.css"

--- a/packages/ui/src/components/Scrollbar.svelte
+++ b/packages/ui/src/components/Scrollbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { pointerCapture } from '../actions';
+  import { prefersReducedMotion } from '../state/reduced-motion.svelte';
 
   const HIDE_DELAY = 1000;
   const MIN_THUMB_SIZE = 30;
@@ -216,13 +217,14 @@
     style:height={vertical ? undefined : `${dimensions.hitLane}px`}
     style:opacity={visible ? 1 : 0}
     style:transition-property="opacity"
-    style:transition-duration={visible ? '300ms' : '600ms'}
+    style:transition-duration={prefersReducedMotion.current ? '0ms' : visible ? '300ms' : '600ms'}
     style:transition-timing-function="cubic-bezier(0.4, 0, 0.2, 1)"
     class={css({
       position: 'absolute',
       zIndex: '1',
       pointerEvents: 'auto',
       touchAction: 'none',
+      _motionReduce: { transitionDuration: '0ms' },
     })}
     aria-controls={controls}
     aria-label={label}
@@ -261,12 +263,14 @@
         style:left={vertical ? undefined : '0'}
         style:width={vertical ? `${dimensions.paintedThumb}px` : undefined}
         style:height={vertical ? undefined : `${dimensions.paintedThumb}px`}
+        style:transition-duration={prefersReducedMotion.current ? '0ms' : undefined}
         class={css({
           position: 'absolute',
           pointerEvents: 'none',
           borderRadius: 'full',
           backgroundColor: dragging || thumbHovered ? 'surface.inverse/30' : 'surface.inverse/18',
           transition: 'colors',
+          _motionReduce: { transition: '[none]' },
         })}
       ></div>
     </div>

--- a/packages/ui/src/state/index.ts
+++ b/packages/ui/src/state/index.ts
@@ -1,3 +1,4 @@
 export * from './local-store.svelte';
 export * from './query-string.svelte';
+export * from './reduced-motion.svelte';
 export * from './session-store.svelte';

--- a/packages/ui/src/state/reduced-motion.svelte.ts
+++ b/packages/ui/src/state/reduced-motion.svelte.ts
@@ -1,0 +1,18 @@
+const query = '(prefers-reduced-motion: reduce)';
+const mediaQuery = globalThis.matchMedia?.(query);
+let subscribedMatches = $state(mediaQuery?.matches ?? false);
+let receivedChange = false;
+
+mediaQuery?.addEventListener('change', () => {
+  receivedChange = true;
+  subscribedMatches = mediaQuery.matches;
+});
+
+export const prefersReducedMotion = {
+  get current(): boolean {
+    // Keep synchronous consumers useful when matchMedia becomes available after module evaluation.
+    // Once the subscribed query changes, its reactive value remains authoritative.
+    const reactiveValue = subscribedMatches;
+    return receivedChange ? reactiveValue : (globalThis.matchMedia?.(query).matches ?? reactiveValue);
+  },
+};


### PR DESCRIPTION
- `prefersReducedMotion.current`를 UI 공용 상태로 추가하고 Website, Desktop renderer, Eval의 개별 reduced-motion 조회를 통합했습니다.
- 범용 스크롤바와 에디터 스크롤바가 reduced motion에서 opacity 및 색상 전환을 즉시 완료하도록 변경했습니다.
- 문서 및 홈 Pane 스켈레톤이 reduced motion에서 shimmer와 typing animation을 정지하도록 변경했습니다.
- Compose Desktop 앱 실행 컨텍스트에 `MotionDurationScale`을 연결했습니다.
  - macOS 접근성 설정을 앱 시작 시 읽습니다.
  - 앱 창이 다시 활성화될 때 설정을 갱신합니다.
  - 플랫폼 세부사항은 Desktop 애플리케이션 실행 계층 내부에 캡슐화했습니다.
- jsdom 환경에 기본 `matchMedia` 폴리필을 제공하고 `vi.restoreAllMocks()` 이후에도 안전하도록 구성했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>