### PR TITLE
에디터 줌 컨트롤과 뷰포트 앵커 동작 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorZoomState.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.setValue
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.documentZoomWidth
 import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.floor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -25,6 +27,7 @@ private const val RenderZoomDebounceMs = 120L
 private const val RenderZoomMinCommitIntervalMs = 160L
 private const val RenderZoomMaxCommitDelayMs = 300L
 private const val RenderZoomScaleRatioThreshold = 1.18f
+private const val DiscreteZoomStep = 0.1f
 
 @Stable
 internal class EditorZoomController(
@@ -78,10 +81,8 @@ internal class EditorZoomController(
       return
     }
 
-    setZoomInternal(
-      zoom = displayZoom,
-      layoutSpec = layoutSpec,
-      viewportWidth = viewportWidth,
+    setResolvedDisplayZoom(
+      displayZoom = clampDocumentZoom(displayZoom, computeDocumentZoomBounds(layoutSpec)),
       commitRender = true,
     )
   }
@@ -90,12 +91,14 @@ internal class EditorZoomController(
     zoom: Float,
     layoutSpec: EditorDocumentLayoutSpec,
     viewportWidth: Float,
+    snapToLandmarks: Boolean = true,
   ): Boolean {
     return setZoomInternal(
       zoom = zoom,
       layoutSpec = layoutSpec,
       viewportWidth = viewportWidth,
       commitRender = false,
+      snapToLandmarks = snapToLandmarks,
     )
   }
 
@@ -144,23 +147,71 @@ internal class EditorZoomController(
     }
   }
 
+  fun resolveLandmark(zoom: Float = indicatorZoom): EditorZoomLandmark? {
+    if (!isZoomEnabled) return null
+    return resolveEditorZoomLandmark(
+      zoom = zoom,
+      layoutSpec = currentLayoutSpec,
+      viewportWidth = currentViewportWidth,
+    )
+  }
+
+  fun resolveIndicatorToggleTarget(): Float? {
+    if (!isZoomEnabled) return null
+    val bounds = computeDocumentZoomBounds(currentLayoutSpec)
+    val unitZoom = clampDocumentZoom(zoom = 1f, bounds = bounds)
+    val fitWidthZoom =
+      computeDocumentFitWidthZoom(
+        layoutSpec = currentLayoutSpec,
+        viewportWidth = currentViewportWidth,
+      )
+    val targetZoom = if (resolveLandmark() == EditorZoomLandmark.Unit) fitWidthZoom else unitZoom
+    return targetZoom.takeUnless { zoomEquals(it, displayZoom) }
+  }
+
+  fun resolveZoomInTarget(): Float? = resolveStepTarget(1)
+
+  fun resolveZoomOutTarget(): Float? = resolveStepTarget(-1)
+
+  private fun resolveStepTarget(direction: Int): Float? {
+    if (!isZoomEnabled) return null
+    return resolveEditorZoomStepTarget(
+      zoom = indicatorZoom,
+      direction = direction,
+      layoutSpec = currentLayoutSpec,
+      viewportWidth = currentViewportWidth,
+    )
+  }
+
   private fun resolveDisplayZoom(
     zoom: Float,
     layoutSpec: EditorDocumentLayoutSpec,
     viewportWidth: Float,
-  ): Float = clampDocumentLayoutZoom(zoom, layoutSpec, viewportWidth)
+    snapToLandmarks: Boolean,
+  ): Float =
+    if (snapToLandmarks) {
+      clampDocumentLayoutZoom(zoom, layoutSpec, viewportWidth)
+    } else {
+      clampDocumentZoom(zoom, computeDocumentZoomBounds(layoutSpec))
+    }
 
   private fun setZoomInternal(
     zoom: Float,
     layoutSpec: EditorDocumentLayoutSpec,
     viewportWidth: Float,
     commitRender: Boolean,
+    snapToLandmarks: Boolean = true,
   ): Boolean {
     currentLayoutSpec = layoutSpec
     currentViewportWidth = viewportWidth
 
     val resolvedZoom =
-      resolveDisplayZoom(zoom = zoom, layoutSpec = layoutSpec, viewportWidth = viewportWidth)
+      resolveDisplayZoom(
+        zoom = zoom,
+        layoutSpec = layoutSpec,
+        viewportWidth = viewportWidth,
+        snapToLandmarks = snapToLandmarks,
+      )
     return setResolvedDisplayZoom(displayZoom = resolvedZoom, commitRender = commitRender)
   }
 
@@ -271,6 +322,39 @@ internal enum class EditorZoomSnapKey {
   Unit,
 }
 
+internal enum class EditorZoomLandmark {
+  Minimum,
+  FitWidth,
+  Unit,
+  Maximum,
+}
+
+internal fun resolveEditorZoomLandmark(
+  zoom: Float,
+  layoutSpec: EditorDocumentLayoutSpec,
+  viewportWidth: Float,
+): EditorZoomLandmark? {
+  val layoutWidth =
+    when (layoutSpec) {
+      is EditorDocumentLayoutSpec.Continuous -> layoutSpec.maxWidth
+      is EditorDocumentLayoutSpec.Paginated -> layoutSpec.pageWidth
+    }
+  if (!zoom.isFinite() || zoom <= 0f || !layoutWidth.isFinite() || layoutWidth <= 0f) return null
+  if (!viewportWidth.isFinite() || viewportWidth <= 0f) return null
+
+  val bounds = computeDocumentZoomBounds(layoutSpec)
+  val unitZoom = clampDocumentZoom(zoom = 1f, bounds = bounds)
+  if (zoomEquals(zoom, unitZoom)) return EditorZoomLandmark.Unit
+
+  val naturalFitWidthZoom = viewportWidth / layoutSpec.documentZoomWidth()
+  if (naturalFitWidthZoom in bounds && zoomEquals(zoom, naturalFitWidthZoom)) {
+    return EditorZoomLandmark.FitWidth
+  }
+  if (zoomEquals(zoom, bounds.start)) return EditorZoomLandmark.Minimum
+  if (zoomEquals(zoom, bounds.endInclusive)) return EditorZoomLandmark.Maximum
+  return null
+}
+
 internal fun computeDocumentZoomBounds(
   layoutSpec: EditorDocumentLayoutSpec
 ): ClosedFloatingPointRange<Float> {
@@ -339,6 +423,34 @@ internal fun clampDocumentLayoutZoom(
   }
 
   return snapped ?: clamped
+}
+
+private fun resolveEditorZoomStepTarget(
+  zoom: Float,
+  direction: Int,
+  layoutSpec: EditorDocumentLayoutSpec,
+  viewportWidth: Float,
+): Float? {
+  val bounds = computeDocumentZoomBounds(layoutSpec)
+  val current = clampDocumentZoom(zoom, bounds)
+  val candidates =
+    mutableListOf(
+      bounds.start,
+      computeDocumentFitWidthZoom(layoutSpec, viewportWidth),
+      clampDocumentZoom(1f, bounds),
+      bounds.endInclusive,
+    )
+  val firstGridIndex = ceil((bounds.start - ZoomEpsilon) / DiscreteZoomStep).toInt()
+  val lastGridIndex = floor((bounds.endInclusive + ZoomEpsilon) / DiscreteZoomStep).toInt()
+  for (index in firstGridIndex..lastGridIndex) {
+    candidates += clampDocumentZoom(index * DiscreteZoomStep, bounds)
+  }
+
+  return if (direction > 0) {
+    candidates.filter { it > current + ZoomEpsilon }.minOrNull()
+  } else {
+    candidates.filter { it < current - ZoomEpsilon }.maxOrNull()
+  }
 }
 
 internal fun renderZoomForDisplay(displayZoom: Float): Float {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputChange
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.EditorZoomLandmark
 import co.typie.editor.ffi.InputModifiers
 import co.typie.editor.interaction.gestures.EditorPanGestureDriver
 import co.typie.editor.interaction.semantics.EditorTableColumnResizePlacement
@@ -177,6 +178,13 @@ internal class EditorInteractionController(
   fun interruptZoomForDirectPan() {
     semantics.viewportZoom.interruptForDirectPan()
   }
+
+  fun zoomInAtViewportCenter(): Boolean = semantics.viewportZoom.zoomInAtViewportCenter()
+
+  fun zoomOutAtViewportCenter(): Boolean = semantics.viewportZoom.zoomOutAtViewportCenter()
+
+  fun toggleIndicatorZoomAtViewportCenter(): EditorZoomLandmark? =
+    semantics.viewportZoom.toggleIndicatorZoomAtViewportCenter()
 
   fun onLongPressTimer(pointerId: Long, position: Offset, nowMillis: Long): Boolean =
     if (ensurePointerInputEnabled()) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.geometry.Offset
 import co.typie.editor.EditorViewportAnchor
 import co.typie.editor.EditorZoomController
+import co.typie.editor.EditorZoomLandmark
 import co.typie.editor.EditorZoomMotion
 import co.typie.editor.EditorZoomMotionFrame
 import co.typie.editor.EditorZoomMotionTuning
@@ -12,6 +13,7 @@ import co.typie.editor.EditorZoomSnapKey
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.body.documentZoomWidth
 import co.typie.editor.clampDocumentLayoutZoom
+import co.typie.editor.clampDocumentZoom
 import co.typie.editor.computeDocumentZoomBounds
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.interaction.EditorPinchSample
@@ -201,10 +203,88 @@ internal class EditorViewportZoomSemantic(
     val seed = currentConfig?.createMotionSeed()
     clearDirectSessions()
     if (currentConfig == null || seed == null) {
-      finishWithoutMotion(currentConfig)
+      settleAndFinishInteraction(currentConfig)
       return
     }
     finishOrRecover(config = currentConfig, seed = seed)
+  }
+
+  fun setZoomAtViewportCenter(targetZoom: Float, snapToLandmarks: Boolean = true): Boolean {
+    val currentConfig = config?.takeIf { it.isUsable } ?: return false
+    if (!targetZoom.isFinite() || targetZoom <= 0f) return false
+    val viewportSize = currentConfig.viewportState.viewportSize
+    if (viewportSize.width <= 0f || viewportSize.height <= 0f) return false
+    val previousZoom = currentConfig.zoomController.displayZoom
+    val startScrollOffset = currentConfig.viewportState.effectiveTransformScrollTarget
+    val viewportCenter =
+      startScrollOffset + Offset(x = viewportSize.width / 2f, y = viewportSize.height / 2f)
+    val anchor =
+      currentConfig
+        .resolveViewportTransform(displayZoom = previousZoom)
+        .resolveAnchor(focalX = viewportCenter.x, focalY = viewportCenter.y) ?: return false
+    val previousAnchorPosition =
+      currentConfig.resolveAnchorDisplayPosition(anchor, previousZoom) ?: return false
+    val resolvedZoom =
+      if (snapToLandmarks) {
+        clampDocumentLayoutZoom(
+          zoom = targetZoom,
+          layoutSpec = currentConfig.layoutSpec,
+          viewportWidth = currentConfig.viewportWidth,
+        )
+      } else {
+        clampDocumentZoom(targetZoom, computeDocumentZoomBounds(currentConfig.layoutSpec))
+      }
+    if (previousZoom == resolvedZoom) return false
+
+    clearDirectSessions()
+    stopMotion(commitRender = false)
+    beginTransform(currentConfig)
+    val changed =
+      currentConfig.zoomController.setDisplayZoom(
+        zoom = resolvedZoom,
+        layoutSpec = currentConfig.layoutSpec,
+        viewportWidth = currentConfig.viewportWidth,
+        snapToLandmarks = snapToLandmarks,
+      )
+    val anchorDisplayPosition =
+      currentConfig.resolveAnchorDisplayPosition(anchor, currentConfig.zoomController.displayZoom)
+    if (!changed || anchorDisplayPosition == null) {
+      finishInteraction(currentConfig)
+      return false
+    }
+    val targetScrollOffset = startScrollOffset + (anchorDisplayPosition - previousAnchorPosition)
+    currentConfig.viewportState.scrollToTransformTarget(
+      offset = targetScrollOffset,
+      retainUntilMeasuredBounds = true,
+    )
+    currentConfig.onAttachViewportAnchor(anchor, anchorDisplayPosition, targetScrollOffset)
+    finishInteraction(currentConfig)
+    return true
+  }
+
+  fun zoomInAtViewportCenter(): Boolean {
+    val currentConfig = config ?: return false
+    val targetZoom = currentConfig.zoomController.resolveZoomInTarget() ?: return false
+    val changed = setZoomAtViewportCenter(targetZoom, snapToLandmarks = false)
+    if (changed) currentConfig.onZoomSnap()
+    return changed
+  }
+
+  fun zoomOutAtViewportCenter(): Boolean {
+    val currentConfig = config ?: return false
+    val targetZoom = currentConfig.zoomController.resolveZoomOutTarget() ?: return false
+    val changed = setZoomAtViewportCenter(targetZoom, snapToLandmarks = false)
+    if (changed) currentConfig.onZoomSnap()
+    return changed
+  }
+
+  fun toggleIndicatorZoomAtViewportCenter(): EditorZoomLandmark? {
+    val currentConfig = config ?: return null
+    val targetZoom = currentConfig.zoomController.resolveIndicatorToggleTarget() ?: return null
+    if (!setZoomAtViewportCenter(targetZoom)) return null
+    val landmark = currentConfig.zoomController.resolveLandmark() ?: return null
+    currentConfig.onZoomSnap()
+    return landmark
   }
 
   private fun releaseForDirectPan() {
@@ -238,7 +318,7 @@ internal class EditorViewportZoomSemantic(
     if (currentConfig != null && seed != null) {
       finishOrRecover(config = currentConfig, seed = seed)
     } else {
-      finishWithoutMotion(currentConfig)
+      settleAndFinishInteraction(currentConfig)
     }
   }
 
@@ -321,6 +401,7 @@ internal class EditorViewportZoomSemantic(
     val bounds = computeDocumentZoomBounds(config.layoutSpec)
     val displayZoom = config.zoomController.displayZoom
     if (displayZoom in bounds) {
+      settleReleasedSnap(config = config, seed = seed, displayZoom = displayZoom)
       finishInteraction(config)
       return
     }
@@ -358,6 +439,41 @@ internal class EditorViewportZoomSemantic(
       }
       finishMotion(active)
     }
+  }
+
+  private fun settleReleasedSnap(
+    config: EditorViewportZoomSemanticConfig,
+    seed: MotionSeed,
+    displayZoom: Float,
+  ) {
+    val settledZoom =
+      clampDocumentLayoutZoom(
+        zoom = displayZoom,
+        layoutSpec = config.layoutSpec,
+        viewportWidth = config.viewportWidth,
+      )
+    val snapKey = config.zoomController.resolveSnapKey(settledZoom) ?: return
+    val anchorDisplayPosition =
+      config.resolveAnchorDisplayPosition(anchor = seed.anchor, displayZoom = settledZoom) ?: return
+    if (
+      !config.zoomController.setDisplayZoom(
+        zoom = settledZoom,
+        layoutSpec = config.layoutSpec,
+        viewportWidth = config.viewportWidth,
+      )
+    ) {
+      return
+    }
+
+    val targetScrollOffset =
+      seed.scrollOffset + (anchorDisplayPosition - seed.anchorDisplayPosition)
+    config.viewportState.scrollToTransformTarget(
+      offset = targetScrollOffset,
+      retainUntilMeasuredBounds = true,
+    )
+    config.onAttachViewportAnchor(seed.anchor, anchorDisplayPosition, targetScrollOffset)
+    lastSnapKey = snapKey
+    config.onZoomSnap()
   }
 
   private fun applyMotionFrame(active: ActiveMotion, frame: EditorZoomMotionFrame): Boolean {
@@ -414,7 +530,7 @@ internal class EditorViewportZoomSemantic(
     if (activeMotion !== active) return
     activeMotion = null
     motionJob = null
-    finishInteraction(config)
+    settleAndFinishInteraction(config)
   }
 
   private fun stopMotion(commitRender: Boolean) {
@@ -429,7 +545,7 @@ internal class EditorViewportZoomSemantic(
     if (config != null) endTransform(config) else transformActive = false
   }
 
-  private fun finishWithoutMotion(config: EditorViewportZoomSemanticConfig?) {
+  private fun settleAndFinishInteraction(config: EditorViewportZoomSemanticConfig?) {
     config
       ?.zoomController
       ?.setDisplayZoom(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewport.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewport.kt
@@ -276,9 +276,12 @@ internal class EditorViewportState(initialScrollOffset: Offset = Offset.Zero) {
       return false
     }
 
-    retainedTransformScrollTarget = null
+    val resolvedScrollOffset = retainedScrollTarget.coerceToBounds()
+    if (resolvedScrollOffset == retainedScrollTarget) {
+      retainedTransformScrollTarget = null
+    }
     setScrollOffset(
-      nextScrollOffset = retainedScrollTarget.coerceToBounds(),
+      nextScrollOffset = resolvedScrollOffset,
       isAutoScroll = true,
       emitScrollEvent = true,
     )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/viewport/EditorViewportAnchorState.kt
@@ -10,6 +10,7 @@ import co.typie.editor.scroll.EditorBringIntoViewTarget
 import co.typie.editor.scroll.EditorVisibleArea
 import co.typie.editor.scroll.resolveKeepVisibleRange
 import co.typie.editor.scroll.resolveKeepVisibleScrollOffset
+import kotlin.math.abs
 
 internal data class EditorViewportAnchorGeometry(
   val pointY: Float,
@@ -23,11 +24,17 @@ internal data class EditorViewportAnchorRevealOrigin(
   val policy: EditorBringIntoViewPolicy,
 )
 
+internal data class EditorViewportAnchorScroll(
+  val scrollOffset: Offset,
+  val attachmentAchieved: Boolean,
+)
+
 internal class EditorViewportAnchorState {
   private data class Active(
     val identity: ViewportAnchor,
     val pointAttachmentX: Float,
     val pointAttachmentY: Float,
+    val attachmentPending: Boolean,
     val rect: VerticalSpan?,
     val revealOrigin: EditorViewportAnchorRevealOrigin?,
   )
@@ -125,8 +132,9 @@ internal class EditorViewportAnchorState {
     identity: ViewportAnchor,
     geometry: EditorViewportAnchorGeometry,
     scrollOffset: Offset,
+    attachmentPending: Boolean = false,
   ) {
-    attachActive(identity, geometry, scrollOffset)
+    attachActive(identity, geometry, scrollOffset, attachmentPending = attachmentPending)
   }
 
   fun adoptSelection(
@@ -169,6 +177,7 @@ internal class EditorViewportAnchorState {
     geometry: EditorViewportAnchorGeometry,
     scrollOffset: Offset,
     revealOrigin: EditorViewportAnchorRevealOrigin? = null,
+    attachmentPending: Boolean = false,
   ) {
     if (!geometry.pointX.isFinite() || !geometry.pointY.isFinite()) return
     if (!scrollOffset.x.isFinite() || !scrollOffset.y.isFinite()) return
@@ -177,6 +186,7 @@ internal class EditorViewportAnchorState {
         identity = identity,
         pointAttachmentX = geometry.pointX - scrollOffset.x,
         pointAttachmentY = geometry.pointY - scrollOffset.y,
+        attachmentPending = attachmentPending,
         rect = geometry.rect,
         revealOrigin = revealOrigin,
       )
@@ -186,16 +196,31 @@ internal class EditorViewportAnchorState {
     geometry: EditorViewportAnchorGeometry,
     currentScrollOffset: Offset,
     maximumScrollOffset: Offset,
-  ): Offset {
-    val current = active ?: return currentScrollOffset
-    if (!geometry.pointX.isFinite() || !geometry.pointY.isFinite()) return currentScrollOffset
-    if (!maximumScrollOffset.x.isFinite() || !maximumScrollOffset.y.isFinite()) {
-      return currentScrollOffset
+  ): EditorViewportAnchorScroll {
+    val current =
+      active ?: return EditorViewportAnchorScroll(currentScrollOffset, attachmentAchieved = false)
+    if (!geometry.pointX.isFinite() || !geometry.pointY.isFinite()) {
+      return EditorViewportAnchorScroll(currentScrollOffset, attachmentAchieved = false)
     }
-    if (maximumScrollOffset.x < 0f || maximumScrollOffset.y < 0f) return currentScrollOffset
-    return Offset(
-      x = (geometry.pointX - current.pointAttachmentX).coerceIn(0f, maximumScrollOffset.x),
-      y = (geometry.pointY - current.pointAttachmentY).coerceIn(0f, maximumScrollOffset.y),
+    if (!maximumScrollOffset.x.isFinite() || !maximumScrollOffset.y.isFinite()) {
+      return EditorViewportAnchorScroll(currentScrollOffset, attachmentAchieved = false)
+    }
+    if (maximumScrollOffset.x < 0f || maximumScrollOffset.y < 0f) {
+      return EditorViewportAnchorScroll(currentScrollOffset, attachmentAchieved = false)
+    }
+    val desiredScrollOffset =
+      Offset(
+        x = geometry.pointX - current.pointAttachmentX,
+        y = geometry.pointY - current.pointAttachmentY,
+      )
+    val scrollOffset =
+      Offset(
+        x = desiredScrollOffset.x.coerceIn(0f, maximumScrollOffset.x),
+        y = desiredScrollOffset.y.coerceIn(0f, maximumScrollOffset.y),
+      )
+    return EditorViewportAnchorScroll(
+      scrollOffset = scrollOffset,
+      attachmentAchieved = scrollOffset == desiredScrollOffset,
     )
   }
 
@@ -205,15 +230,24 @@ internal class EditorViewportAnchorState {
     maximumScrollOffset: Offset,
     visibleArea: EditorVisibleArea,
     resolveReveal: ((EditorViewportAnchorRevealOrigin) -> Float?)? = null,
-  ): Offset {
+  ): EditorViewportAnchorScroll {
     val exact = publicationScroll(geometry, currentScrollOffset, maximumScrollOffset)
     if (!rectHeightChanged(active?.rect, geometry.rect)) return exact
     active?.revealOrigin?.let { origin ->
       resolveReveal?.invoke(origin)?.let {
-        return exact.copy(y = it.coerceIn(0f, maximumScrollOffset.y))
+        return EditorViewportAnchorScroll(
+          scrollOffset = exact.scrollOffset.copy(y = it.coerceIn(0f, maximumScrollOffset.y)),
+          attachmentAchieved = true,
+        )
       }
     }
-    return exact.copy(y = resizeScroll(geometry, exact.y, maximumScrollOffset.y, visibleArea))
+    return EditorViewportAnchorScroll(
+      scrollOffset =
+        exact.scrollOffset.copy(
+          y = resizeScroll(geometry, exact.scrollOffset.y, maximumScrollOffset.y, visibleArea)
+        ),
+      attachmentAchieved = true,
+    )
   }
 
   fun acceptGeometry(geometry: EditorViewportAnchorGeometry, scrollOffset: Offset) {
@@ -224,6 +258,42 @@ internal class EditorViewportAnchorState {
       scrollOffset = scrollOffset,
       revealOrigin = current.revealOrigin,
     )
+  }
+
+  fun deferAttachment() {
+    active = active?.copy(attachmentPending = true)
+  }
+
+  fun acceptGeometryAfterAutomaticScroll(
+    geometry: EditorViewportAnchorGeometry,
+    scrollOffset: Offset,
+  ) {
+    if (active?.attachmentPending == true) {
+      acceptGeometryIfAttached(geometry, scrollOffset)
+    } else {
+      acceptGeometry(geometry, scrollOffset)
+    }
+  }
+
+  private fun acceptGeometryIfAttached(
+    geometry: EditorViewportAnchorGeometry,
+    scrollOffset: Offset,
+    tolerance: Float = 1f,
+  ): Boolean {
+    val current = active ?: return false
+    val desiredScrollOffset =
+      Offset(
+        x = geometry.pointX - current.pointAttachmentX,
+        y = geometry.pointY - current.pointAttachmentY,
+      )
+    if (
+      abs(scrollOffset.x - desiredScrollOffset.x) > tolerance ||
+        abs(scrollOffset.y - desiredScrollOffset.y) > tolerance
+    ) {
+      return false
+    }
+    acceptGeometry(geometry, scrollOffset)
+    return true
   }
 
   fun finishRevealConvergence() {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -162,6 +162,7 @@ import co.typie.screen.editor.editor.overlay.EditorCharacterCountOverlay
 import co.typie.screen.editor.editor.overlay.EditorRepasteAsTextOverlay
 import co.typie.screen.editor.editor.overlay.EditorScreenOverlayHost
 import co.typie.screen.editor.editor.overlay.EditorScrollbars
+import co.typie.screen.editor.editor.overlay.EditorZoomIndicatorState
 import co.typie.screen.editor.editor.overlay.EditorZoomOverlay
 import co.typie.screen.editor.editor.placeholder.EditorDocumentPlaceholder
 import co.typie.screen.editor.editor.spellcheck.SpellcheckOverlay
@@ -220,6 +221,7 @@ import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
 import co.typie.ui.component.topbar.ProvideTopBar
 import co.typie.ui.component.topbar.TopBarCenterAppearance
+import co.typie.ui.input.PointerInputModeState
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.HazeState
@@ -284,6 +286,8 @@ fun EditorScreen(entityId: String) {
     }
   var assetQueryGeneration by remember(entityId) { mutableStateOf(0L) }
   val zoomController = rememberEditorZoomController(key = entityId)
+  val zoomIndicatorState = remember(entityId) { EditorZoomIndicatorState() }
+  val pointerInputModeState = remember(entityId) { PointerInputModeState() }
   val viewportAnchorState = remember(entityId) { EditorViewportAnchorState() }
   val screenState = rememberEditorScreenState(key = entityId)
   val subPaneState = remember(entityId) { EditorSubPaneState() }
@@ -1759,6 +1763,7 @@ fun EditorScreen(entityId: String) {
                 anchor = anchor,
                 displayPosition = displayPosition,
                 scrollOffset = scrollOffset,
+                attachmentPending = screenState.viewportState.scrollOffset != scrollOffset,
                 contentOriginY = resolveViewportAnchorContentOriginY(frame),
               )
             },
@@ -1851,7 +1856,11 @@ fun EditorScreen(entityId: String) {
         viewportContentWidth = bodyTrackWidth,
         viewportAnchorState = viewportAnchorState,
         viewportScrollReconcileMode = viewportScrollReconcileMode,
+        pointerInputModeState = pointerInputModeState,
         onViewportIndirectInput = { uiState.contextMenu.hide() },
+        onViewportPointerEnter = {
+          zoomIndicatorState.onPanePointerEnter(zoomController.resolveLandmark())
+        },
         onRequestEditing =
           if (!isEditing && !editorReadOnly) {
             {
@@ -1952,9 +1961,15 @@ fun EditorScreen(entityId: String) {
           }
           if (editorReady) {
             EditorZoomOverlay(
+              state = zoomIndicatorState,
+              nonTouchPointerActive = pointerInputModeState.nonTouchPointerActive,
+              onZoomIn = interactionScope.controller::zoomInAtViewportCenter,
+              onZoomOut = interactionScope.controller::zoomOutAtViewportCenter,
+              onToggleZoom = interactionScope.controller::toggleIndicatorZoomAtViewportCenter,
+              onRequestEditorFocus = ::requestEditorFocus,
               modifier =
-                Modifier.align(Alignment.BottomStart)
-                  .padding(start = 20.dp, bottom = 20.dp + visibleArea.bottomOcclusion.dp)
+                Modifier.align(Alignment.TopEnd)
+                  .padding(end = 20.dp, top = 20.dp + visibleArea.topOcclusion.dp),
             )
             EditorCharacterCountOverlay(
               editor = runtime.editor,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/header/EditorHeaderReadingTapGesture.kt
@@ -137,6 +137,10 @@ internal fun Modifier.observeEditorHeaderReadingTaps(
       try {
         awaitEachGesture {
           val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+          if (down.isConsumed) {
+            tracker.cancel()
+            return@awaitEachGesture
+          }
           if (!enabled()) {
             tracker.cancel()
             return@awaitEachGesture
@@ -176,6 +180,10 @@ internal fun Modifier.observeEditorHeaderReadingTaps(
                 return@awaitEachGesture
               }
               continue
+            }
+            if (change.isConsumed) {
+              tracker.cancel()
+              return@awaitEachGesture
             }
             if (event.changes.count { it.pressed } > 1) {
               tracker.cancel()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayout.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.draw.clipToBounds
@@ -88,6 +89,8 @@ import co.typie.screen.editor.editor.overlay.editorSoftwareMagnifierLens
 import co.typie.screen.editor.editor.overlay.editorSoftwareMagnifierSource
 import co.typie.screen.editor.editor.overlay.resolveEditorMagnifierPlacement
 import co.typie.screen.editor.editor.state.EditorScreenState
+import co.typie.ui.input.PointerInputModeState
+import co.typie.ui.input.trackPointerInputMode
 import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.hazeSource
 import kotlin.math.max
@@ -198,6 +201,7 @@ internal enum class EditorViewportScrollReconcileMode {
   Enabled,
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun EditorScreenLayout(
   state: EditorScreenState,
@@ -212,7 +216,9 @@ internal fun EditorScreenLayout(
   editorInteractionEnabled: Boolean = true,
   platformIndirectScaleEnabled: Boolean = editorInteractionEnabled,
   viewportScrollReconcileMode: EditorViewportScrollReconcileMode,
+  pointerInputModeState: PointerInputModeState? = null,
   onViewportIndirectInput: () -> Unit = {},
+  onViewportPointerEnter: () -> Unit = {},
   onRequestEditing: (() -> Boolean)? = null,
   onMeasuredViewportSizeChange: (Size) -> Unit,
   header: @Composable () -> Unit,
@@ -225,6 +231,7 @@ internal fun EditorScreenLayout(
   modifier: Modifier = Modifier,
 ) {
   val density = LocalDensity.current
+  val activePointerInputModeState = pointerInputModeState ?: remember { PointerInputModeState() }
   val scrollGestureLockState = LocalScrollGestureLockState.current
   val platformIndirectScaleBridge = remember { EditorPlatformIndirectScaleBridge() }
   val viewConfiguration = LocalViewConfiguration.current
@@ -342,6 +349,10 @@ internal fun EditorScreenLayout(
       modifier
         .fillMaxSize()
         .observeEditorScreenPointerSequence(screenPointerSequence)
+        .trackPointerInputMode(
+          state = activePointerInputModeState,
+          onNonTouchPointerEnter = onViewportPointerEnter,
+        )
         .editorNativeMagnifier(magnifierPlacement)
         .onGloballyPositioned { coordinates ->
           layoutBoundsInRoot = coordinates.unclippedBoundsInRoot()
@@ -433,7 +444,13 @@ internal fun EditorScreenLayout(
         )
         smoothScrollSession.translate(state.viewportState.scrollOffset.y - previousScrollOffset.y)
         anchorPublication.geometry?.let { geometry ->
-          activeViewportAnchorState.acceptGeometry(geometry, state.viewportState.scrollOffset)
+          if (
+            anchorPublication.attachmentAchieved &&
+              (state.viewportState.scrollOffset - anchorPublication.scrollOffset).getDistance() <=
+                1f
+          ) {
+            activeViewportAnchorState.acceptGeometry(geometry, state.viewportState.scrollOffset)
+          }
         }
         candidate
       }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconciler.kt
@@ -22,8 +22,11 @@ import co.typie.editor.viewport.viewportCenterAnchorPoint
 internal sealed interface EditorViewportAnchorPublication {
   data object Withhold : EditorViewportAnchorPublication
 
-  data class Ready(val scrollOffset: Offset, val geometry: EditorViewportAnchorGeometry?) :
-    EditorViewportAnchorPublication
+  data class Ready(
+    val scrollOffset: Offset,
+    val geometry: EditorViewportAnchorGeometry?,
+    val attachmentAchieved: Boolean = true,
+  ) : EditorViewportAnchorPublication
 }
 
 internal fun reconcileViewportAnchorPublication(
@@ -77,6 +80,7 @@ internal fun reconcileViewportAnchorPublication(
           y = currentScrollY.coerceIn(0f, maximumScrollY),
         ),
       geometry = null,
+      attachmentAchieved = false,
     )
   if (publishedBundle == null || publishedBundle.snapshot.version == candidateState.version) {
     return unanchoredPublication
@@ -103,32 +107,35 @@ internal fun reconcileViewportAnchorPublication(
           frame = candidateFrame,
           contentOriginY = contentOriginY,
         ) ?: return EditorViewportAnchorPublication.Withhold
+      val anchorScroll =
+        anchorState.publicationRevealScroll(
+          geometry = geometry,
+          currentScrollOffset = currentScrollOffset,
+          maximumScrollOffset = Offset(x = maximumScrollX, y = maximumScrollY),
+          visibleArea = measuredScrollFrame.visibleArea,
+          resolveReveal = { origin ->
+            when (
+              val result =
+                resolveEditorScrollIntent(
+                  frame = candidateFrame,
+                  target = origin.target,
+                  policy = origin.policy,
+                  currentScroll = origin.scrollY,
+                  contentOriginY = contentOriginY,
+                  maximumScrollY = maximumScrollY,
+                )
+            ) {
+              EditorScrollIntentResult.Unresolved -> null
+              EditorScrollIntentResult.NoScroll -> origin.scrollY
+              is EditorScrollIntentResult.ScrollTo -> result.y
+            }
+          },
+        )
+      if (!anchorScroll.attachmentAchieved) anchorState.deferAttachment()
       EditorViewportAnchorPublication.Ready(
-        scrollOffset =
-          anchorState.publicationRevealScroll(
-            geometry = geometry,
-            currentScrollOffset = currentScrollOffset,
-            maximumScrollOffset = Offset(x = maximumScrollX, y = maximumScrollY),
-            visibleArea = measuredScrollFrame.visibleArea,
-            resolveReveal = { origin ->
-              when (
-                val result =
-                  resolveEditorScrollIntent(
-                    frame = candidateFrame,
-                    target = origin.target,
-                    policy = origin.policy,
-                    currentScroll = origin.scrollY,
-                    contentOriginY = contentOriginY,
-                    maximumScrollY = maximumScrollY,
-                  )
-              ) {
-                EditorScrollIntentResult.Unresolved -> null
-                EditorScrollIntentResult.NoScroll -> origin.scrollY
-                is EditorScrollIntentResult.ScrollTo -> result.y
-              }
-            },
-          ),
+        scrollOffset = anchorScroll.scrollOffset,
         geometry = geometry,
+        attachmentAchieved = anchorScroll.attachmentAchieved,
       )
     }
   }
@@ -283,7 +290,9 @@ internal fun reconcileViewportAnchorObservation(
       }
     when {
       viewportState.lastScrollWasAuto ->
-        geometry?.let { anchorState.acceptGeometry(it, viewportState.scrollOffset) }
+        geometry?.let {
+          anchorState.acceptGeometryAfterAutomaticScroll(it, viewportState.scrollOffset)
+        }
       preferredSelectionGeometry != null &&
         anchorState.tryReactivatePreferredSelection(
           geometry = preferredSelectionGeometry,
@@ -372,6 +381,7 @@ internal fun attachViewportZoomAnchor(
   displayPosition: Offset,
   scrollOffset: Offset,
   contentOriginY: Float,
+  attachmentPending: Boolean = false,
 ) {
   if (
     !displayPosition.x.isFinite() || !displayPosition.y.isFinite() || !contentOriginY.isFinite()
@@ -393,6 +403,7 @@ internal fun attachViewportZoomAnchor(
         pointY = contentOriginY + displayPosition.y,
       ),
     scrollOffset = scrollOffset,
+    attachmentPending = attachmentPending,
   )
 }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomIndicatorState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomIndicatorState.kt
@@ -1,0 +1,233 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import co.typie.editor.EditorZoomLandmark
+import co.typie.editor.zoomDiffers
+
+@Stable
+internal class EditorZoomIndicatorState {
+  var visibilityRequest by mutableIntStateOf(0)
+    private set
+
+  var autoHideDelayMillis by mutableLongStateOf(ZOOM_INDICATOR_DEFAULT_DWELL_MS)
+    private set
+
+  var landmarkRequest by mutableIntStateOf(0)
+    private set
+
+  var announcedLandmark by mutableStateOf<EditorZoomLandmark?>(null)
+    private set
+
+  var landmarkHeld by mutableStateOf(false)
+    private set
+
+  var snapFeedbackRequest by mutableIntStateOf(0)
+    private set
+
+  var snapFeedbackLandmark by mutableStateOf<EditorZoomLandmark?>(null)
+    private set
+
+  private var enabled by mutableStateOf(false)
+  private var transientVisible by mutableStateOf(false)
+  private var indicatorHovered by mutableStateOf(false)
+  private var focusWithin by mutableStateOf(false)
+  private var valueHovered by mutableStateOf(false)
+  private var valueFocused by mutableStateOf(false)
+  private var lastZoom: Float? = null
+  private var lastLandmark: EditorZoomLandmark? = null
+  private var landmarkInitialized = false
+  private var lastRangeState: ZoomRangeState? = null
+
+  val visible: Boolean
+    get() = enabled && (transientVisible || landmarkHeld || indicatorHovered || focusWithin)
+
+  fun updateZoom(
+    enabled: Boolean,
+    displayZoom: Float,
+    indicatorZoom: Float = displayZoom,
+    landmark: EditorZoomLandmark?,
+  ) {
+    val entered = enabled && !this.enabled
+    this.enabled = enabled
+    if (!enabled) {
+      transientVisible = false
+      announcedLandmark = null
+      landmarkHeld = false
+      snapFeedbackLandmark = null
+      lastZoom = null
+      lastRangeState = null
+      lastLandmark = null
+      landmarkInitialized = false
+      return
+    }
+
+    val previousZoom = lastZoom
+    val initialObservation = previousZoom == null
+    val zoomChanged = !initialObservation && zoomDiffers(previousZoom, displayZoom)
+    val rangeState = resolveZoomRangeState(displayZoom, indicatorZoom)
+    val previousRangeState = lastRangeState
+    val previousLandmark = lastLandmark
+    val hadPreviousLandmark = landmarkInitialized
+    lastZoom = displayZoom
+    lastRangeState = rangeState
+    lastLandmark = landmark
+    landmarkInitialized = true
+
+    val shouldShowOnEntry = entered && landmark != EditorZoomLandmark.Unit
+    if (zoomChanged || shouldShowOnEntry) requestVisibility()
+
+    if (previousRangeState == null || !hadPreviousLandmark) return
+
+    if (rangeState != previousRangeState) {
+      onRangeStateChanged(previousRangeState, rangeState)
+      return
+    }
+
+    if (rangeState == ZoomRangeState.InRange && landmark != previousLandmark) {
+      onInRangeLandmarkChanged(landmark)
+    }
+  }
+
+  fun onBoundaryAttempt(landmark: EditorZoomLandmark) {
+    if (!enabled) return
+    if (lastRangeState != ZoomRangeState.InRange || lastLandmark != landmark) return
+    if (landmark != EditorZoomLandmark.Minimum && landmark != EditorZoomLandmark.Maximum) return
+    announceLandmark(landmark)
+    requestVisibility()
+  }
+
+  fun onPanePointerEnter(landmark: EditorZoomLandmark?) {
+    if (enabled && landmark != EditorZoomLandmark.Unit) requestVisibility()
+  }
+
+  fun onIndicatorPointerEnter() {
+    indicatorHovered = true
+  }
+
+  fun onIndicatorPointerExit() {
+    if (enabled && indicatorHovered) requestVisibility()
+    indicatorHovered = false
+  }
+
+  fun onFocusChanged(focused: Boolean) {
+    if (enabled && focusWithin && !focused) requestVisibility()
+    focusWithin = focused
+  }
+
+  fun onValuePointerEnter() {
+    valueHovered = true
+  }
+
+  fun onValuePointerExit() {
+    valueHovered = false
+  }
+
+  fun displayedLandmark(landmark: EditorZoomLandmark?): EditorZoomLandmark? =
+    if (valueHovered || valueFocused) landmark else announcedLandmark
+
+  fun displayText(landmark: EditorZoomLandmark?, zoomPercent: Int): String =
+    displayedLandmark(landmark)?.label ?: "$zoomPercent%"
+
+  fun onValueFocusChanged(focused: Boolean) {
+    valueFocused = focused
+  }
+
+  fun expireVisibility(request: Int) {
+    if (request == visibilityRequest) transientVisible = false
+  }
+
+  fun expireLandmark(request: Int) {
+    if (request == landmarkRequest && !landmarkHeld) announcedLandmark = null
+  }
+
+  fun reset() {
+    visibilityRequest += 1
+    landmarkRequest += 1
+    autoHideDelayMillis = ZOOM_INDICATOR_DEFAULT_DWELL_MS
+    enabled = false
+    transientVisible = false
+    indicatorHovered = false
+    focusWithin = false
+    valueHovered = false
+    valueFocused = false
+    announcedLandmark = null
+    landmarkHeld = false
+    snapFeedbackRequest = 0
+    snapFeedbackLandmark = null
+    lastZoom = null
+    lastLandmark = null
+    landmarkInitialized = false
+    lastRangeState = null
+  }
+
+  private fun requestVisibility() {
+    autoHideDelayMillis =
+      if (announcedLandmark == null) {
+        ZOOM_INDICATOR_DEFAULT_DWELL_MS
+      } else {
+        ZOOM_INDICATOR_LANDMARK_DWELL_MS
+      }
+    visibilityRequest += 1
+    transientVisible = true
+  }
+
+  private fun announceLandmark(landmark: EditorZoomLandmark?, held: Boolean = false) {
+    if (landmark == null && announcedLandmark == null && !landmarkHeld) return
+    landmarkRequest += 1
+    announcedLandmark = landmark
+    landmarkHeld = landmark != null && held
+  }
+
+  private fun onRangeStateChanged(previous: ZoomRangeState, current: ZoomRangeState) {
+    val boundary = current.landmark
+    if (boundary != null) {
+      announceLandmark(boundary, held = true)
+    } else {
+      announceLandmark(previous.landmark)
+      requestSnapFeedback(previous.landmark)
+    }
+    requestVisibility()
+  }
+
+  private fun onInRangeLandmarkChanged(landmark: EditorZoomLandmark?) {
+    announceLandmark(landmark)
+    requestSnapFeedback(landmark)
+    requestVisibility()
+  }
+
+  private fun requestSnapFeedback(landmark: EditorZoomLandmark?) {
+    if (landmark == null) return
+    snapFeedbackLandmark = landmark
+    snapFeedbackRequest += 1
+  }
+}
+
+private const val ZOOM_INDICATOR_DEFAULT_DWELL_MS = 1000L
+private const val ZOOM_INDICATOR_LANDMARK_DWELL_MS = 2000L
+
+private enum class ZoomRangeState(val landmark: EditorZoomLandmark?) {
+  InRange(null),
+  BelowMinimum(EditorZoomLandmark.Minimum),
+  AboveMaximum(EditorZoomLandmark.Maximum),
+}
+
+private fun resolveZoomRangeState(displayZoom: Float, indicatorZoom: Float): ZoomRangeState =
+  when {
+    !zoomDiffers(displayZoom, indicatorZoom) -> ZoomRangeState.InRange
+    displayZoom < indicatorZoom -> ZoomRangeState.BelowMinimum
+    else -> ZoomRangeState.AboveMaximum
+  }
+
+private val EditorZoomLandmark.label: String
+  get() =
+    when (this) {
+      EditorZoomLandmark.Minimum -> "최소"
+      EditorZoomLandmark.FitWidth -> "맞춤"
+      EditorZoomLandmark.Unit -> "원본"
+      EditorZoomLandmark.Maximum -> "최대"
+    }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomOverlay.kt
@@ -1,102 +1,458 @@
 package co.typie.screen.editor.editor.overlay
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import co.typie.editor.EditorZoomLandmark
 import co.typie.editor.LocalEditorZoomController
-import co.typie.editor.zoomDiffers
+import co.typie.ext.LocalInteractionSource
+import co.typie.ext.pressScale
+import co.typie.icons.Lucide
+import co.typie.screen.editor.editor.layout.viewportDirectControl
+import co.typie.screen.editor.editor.toolbar.emitPressInteractions
+import co.typie.screen.editor.editor.toolbar.preserveEditorFocusOnToolbarInteraction
 import co.typie.ui.component.Text
+import co.typie.ui.icon.Icon
+import co.typie.ui.icon.IconData
+import co.typie.ui.input.hasNonTouchPointer
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
+import kotlin.math.roundToInt
 import kotlinx.coroutines.delay
 
-private const val ZoomOverlayVisibleMs = 1000L
-private const val ZoomOverlayFadeMs = 180
-private val ZoomOverlayWidth = 56.dp
+private const val ZOOM_LANDMARK_VISIBLE_MS = 1000L
+private const val ZOOM_OVERLAY_FADE_MS = 180
+private const val ZOOM_VALUE_TRANSITION_MS = 160
+private val ZoomPointerValueWidth = 68.dp
 private val ZoomOverlayShape = AppShapes.rounded(8.dp)
+private val ZoomButtonShape = AppShapes.rounded(8.dp)
+private val ZoomValueEasing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
 
+private data class ZoomValuePresentation(
+  val text: String,
+  val icon: IconData,
+  val isLandmark: Boolean,
+)
+
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-internal fun EditorZoomOverlay(modifier: Modifier = Modifier) {
+internal fun EditorZoomOverlay(
+  state: EditorZoomIndicatorState,
+  nonTouchPointerActive: Boolean,
+  onZoomOut: () -> Boolean,
+  onZoomIn: () -> Boolean,
+  onToggleZoom: () -> EditorZoomLandmark?,
+  onRequestEditorFocus: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
   val zoomController = LocalEditorZoomController.current
   val enabled = zoomController.isZoomEnabled
   val displayZoom = zoomController.displayZoom
   val indicatorZoom = zoomController.indicatorZoom
+  val landmark = zoomController.resolveLandmark()
+  val zoomOutAvailable = zoomController.resolveZoomOutTarget() != null
+  val zoomInAvailable = zoomController.resolveZoomInTarget() != null
+  val toggleTarget = zoomController.resolveIndicatorToggleTarget()
+  val toggleTargetLandmark = toggleTarget?.let(zoomController::resolveLandmark)
+  val toggleDescription = toggleDescription(toggleTargetLandmark)
 
-  var visible by remember { mutableStateOf(false) }
-  var lastZoom by remember { mutableStateOf<Float?>(null) }
-  var wasEnabled by remember { mutableStateOf(false) }
-  var showRequest by remember { mutableIntStateOf(0) }
-
-  LaunchedEffect(enabled, displayZoom) {
-    val entered = enabled && !wasEnabled
-    wasEnabled = enabled
-    val previousZoom = lastZoom
-    lastZoom = displayZoom
-    val shouldShow = previousZoom == null || zoomDiffers(previousZoom, displayZoom)
-
-    if (enabled && (entered || shouldShow)) {
-      showRequest += 1
-    } else if (!enabled) {
-      visible = false
-    }
+  LaunchedEffect(enabled, displayZoom, indicatorZoom, landmark) {
+    state.updateZoom(
+      enabled = enabled,
+      displayZoom = displayZoom,
+      indicatorZoom = indicatorZoom,
+      landmark = landmark,
+    )
   }
-
-  LaunchedEffect(showRequest) {
-    if (showRequest <= 0) {
-      return@LaunchedEffect
-    }
-
-    visible = true
-    delay(ZoomOverlayVisibleMs)
-    visible = false
+  LaunchedEffect(state.visibilityRequest) {
+    val request = state.visibilityRequest
+    if (request <= 0) return@LaunchedEffect
+    delay(state.autoHideDelayMillis)
+    state.expireVisibility(request)
   }
-
-  if (!enabled) {
-    return
+  LaunchedEffect(state.landmarkRequest) {
+    val request = state.landmarkRequest
+    if (request <= 0 || state.landmarkHeld) return@LaunchedEffect
+    delay(ZOOM_LANDMARK_VISIBLE_MS)
+    state.expireLandmark(request)
   }
+  DisposableEffect(state) { onDispose(state::reset) }
+
+  if (!enabled) return
 
   val alpha by
     animateFloatAsState(
-      targetValue = if (visible) 1f else 0f,
-      animationSpec = tween(durationMillis = ZoomOverlayFadeMs),
+      targetValue = if (state.visible) 1f else 0f,
+      animationSpec = tween(durationMillis = ZOOM_OVERLAY_FADE_MS),
       label = "editor-zoom-overlay-alpha",
     )
-  val zoomPercent = (indicatorZoom * 100f).toInt()
+  if (!state.visible && alpha == 0f && !nonTouchPointerActive) return
 
-  Box(modifier = modifier.graphicsLayer { this.alpha = alpha }) {
-    Box(
+  val zoomPercent = (indicatorZoom * 100f).roundToInt()
+  val displayedLandmark = state.displayedLandmark(landmark)
+  val valuePresentation =
+    ZoomValuePresentation(
+      text = state.displayText(landmark = landmark, zoomPercent = zoomPercent),
+      icon = displayedLandmark?.indicatorIcon ?: Lucide.Search,
+      isLandmark = displayedLandmark != null,
+    )
+
+  Box(
+    modifier =
+      modifier
+        .graphicsLayer { this.alpha = alpha }
+        .onFocusChanged { state.onFocusChanged(it.hasFocus) }
+  ) {
+    Row(
       modifier =
         Modifier.clip(ZoomOverlayShape)
           .border(1.dp, AppTheme.colors.borderEmphasis, ZoomOverlayShape)
-          .background(AppTheme.colors.surfaceDefault.copy(alpha = 0.95f), ZoomOverlayShape)
-          .width(ZoomOverlayWidth)
-          .padding(vertical = 8.dp),
+          .background(
+            lerp(AppTheme.colors.surfaceDefault, AppTheme.colors.surfaceInset, 0.15f)
+              .copy(alpha = 0.95f),
+            ZoomOverlayShape,
+          )
+          .onPointerEvent(PointerEventType.Enter, PointerEventPass.Initial) { event ->
+            if (event.hasNonTouchPointer()) {
+              state.onIndicatorPointerEnter()
+            }
+          }
+          .onPointerEvent(PointerEventType.Exit, PointerEventPass.Initial) {
+            state.onIndicatorPointerExit()
+          }
+          .then(
+            if (state.visible) {
+              Modifier.viewportDirectControl().preserveEditorFocusOnToolbarInteraction()
+            } else {
+              Modifier
+            }
+          )
+          .padding(4.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      if (nonTouchPointerActive) {
+        ZoomIconButton(
+          icon = Lucide.Minus,
+          contentDescription = if (zoomOutAvailable) "페이지 축소" else "최소 배율입니다",
+          enabled = state.visible,
+          available = zoomOutAvailable,
+          onClick = {
+            try {
+              applyZoomStep(onZoomOut, state, EditorZoomLandmark.Minimum)
+            } finally {
+              onRequestEditorFocus()
+            }
+          },
+        )
+      }
+
+      ZoomValueButton(
+        presentation = valuePresentation,
+        snapFeedbackRequest = state.snapFeedbackRequest,
+        snapFeedbackLandmark = state.snapFeedbackLandmark,
+        contentDescription = toggleDescription,
+        fixedWidth = nonTouchPointerActive,
+        enabled = state.visible && toggleTarget != null,
+        onPointerEnter = state::onValuePointerEnter,
+        onPointerExit = state::onValuePointerExit,
+        onFocusChanged = state::onValueFocusChanged,
+        onClick = {
+          try {
+            onToggleZoom()
+          } finally {
+            onRequestEditorFocus()
+          }
+        },
+      )
+
+      if (nonTouchPointerActive) {
+        ZoomIconButton(
+          icon = Lucide.Plus,
+          contentDescription = if (zoomInAvailable) "페이지 확대" else "최대 배율입니다",
+          enabled = state.visible,
+          available = zoomInAvailable,
+          onClick = {
+            try {
+              applyZoomStep(onZoomIn, state, EditorZoomLandmark.Maximum)
+            } finally {
+              onRequestEditorFocus()
+            }
+          },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun ZoomIconButton(
+  icon: IconData,
+  contentDescription: String,
+  enabled: Boolean,
+  available: Boolean,
+  onClick: () -> Unit,
+) {
+  val interactionSource = remember { MutableInteractionSource() }
+  val hovered by interactionSource.collectIsHoveredAsState()
+  CompositionLocalProvider(LocalInteractionSource provides interactionSource) {
+    Box(
+      modifier =
+        Modifier.size(28.dp)
+          .pressScale()
+          .focusProperties { canFocus = false }
+          .clip(ZoomButtonShape)
+          .background(
+            if (hovered && enabled) AppTheme.colors.borderDefault else Color.Transparent,
+            ZoomButtonShape,
+          )
+          .clickable(
+            enabled = enabled,
+            interactionSource = interactionSource,
+            indication = null,
+            role = Role.Button,
+            onClick = onClick,
+          )
+          .acceptDirectControlClick(
+            enabled = enabled,
+            interactionSource = interactionSource,
+            onClick = onClick,
+          )
+          .semantics { this.contentDescription = contentDescription },
       contentAlignment = Alignment.Center,
     ) {
-      Text(
-        text = "$zoomPercent%",
-        style = AppTheme.typography.caption.copy(fontWeight = FontWeight.W500),
-        color = AppTheme.colors.textDefault,
-        textAlign = TextAlign.Center,
+      Icon(
+        icon = icon,
+        contentDescription = null,
+        modifier = Modifier.size(14.dp),
+        tint = if (enabled && available) AppTheme.colors.textMuted else AppTheme.colors.textHint,
       )
     }
   }
 }
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun ZoomValueButton(
+  presentation: ZoomValuePresentation,
+  snapFeedbackRequest: Int,
+  snapFeedbackLandmark: EditorZoomLandmark?,
+  contentDescription: String,
+  fixedWidth: Boolean,
+  enabled: Boolean,
+  onPointerEnter: () -> Unit,
+  onPointerExit: () -> Unit,
+  onFocusChanged: (Boolean) -> Unit,
+  onClick: () -> Unit,
+) {
+  val interactionSource = remember { MutableInteractionSource() }
+  val hovered by interactionSource.collectIsHoveredAsState()
+  CompositionLocalProvider(LocalInteractionSource provides interactionSource) {
+    Box(
+      modifier =
+        Modifier.sizeIn(minWidth = 36.dp, minHeight = 28.dp)
+          .then(if (fixedWidth) Modifier.width(ZoomPointerValueWidth) else Modifier)
+          .pressScale()
+          .focusProperties { canFocus = false }
+          .clip(ZoomButtonShape)
+          .border(1.dp, Color.Transparent, ZoomButtonShape)
+          .background(
+            if (hovered && enabled) AppTheme.colors.borderDefault else Color.Transparent,
+            ZoomButtonShape,
+          )
+          .onPointerEvent(PointerEventType.Enter, PointerEventPass.Initial) { event ->
+            if (event.hasNonTouchPointer()) onPointerEnter()
+          }
+          .onPointerEvent(PointerEventType.Exit, PointerEventPass.Initial) { onPointerExit() }
+          .onFocusChanged { onFocusChanged(it.isFocused) }
+          .clickable(
+            enabled = enabled,
+            interactionSource = interactionSource,
+            indication = null,
+            role = Role.Button,
+            onClick = onClick,
+          )
+          .acceptDirectControlClick(
+            enabled = enabled,
+            interactionSource = interactionSource,
+            onClick = onClick,
+          )
+          .semantics { this.contentDescription = contentDescription },
+      contentAlignment = Alignment.Center,
+    ) {
+      ZoomSnapBorderFlash(request = snapFeedbackRequest, landmark = snapFeedbackLandmark)
+      AnimatedContent(
+        modifier = Modifier.padding(horizontal = 6.dp),
+        targetState = presentation,
+        contentKey = ZoomValuePresentation::isLandmark,
+        transitionSpec = {
+          val contentTransition =
+            if (initialState.isLandmark != targetState.isLandmark) {
+              fadeIn(tween(ZOOM_VALUE_TRANSITION_MS)) togetherWith
+                fadeOut(tween(ZOOM_VALUE_TRANSITION_MS))
+            } else {
+              EnterTransition.None togetherWith ExitTransition.None
+            }
+          if (fixedWidth) {
+            contentTransition
+          } else {
+            contentTransition.using(
+              SizeTransform(clip = false) { _, _ ->
+                tween(durationMillis = ZOOM_VALUE_TRANSITION_MS, easing = ZoomValueEasing)
+              }
+            )
+          }
+        },
+        contentAlignment = Alignment.Center,
+        label = "editor-zoom-value",
+      ) { target ->
+        Row(
+          horizontalArrangement = Arrangement.spacedBy(4.dp),
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Icon(
+            icon = target.icon,
+            contentDescription = null,
+            modifier = Modifier.size(14.dp),
+            tint = AppTheme.colors.textMuted,
+          )
+          Text(
+            text = target.text,
+            style = AppTheme.typography.caption.copy(fontWeight = FontWeight.W500),
+            color = AppTheme.colors.textDefault,
+            textAlign = TextAlign.Center,
+            softWrap = false,
+            maxLines = 1,
+          )
+        }
+      }
+    }
+  }
+}
+
+private fun Modifier.acceptDirectControlClick(
+  enabled: Boolean,
+  interactionSource: MutableInteractionSource,
+  onClick: () -> Unit,
+): Modifier =
+  if (enabled) {
+    emitPressInteractions(interactionSource).pointerInput(onClick) {
+      detectTapAfterConsumedDown(onClick)
+    }
+  } else {
+    this
+  }
+
+@Composable
+private fun BoxScope.ZoomSnapBorderFlash(request: Int, landmark: EditorZoomLandmark?) {
+  if (request <= 0 || landmark == null) return
+
+  val coroutineScope = rememberCoroutineScope()
+  val reducedMotion =
+    coroutineScope.coroutineContext[MotionDurationScale]
+      ?.scaleFactor
+      ?.takeIf { it.isFinite() }
+      ?.let { it <= 0f } ?: false
+
+  if (reducedMotion) {
+    var visible by remember(request) { mutableStateOf(true) }
+    LaunchedEffect(request) {
+      delay(280L)
+      visible = false
+    }
+    if (visible) {
+      Box(
+        modifier =
+          Modifier.matchParentSize().border(1.dp, AppTheme.colors.borderDefault, ZoomButtonShape)
+      )
+    }
+    return
+  }
+
+  val alpha = remember(request) { Animatable(0f) }
+  LaunchedEffect(request) {
+    alpha.animateTo(1f, tween(durationMillis = 70))
+    alpha.animateTo(0f, tween(durationMillis = 310))
+  }
+  Box(
+    modifier =
+      Modifier.matchParentSize()
+        .graphicsLayer { this.alpha = alpha.value }
+        .border(2.dp, AppTheme.colors.borderDefault, ZoomButtonShape)
+  )
+}
+
+private fun applyZoomStep(
+  step: () -> Boolean,
+  state: EditorZoomIndicatorState,
+  boundary: EditorZoomLandmark,
+) {
+  if (!step()) state.onBoundaryAttempt(boundary)
+}
+
+private fun toggleDescription(landmark: EditorZoomLandmark?): String =
+  when (landmark) {
+    EditorZoomLandmark.FitWidth -> "화면에 맞추기"
+    EditorZoomLandmark.Unit -> "원본 크기로 돌아가기  ⌘/Ctrl 0"
+    EditorZoomLandmark.Minimum -> "최소 배율로 축소"
+    EditorZoomLandmark.Maximum -> "최대 배율로 확대"
+    null -> "원본 크기가 화면에 맞춰져 있어요"
+  }
+
+private val EditorZoomLandmark.indicatorIcon: IconData
+  get() =
+    when (this) {
+      EditorZoomLandmark.Minimum -> Lucide.ZoomOut
+      EditorZoomLandmark.FitWidth -> Lucide.GalleryHorizontal
+      EditorZoomLandmark.Unit -> Lucide.FileCheckCorner
+      EditorZoomLandmark.Maximum -> Lucide.ZoomIn
+    }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/input/PointerInputModeState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/input/PointerInputModeState.kt
@@ -1,0 +1,51 @@
+package co.typie.ui.input
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.onPointerEvent
+
+@Stable
+internal class PointerInputModeState {
+  var nonTouchPointerActive by mutableStateOf(false)
+    private set
+
+  fun observe(event: PointerEvent): Boolean {
+    nonTouchPointerActive = event.hasNonTouchPointer()
+    return nonTouchPointerActive
+  }
+
+  fun leave(event: PointerEvent) {
+    if (event.hasNonTouchPointer()) nonTouchPointerActive = false
+  }
+}
+
+internal fun PointerEvent.hasNonTouchPointer(): Boolean = changes.any { change ->
+  change.type != PointerType.Touch
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun Modifier.trackPointerInputMode(
+  state: PointerInputModeState,
+  onNonTouchPointerEnter: () -> Unit = {},
+): Modifier =
+  onPointerEvent(PointerEventType.Enter, PointerEventPass.Initial) { event ->
+      if (state.observe(event)) onNonTouchPointerEnter()
+    }
+    .onPointerEvent(PointerEventType.Move, PointerEventPass.Initial) { event ->
+      state.observe(event)
+    }
+    .onPointerEvent(PointerEventType.Press, PointerEventPass.Initial) { event ->
+      state.observe(event)
+    }
+    .onPointerEvent(PointerEventType.Scroll, PointerEventPass.Initial) { event ->
+      state.observe(event)
+    }
+    .onPointerEvent(PointerEventType.Exit, PointerEventPass.Initial) { event -> state.leave(event) }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/EditorZoomStateTest.kt
@@ -5,6 +5,7 @@ import co.typie.editor.body.resolveBaseBottomSpace
 import co.typie.editor.body.resolveContinuousLayoutViewportWidth
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
@@ -78,6 +79,20 @@ class EditorZoomControllerTest {
 
     assertEquals(1f, state.displayZoom, 0.0001f)
     assertEquals(1f, state.renderZoom, 0.0001f)
+  }
+
+  @Test
+  fun `layout sync does not resnap a settled zoom when the viewport resizes`() {
+    val state = EditorZoomController()
+    val layout = EditorDocumentLayoutSpec.Continuous(maxWidth = 600f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+    state.setDisplayZoom(zoom = 0.79f, layoutSpec = layout, viewportWidth = 500f)
+    assertEquals(0.78125f, state.displayZoom, 0.0001f)
+
+    state.syncLayout(layoutSpec = layout, viewportWidth = 496f)
+
+    assertEquals(0.78125f, state.displayZoom, 0.0001f)
+    assertNull(state.resolveLandmark())
   }
 
   @Test
@@ -340,4 +355,133 @@ class EditorZoomControllerTest {
     assertEquals(0.5f, state.displayZoom, 0.0001f)
     assertEquals(EditorZoomSnapKey.FitWidth, state.resolveSnapKey())
   }
+
+  @Test
+  fun `landmark resolver names bounds fit unit and unnamed zooms`() {
+    val layout = paginatedLayout(pageWidth = 1000f)
+
+    assertEquals(EditorZoomLandmark.Minimum, resolveEditorZoomLandmark(0.1f, layout, 500f))
+    assertEquals(EditorZoomLandmark.FitWidth, resolveEditorZoomLandmark(0.5f, layout, 500f))
+    assertNull(resolveEditorZoomLandmark(0.75f, layout, 500f))
+    assertEquals(EditorZoomLandmark.Unit, resolveEditorZoomLandmark(1f, layout, 500f))
+    assertEquals(EditorZoomLandmark.Maximum, resolveEditorZoomLandmark(2f, layout, 500f))
+  }
+
+  @Test
+  fun `landmark resolver prefers unit then fit-width over bounds`() {
+    val layout = paginatedLayout(pageWidth = 1000f)
+
+    assertEquals(EditorZoomLandmark.Unit, resolveEditorZoomLandmark(1f, layout, 1000f))
+    assertEquals(EditorZoomLandmark.FitWidth, resolveEditorZoomLandmark(0.1f, layout, 100f))
+  }
+
+  @Test
+  fun `landmark resolver does not name clamped fit targets as fit-width`() {
+    val layout = paginatedLayout(pageWidth = 1000f)
+
+    assertEquals(EditorZoomLandmark.Minimum, resolveEditorZoomLandmark(0.1f, layout, 50f))
+    assertEquals(EditorZoomLandmark.Maximum, resolveEditorZoomLandmark(2f, layout, 2500f))
+  }
+
+  @Test
+  fun `landmark resolver rejects invalid input`() {
+    val layout = paginatedLayout(pageWidth = 1000f)
+
+    assertNull(resolveEditorZoomLandmark(Float.NaN, layout, 500f))
+    assertNull(resolveEditorZoomLandmark(1f, layout, 0f))
+    assertNull(resolveEditorZoomLandmark(1f, layout, Float.NaN))
+    assertNull(resolveEditorZoomLandmark(1f, paginatedLayout(Float.NaN), 500f))
+  }
+
+  @Test
+  fun `indicator toggle target switches unit and fit and returns other zooms to unit`() {
+    val state = EditorZoomController()
+    val layout = paginatedLayout(pageWidth = 1000f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+    assertEquals(1f, state.resolveIndicatorToggleTarget())
+    state.setDisplayZoom(zoom = 1f, layoutSpec = layout, viewportWidth = 500f)
+    assertEquals(0.5f, state.resolveIndicatorToggleTarget())
+    state.setDisplayZoom(zoom = 1.4f, layoutSpec = layout, viewportWidth = 500f)
+    assertEquals(1f, state.resolveIndicatorToggleTarget())
+  }
+
+  @Test
+  fun `indicator toggle has no target when unit equals fit-width`() {
+    val state = EditorZoomController()
+    val layout = paginatedLayout(pageWidth = 1000f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 1000f)
+
+    assertNull(state.resolveIndicatorToggleTarget())
+  }
+
+  @Test
+  fun `button step targets stop at the normal zoom bounds`() {
+    val state = EditorZoomController()
+    val layout = paginatedLayout(pageWidth = 1000f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+    assertEquals(0.6f, requireNotNull(state.resolveZoomInTarget()), 0.0001f)
+    assertEquals(0.4f, requireNotNull(state.resolveZoomOutTarget()), 0.0001f)
+    state.setDisplayZoom(zoom = 2f, layoutSpec = layout, viewportWidth = 500f)
+    assertNull(state.resolveZoomInTarget())
+    state.setDisplayZoom(zoom = 0.1f, layoutSpec = layout, viewportWidth = 500f)
+    assertNull(state.resolveZoomOutTarget())
+  }
+
+  @Test
+  fun `button steps move to the next ten-percent grid line`() {
+    val state = EditorZoomController()
+    val layout = paginatedLayout(pageWidth = 1000f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 1000f)
+
+    state.setDisplayZoom(zoom = 0.53f, layoutSpec = layout, viewportWidth = 1000f)
+    assertEquals(0.6f, requireNotNull(state.resolveZoomInTarget()), 0.0001f)
+    assertEquals(0.5f, requireNotNull(state.resolveZoomOutTarget()), 0.0001f)
+  }
+
+  @Test
+  fun `button steps stop at landmarks between ten-percent grid lines`() {
+    val state = EditorZoomController()
+    val layout = paginatedLayout(pageWidth = 1000f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 520f)
+
+    state.setDisplayZoom(zoom = 0.45f, layoutSpec = layout, viewportWidth = 520f)
+    assertEquals(0.5f, requireNotNull(state.resolveZoomInTarget()), 0.0001f)
+    state.setDisplayZoom(
+      zoom = 0.5f,
+      layoutSpec = layout,
+      viewportWidth = 520f,
+      snapToLandmarks = false,
+    )
+    assertEquals(0.52f, requireNotNull(state.resolveZoomInTarget()), 0.0001f)
+
+    state.setDisplayZoom(zoom = 0.58f, layoutSpec = layout, viewportWidth = 520f)
+    assertEquals(0.52f, requireNotNull(state.resolveZoomOutTarget()), 0.0001f)
+  }
+
+  @Test
+  fun `button step targets stay unavailable while elastically overshooting their bound`() {
+    val state = EditorZoomController()
+    val layout = paginatedLayout(pageWidth = 1000f)
+    state.syncLayout(layoutSpec = layout, viewportWidth = 500f)
+
+    state.setGestureDisplayZoom(rawZoom = 0.05f, layoutSpec = layout, viewportWidth = 500f)
+    assertTrue(state.displayZoom < state.indicatorZoom)
+    assertNull(state.resolveZoomOutTarget())
+
+    state.setGestureDisplayZoom(rawZoom = 2.2f, layoutSpec = layout, viewportWidth = 500f)
+    assertTrue(state.displayZoom > state.indicatorZoom)
+    assertNull(state.resolveZoomInTarget())
+  }
 }
+
+private fun paginatedLayout(pageWidth: Float) =
+  EditorDocumentLayoutSpec.Paginated(
+    pageWidth = pageWidth,
+    pageHeight = 1200f,
+    pageMarginTop = 72f,
+    pageMarginBottom = 72f,
+    pageMarginLeft = 64f,
+    pageMarginRight = 64f,
+  )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
@@ -1,19 +1,28 @@
 package co.typie.editor.interaction.semantics
 
+import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import co.typie.editor.EditorZoomController
+import co.typie.editor.EditorZoomLandmark
 import co.typie.editor.body.EditorDocumentLayoutSpec
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.interaction.EditorPinchSample
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.viewport.EditorViewportState
+import kotlin.coroutines.coroutineContext
 import kotlin.math.ln
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class EditorViewportZoomSemanticTest {
   @Test
   fun `slow pinch detents at a snap point while hard bounds remain elastic`() {
@@ -142,6 +151,107 @@ class EditorViewportZoomSemanticTest {
   }
 
   @Test
+  fun `recovery normalizes zoom when presentation changes during motion`() =
+    runTest(StandardTestDispatcher()) {
+      val frameClock = BroadcastFrameClock()
+      val pageSizes = mutableListOf(PageSize(width = 720f, height = 960f))
+      val fixture =
+        Fixture(
+          pageSizes = pageSizes,
+          coroutineScope = CoroutineScope(coroutineContext + frameClock),
+        )
+      val start =
+        EditorPinchSample(
+          focalInRootPx = Offset(80f, 150f),
+          distancePx = 100f,
+          timestampMillis = 0L,
+        )
+
+      assertTrue(fixture.semantic.beginPinch(start))
+      assertTrue(
+        fixture.semantic.updatePinch(start.copy(distancePx = 220f, timestampMillis = 250L))
+      )
+      assertTrue(fixture.zoomController.displayZoom > 2f)
+
+      fixture.semantic.release()
+      pageSizes.clear()
+      runCurrent()
+      frameClock.sendFrame(16_000_000L)
+      runCurrent()
+
+      assertEquals(2f, fixture.zoomController.displayZoom)
+    }
+
+  @Test
+  fun `indicator toggle sends one snap haptic for each applied landmark`() {
+    val fixture = Fixture(viewportWidth = 360f)
+
+    assertEquals(EditorZoomLandmark.Unit, fixture.semantic.toggleIndicatorZoomAtViewportCenter())
+    assertEquals(1, fixture.zoomSnapCount)
+
+    assertEquals(
+      EditorZoomLandmark.FitWidth,
+      fixture.semantic.toggleIndicatorZoomAtViewportCenter(),
+    )
+    assertEquals(2, fixture.zoomSnapCount)
+  }
+
+  @Test
+  fun `indicator steps stop at ten-percent grid lines and send snap haptics`() {
+    val fixture = Fixture()
+    fixture.zoomController.setDisplayZoom(
+      zoom = 0.53f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+      snapToLandmarks = false,
+    )
+
+    assertTrue(fixture.semantic.zoomInAtViewportCenter())
+    assertEquals(0.6f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(1, fixture.zoomSnapCount)
+
+    assertTrue(fixture.semantic.zoomOutAtViewportCenter())
+    assertEquals(0.5f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(2, fixture.zoomSnapCount)
+  }
+
+  @Test
+  fun `rapid fit and unit toggles retain the viewport center through stale bounds`() {
+    val viewportSize = Size(width = 360f, height = 300f)
+    val fixture =
+      Fixture(
+        viewportWidth = 360f,
+        initialScrollOffset = Offset(x = 0f, y = 600f),
+        measuredViewportSize = viewportSize,
+        contentSize = Size(width = 720f, height = 1500f),
+      )
+    fixture.zoomController.setDisplayZoom(
+      zoom = 1f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+    )
+    fixture.uiState.updateDisplayZoom(1f)
+
+    assertEquals(
+      EditorZoomLandmark.FitWidth,
+      fixture.semantic.toggleIndicatorZoomAtViewportCenter(),
+    )
+    fixture.viewportState.updateMeasuredBounds(
+      viewportSize = viewportSize,
+      contentSize = Size(width = 360f, height = 450f),
+    )
+    assertEquals(150f, fixture.viewportState.scrollOffset.y)
+
+    assertEquals(EditorZoomLandmark.Unit, fixture.semantic.toggleIndicatorZoomAtViewportCenter())
+    fixture.viewportState.updateMeasuredBounds(
+      viewportSize = viewportSize,
+      contentSize = Size(width = 720f, height = 1500f),
+    )
+
+    assertEquals(600f, fixture.viewportState.scrollOffset.y)
+  }
+
+  @Test
   fun `first indirect update does not assume a slow velocity`() {
     val fixture = Fixture()
     fixture.zoomController.setDisplayZoom(
@@ -160,6 +270,33 @@ class EditorViewportZoomSemanticTest {
     )
 
     assertEquals(0.99f, fixture.zoomController.displayZoom, 0.0001f)
+  }
+
+  @Test
+  fun `releasing indirect input near unit settles the rounded percentage onto the landmark`() {
+    val fixture = Fixture()
+    fixture.zoomController.setDisplayZoom(
+      zoom = 0.95f,
+      layoutSpec = fixture.layoutSpec,
+      viewportWidth = fixture.viewportWidth,
+    )
+    fixture.uiState.updateDisplayZoom(0.95f)
+
+    assertTrue(fixture.semantic.beginIndirect())
+    assertTrue(
+      fixture.semantic.updateIndirectScale(
+        focalInRootPx = Offset(80f, 150f),
+        scaleFactor = 0.995f / 0.95f,
+      )
+    )
+    assertEquals(0.995f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(null, fixture.zoomController.resolveLandmark())
+
+    fixture.semantic.release()
+
+    assertEquals(1f, fixture.zoomController.displayZoom)
+    assertEquals(EditorZoomLandmark.Unit, fixture.zoomController.resolveLandmark())
+    assertEquals(1, fixture.zoomSnapCount)
   }
 
   @Test
@@ -472,6 +609,22 @@ class EditorViewportZoomSemanticTest {
     assertEquals(fixture.zoomController.displayZoom, fixture.zoomController.renderZoom, 0.0001f)
   }
 
+  @Test
+  fun `bounded zoom command preserves the viewport center anchor`() {
+    val fixture =
+      Fixture(
+        initialScrollOffset = Offset(40f, 80f),
+        measuredViewportSize = Size(width = 200f, height = 300f),
+      )
+
+    assertTrue(fixture.semantic.setZoomAtViewportCenter(1.5f))
+
+    assertEquals(1.5f, fixture.zoomController.displayZoom, 0.0001f)
+    assertEquals(1.5f, fixture.zoomController.renderZoom, 0.0001f)
+    assertEquals(Offset(110f, 195f), fixture.viewportState.scrollOffset)
+    assertEquals(Offset(110f, 195f), fixture.attachedAnchors.single().third)
+  }
+
   private class Fixture(
     val pageSizes: List<PageSize> = listOf(PageSize(width = 720f, height = 960f)),
     val viewportWidth: Float = 720f,
@@ -480,6 +633,7 @@ class EditorViewportZoomSemanticTest {
     editorBoundsInRoot: Rect = Rect(left = 0f, top = 0f, right = 720f, bottom = 2000f),
     measuredViewportSize: Size = Size(width = 100f, height = 120f),
     contentSize: Size = Size(width = 2000f, height = 2000f),
+    coroutineScope: CoroutineScope? = null,
     documentLayoutSpec: EditorDocumentLayoutSpec =
       EditorDocumentLayoutSpec.Paginated(
         pageWidth = 720f,
@@ -508,7 +662,7 @@ class EditorViewportZoomSemanticTest {
         pageOffsets.forEach { (page, offset) -> updatePageOffset(page = page, offset = offset) }
         updateEditorBounds(boundsInRoot = editorBoundsInRoot, density = 1f)
       }
-    val semantic = EditorViewportZoomSemantic()
+    val semantic = EditorViewportZoomSemantic(coroutineScope = coroutineScope)
 
     init {
       zoomController.syncLayout(layoutSpec = layoutSpec, viewportWidth = viewportWidth)

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportAnchorStateTest.kt
@@ -22,7 +22,10 @@ class EditorViewportAnchorStateTest {
     state.attach(identity, geometry(pointY = 200f), scrollOffset = Offset(x = 0f, y = 100f))
 
     assertEquals(
-      Offset(x = 0f, y = 220f),
+      EditorViewportAnchorScroll(
+        scrollOffset = Offset(x = 0f, y = 220f),
+        attachmentAchieved = true,
+      ),
       state.publicationScroll(
         geometry = geometry(pointY = 320f),
         currentScrollOffset = Offset(x = 0f, y = 100f),
@@ -41,7 +44,10 @@ class EditorViewportAnchorStateTest {
     )
 
     assertEquals(
-      Offset(x = 180f, y = 220f),
+      EditorViewportAnchorScroll(
+        scrollOffset = Offset(x = 180f, y = 220f),
+        attachmentAchieved = true,
+      ),
       state.publicationScroll(
         geometry = geometry(pointX = 260f, pointY = 320f),
         currentScrollOffset = Offset(x = 20f, y = 100f),
@@ -56,7 +62,10 @@ class EditorViewportAnchorStateTest {
     state.attach(identity, geometry(pointY = 200f), scrollOffset = Offset(x = 0f, y = 100f))
 
     assertEquals(
-      Offset(x = 0f, y = 100f),
+      EditorViewportAnchorScroll(
+        scrollOffset = Offset(x = 0f, y = 100f),
+        attachmentAchieved = true,
+      ),
       state.publicationScroll(
         geometry = geometry(pointY = 200f),
         currentScrollOffset = Offset(x = 0f, y = 100f),
@@ -142,20 +151,29 @@ class EditorViewportAnchorStateTest {
   }
 
   @Test
-  fun `clamped publication records the achieved attachment`() {
+  fun `publication preserves the desired attachment until bounds can reach it`() {
     val state = EditorViewportAnchorState()
     state.attach(identity, geometry(pointY = 200f), scrollOffset = Offset(x = 0f, y = 100f))
     val candidate = geometry(pointY = 800f)
 
-    val clamped =
+    val constrained =
       state.publicationScroll(
         geometry = candidate,
         currentScrollOffset = Offset(x = 0f, y = 100f),
         maximumScrollOffset = Offset(x = 0f, y = 500f),
       )
-    state.acceptGeometry(candidate, scrollOffset = clamped)
 
-    assertEquals(300f, state.pointAttachmentY)
+    assertEquals(Offset(x = 0f, y = 500f), constrained.scrollOffset)
+    assertFalse(constrained.attachmentAchieved)
+    val recovered =
+      state.publicationScroll(
+        geometry = candidate,
+        currentScrollOffset = constrained.scrollOffset,
+        maximumScrollOffset = Offset(x = 0f, y = 1000f),
+      )
+    assertEquals(Offset(x = 0f, y = 700f), recovered.scrollOffset)
+    assertTrue(recovered.attachmentAchieved)
+    assertEquals(100f, state.pointAttachmentY)
   }
 
   @Test
@@ -176,7 +194,10 @@ class EditorViewportAnchorStateTest {
     )
 
     assertEquals(
-      Offset(x = 0f, y = 240f),
+      EditorViewportAnchorScroll(
+        scrollOffset = Offset(x = 0f, y = 240f),
+        attachmentAchieved = true,
+      ),
       state.publicationRevealScroll(
         geometry = geometry(pointY = 600f, top = 500f, bottom = 700f),
         currentScrollOffset = Offset(x = 0f, y = 161f),
@@ -213,7 +234,10 @@ class EditorViewportAnchorStateTest {
     assertEquals(-20f, state.pointAttachmentX)
     assertEquals(80f, state.pointAttachmentY)
     assertEquals(
-      Offset(x = 160f, y = 120f),
+      EditorViewportAnchorScroll(
+        scrollOffset = Offset(x = 160f, y = 120f),
+        attachmentAchieved = true,
+      ),
       state.publicationScroll(
         geometry = selectionGeometry.copy(pointX = 140f),
         currentScrollOffset = Offset(x = 120f, y = 120f),

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/viewport/EditorViewportStateTest.kt
@@ -197,7 +197,7 @@ class EditorViewportStateTest {
   }
 
   @Test
-  fun `same measured bounds consume retained zoom target without reviving it later`() {
+  fun `retained zoom target survives stale measured bounds until it becomes reachable`() {
     val state = EditorViewportState()
     state.updateMeasuredBounds(
       viewportSize = Size(width = 100f, height = 100f),
@@ -221,8 +221,8 @@ class EditorViewportStateTest {
       contentSize = Size(width = 400f, height = 400f),
     )
 
-    assertEquals(Offset(x = 100f, y = 100f), state.scrollOffset)
-    assertEquals(1, state.lastScrollRevision)
+    assertEquals(Offset(x = 180f, y = 240f), state.scrollOffset)
+    assertEquals(2, state.lastScrollRevision)
   }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorSurfacePreparationTest.kt
@@ -273,6 +273,7 @@ class EditorSurfacePreparationTest {
         EditorViewportAnchorPublication.Ready(
           scrollOffset = Offset(x = 0f, y = resolved.maximumScrollY),
           geometry = null,
+          attachmentAchieved = false,
         ),
         resolved.anchorPublication,
       )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/layout/EditorViewportAnchorReconcilerTest.kt
@@ -328,6 +328,7 @@ class EditorViewportAnchorReconcilerTest {
       EditorViewportAnchorPublication.Ready(
         scrollOffset = Offset(x = 0f, y = 100f),
         geometry = null,
+        attachmentAchieved = false,
       ),
       publication,
     )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomIndicatorStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomIndicatorStateTest.kt
@@ -1,0 +1,258 @@
+package co.typie.screen.editor.editor.overlay
+
+import co.typie.editor.EditorZoomLandmark
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EditorZoomIndicatorStateTest {
+  @Test
+  fun `initial unit zoom stays hidden in touch only state`() {
+    val state = EditorZoomIndicatorState()
+
+    state.updateZoom(enabled = true, displayZoom = 1f, landmark = EditorZoomLandmark.Unit)
+
+    assertFalse(state.visible)
+  }
+
+  @Test
+  fun `unit zoom stays hidden when initial layout enables the indicator`() {
+    val state = EditorZoomIndicatorState()
+
+    state.updateZoom(enabled = false, displayZoom = 1f, landmark = null)
+    state.onPanePointerEnter(landmark = null)
+    state.updateZoom(enabled = true, displayZoom = 1f, landmark = EditorZoomLandmark.Unit)
+
+    assertFalse(state.visible)
+    assertEquals(null, state.announcedLandmark)
+  }
+
+  @Test
+  fun `initial non unit zoom remains transiently visible`() {
+    val state = EditorZoomIndicatorState()
+
+    state.updateZoom(enabled = true, displayZoom = 1.25f, landmark = null)
+
+    assertTrue(state.visible)
+    state.expireVisibility(state.visibilityRequest)
+    assertFalse(state.visible)
+  }
+
+  @Test
+  fun `first non touch pointer entry enables controls and reveals non unit zoom`() {
+    val state = settledState(landmark = null, displayZoom = 1.25f)
+
+    state.onPanePointerEnter(landmark = null)
+
+    assertTrue(state.visible)
+  }
+
+  @Test
+  fun `unit pointer entry enables controls without revealing the indicator`() {
+    val state = settledState(landmark = EditorZoomLandmark.Unit, displayZoom = 1f)
+
+    state.onPanePointerEnter(landmark = EditorZoomLandmark.Unit)
+
+    assertFalse(state.visible)
+  }
+
+  @Test
+  fun `indicator hover holds visibility after the transient request expires`() {
+    val state = settledState(landmark = null, displayZoom = 1.25f)
+    state.onPanePointerEnter(landmark = null)
+    val request = state.visibilityRequest
+
+    state.onIndicatorPointerEnter()
+    state.expireVisibility(request)
+
+    assertTrue(state.visible)
+    state.onIndicatorPointerExit()
+    assertTrue(state.visible)
+    state.expireVisibility(state.visibilityRequest)
+    assertFalse(state.visible)
+  }
+
+  @Test
+  fun `focus exit keeps the indicator visible for one more transient request`() {
+    val state = settledState(landmark = null, displayZoom = 1.25f)
+
+    state.onFocusChanged(true)
+    assertTrue(state.visible)
+
+    state.onFocusChanged(false)
+    assertTrue(state.visible)
+
+    state.expireVisibility(state.visibilityRequest)
+    assertFalse(state.visible)
+  }
+
+  @Test
+  fun `landmark labels are temporary and value hover always describes current state`() {
+    val state = settledState(landmark = null, displayZoom = 1.25f)
+
+    state.updateZoom(enabled = true, displayZoom = 1f, landmark = EditorZoomLandmark.Unit)
+
+    assertEquals("원본", state.displayText(EditorZoomLandmark.Unit, 100))
+    state.expireLandmark(state.landmarkRequest)
+    assertEquals("100%", state.displayText(EditorZoomLandmark.Unit, 100))
+
+    state.onValuePointerEnter()
+    assertEquals("원본", state.displayText(EditorZoomLandmark.Unit, 100))
+    state.onValuePointerExit()
+    assertEquals("100%", state.displayText(EditorZoomLandmark.Unit, 100))
+  }
+
+  @Test
+  fun `snap feedback starts only when applied state enters a named landmark`() {
+    val state = settledState(landmark = null, displayZoom = 1.25f)
+
+    assertEquals(0, state.snapFeedbackRequest)
+
+    state.updateZoom(enabled = true, displayZoom = 1f, landmark = EditorZoomLandmark.Unit)
+    assertEquals(1, state.snapFeedbackRequest)
+
+    state.updateZoom(enabled = true, displayZoom = 1f, landmark = EditorZoomLandmark.Unit)
+    assertEquals(1, state.snapFeedbackRequest)
+
+    state.updateZoom(enabled = true, displayZoom = 0.95f, landmark = null)
+    assertEquals(1, state.snapFeedbackRequest)
+    assertEquals(EditorZoomLandmark.Unit, state.snapFeedbackLandmark)
+
+    state.updateZoom(enabled = true, displayZoom = 1f, landmark = EditorZoomLandmark.Unit)
+    assertEquals(2, state.snapFeedbackRequest)
+  }
+
+  @Test
+  fun `snap feedback identifies the actual applied bound landmark`() {
+    val state = settledState(landmark = EditorZoomLandmark.Unit, displayZoom = 1f)
+
+    state.updateZoom(enabled = true, displayZoom = 2f, landmark = EditorZoomLandmark.Maximum)
+
+    assertEquals(1, state.snapFeedbackRequest)
+    assertEquals(EditorZoomLandmark.Maximum, state.snapFeedbackLandmark)
+  }
+
+  @Test
+  fun `unchanged boundary attempts restart only the matching label and visibility`() {
+    val minimum = settledState(landmark = EditorZoomLandmark.Minimum, displayZoom = 0.2f)
+    val minimumSnapRequest = minimum.snapFeedbackRequest
+
+    minimum.onBoundaryAttempt(EditorZoomLandmark.Minimum)
+
+    assertTrue(minimum.visible)
+    assertEquals(EditorZoomLandmark.Minimum, minimum.announcedLandmark)
+    assertEquals(minimumSnapRequest, minimum.snapFeedbackRequest)
+
+    val maximum = settledState(landmark = EditorZoomLandmark.Maximum, displayZoom = 2f)
+    val maximumSnapRequest = maximum.snapFeedbackRequest
+
+    maximum.onBoundaryAttempt(EditorZoomLandmark.Maximum)
+
+    assertEquals(EditorZoomLandmark.Maximum, maximum.announcedLandmark)
+    assertEquals(maximumSnapRequest, maximum.snapFeedbackRequest)
+  }
+
+  @Test
+  fun `overshoot announces once and recovery restarts the boundary label with its flash`() {
+    val state = settledState(landmark = null, displayZoom = 1.25f)
+    val initialLandmarkRequest = state.landmarkRequest
+    val initialSnapRequest = state.snapFeedbackRequest
+
+    state.updateZoom(
+      enabled = true,
+      displayZoom = 0.15f,
+      indicatorZoom = 0.2f,
+      landmark = EditorZoomLandmark.Minimum,
+    )
+    assertEquals(initialLandmarkRequest + 1, state.landmarkRequest)
+    assertEquals(EditorZoomLandmark.Minimum, state.announcedLandmark)
+    assertEquals(initialSnapRequest, state.snapFeedbackRequest)
+
+    state.updateZoom(
+      enabled = true,
+      displayZoom = 0.14f,
+      indicatorZoom = 0.2f,
+      landmark = EditorZoomLandmark.Minimum,
+    )
+    assertEquals(initialLandmarkRequest + 1, state.landmarkRequest)
+
+    state.expireLandmark(state.landmarkRequest)
+    assertEquals(EditorZoomLandmark.Minimum, state.announcedLandmark)
+    state.expireVisibility(state.visibilityRequest)
+    assertTrue(state.visible)
+    state.updateZoom(
+      enabled = true,
+      displayZoom = 0.2f,
+      indicatorZoom = 0.2f,
+      landmark = EditorZoomLandmark.Minimum,
+    )
+    assertEquals(initialLandmarkRequest + 2, state.landmarkRequest)
+    state.expireLandmark(state.landmarkRequest)
+    assertEquals(null, state.announcedLandmark)
+    assertEquals(initialSnapRequest + 1, state.snapFeedbackRequest)
+    assertEquals(EditorZoomLandmark.Minimum, state.snapFeedbackLandmark)
+
+    state.updateZoom(
+      enabled = true,
+      displayZoom = 0.15f,
+      indicatorZoom = 0.2f,
+      landmark = EditorZoomLandmark.Minimum,
+    )
+    assertEquals(initialLandmarkRequest + 3, state.landmarkRequest)
+    assertEquals(initialSnapRequest + 1, state.snapFeedbackRequest)
+  }
+
+  @Test
+  fun `overshoot precedence handles side changes and recovery into another landmark`() {
+    val state = settledState(landmark = null, displayZoom = 1.25f)
+
+    state.updateZoom(
+      enabled = true,
+      displayZoom = 0.15f,
+      indicatorZoom = 0.2f,
+      landmark = EditorZoomLandmark.Minimum,
+    )
+    state.updateZoom(
+      enabled = true,
+      displayZoom = 2.1f,
+      indicatorZoom = 2f,
+      landmark = EditorZoomLandmark.Maximum,
+    )
+    assertEquals(EditorZoomLandmark.Maximum, state.announcedLandmark)
+    assertEquals(0, state.snapFeedbackRequest)
+
+    state.expireLandmark(state.landmarkRequest)
+    state.updateZoom(
+      enabled = true,
+      displayZoom = 1f,
+      indicatorZoom = 1f,
+      landmark = EditorZoomLandmark.Unit,
+    )
+    assertEquals(EditorZoomLandmark.Maximum, state.announcedLandmark)
+    assertEquals(1, state.snapFeedbackRequest)
+    assertEquals(EditorZoomLandmark.Maximum, state.snapFeedbackLandmark)
+  }
+
+  @Test
+  fun `reset clears late visibility requests`() {
+    val state = settledState(landmark = null, displayZoom = 1.25f)
+    state.onPanePointerEnter(landmark = null)
+    state.onIndicatorPointerEnter()
+
+    state.reset()
+
+    assertFalse(state.visible)
+    assertEquals(null, state.announcedLandmark)
+  }
+
+  private fun settledState(
+    landmark: EditorZoomLandmark?,
+    displayZoom: Float,
+  ): EditorZoomIndicatorState =
+    EditorZoomIndicatorState().also { state ->
+      state.updateZoom(enabled = true, displayZoom = displayZoom, landmark = landmark)
+      state.expireVisibility(state.visibilityRequest)
+      state.expireLandmark(state.landmarkRequest)
+    }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomOverlayDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorZoomOverlayDesktopTest.kt
@@ -1,0 +1,244 @@
+package co.typie.screen.editor.editor.overlay
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.PointerInputModifierNode
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import co.typie.editor.EditorZoomController
+import co.typie.editor.EditorZoomLandmark
+import co.typie.editor.LocalEditorZoomController
+import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.screen.editor.editor.header.EditorHeaderReadingTapTracker
+import co.typie.screen.editor.editor.header.observeEditorHeaderReadingTaps
+import co.typie.ui.theme.LightColors
+import co.typie.ui.theme.LocalAppColors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class EditorZoomOverlayDesktopTest {
+  @Test
+  fun hiddenTouchOnlyZoomControlLeavesTheHitTestTree() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val fixture = ZoomOverlayFixture()
+    setContent { fixture.Content() }
+    mainClock.advanceTimeByFrame()
+    runOnIdle {
+      fixture.state.expireLandmark(fixture.state.landmarkRequest)
+      fixture.state.expireVisibility(fixture.state.visibilityRequest)
+    }
+    mainClock.advanceTimeBy(200)
+
+    onNodeWithTag(OverlayTag).assertDoesNotExist()
+  }
+
+  @Test
+  fun zoomControlClaimsHeaderTapsOnlyWhileVisible() = runComposeUiTest {
+    var toggleCount = 0
+    var headerActivationCount = 0
+    val fixture = ZoomOverlayFixture()
+    val headerTapTracker =
+      EditorHeaderReadingTapTracker(
+        touchSlopPx = 8f,
+        maxTapDistancePx = 20f,
+        doubleTapToEditEnabled = false,
+      )
+    setContent {
+      CompositionLocalProvider(
+        LocalEditorZoomController provides fixture.controller,
+        LocalAppColors provides LightColors,
+      ) {
+        Box(Modifier.size(240.dp)) {
+          Box(
+            Modifier.fillMaxSize()
+              .testTag(SurfaceTag)
+              .observeEditorHeaderReadingTaps(
+                enabled = { true },
+                tracker = headerTapTracker,
+                currentSelectionIsExpanded = { false },
+                offsetForPosition = { 0 },
+                onActivate = { headerActivationCount += 1 },
+                onShowHint = {},
+              )
+          )
+          Box(Modifier.fillMaxSize().sharePointerInputWithSiblingsForTest()) {
+            EditorZoomOverlay(
+              state = fixture.state,
+              nonTouchPointerActive = false,
+              onZoomOut = { false },
+              onZoomIn = { false },
+              onToggleZoom = {
+                toggleCount += 1
+                null
+              },
+              onRequestEditorFocus = {},
+              modifier = Modifier.align(Alignment.Center).testTag(OverlayTag),
+            )
+          }
+        }
+      }
+    }
+
+    onNodeWithTag(OverlayTag).performTouchInput { click() }
+
+    runOnIdle {
+      assertEquals(1, toggleCount)
+      assertEquals(0, headerActivationCount)
+    }
+
+    runOnIdle { fixture.controller.setDisplayZoom(1f, fixture.layoutSpec, fixture.viewportWidth) }
+    waitForIdle()
+    runOnIdle {
+      fixture.state.expireLandmark(fixture.state.landmarkRequest)
+      fixture.state.expireVisibility(fixture.state.visibilityRequest)
+    }
+
+    onNodeWithTag(SurfaceTag).performTouchInput { click() }
+
+    runOnIdle {
+      assertEquals(1, toggleCount)
+      assertEquals(1, headerActivationCount)
+    }
+  }
+
+  @Test
+  fun zoomControlsRequestEditorFocusAfterEveryAction() = runComposeUiTest {
+    var toggleCount = 0
+    var focusRequestCount = 0
+    val fixture =
+      ZoomOverlayFixture(
+        pointerCapable = true,
+        onToggleZoom = { toggleCount += 1 },
+        onRequestEditorFocus = { focusRequestCount += 1 },
+      )
+    setContent { fixture.Content() }
+
+    onAllNodes(hasClickAction()).apply {
+      repeat(fetchSemanticsNodes().size) { index -> this[index].performTouchInput { click() } }
+    }
+
+    runOnIdle { assertEquals(1, toggleCount) }
+    runOnIdle { assertEquals(3, focusRequestCount) }
+  }
+
+  @Test
+  fun plainZoomActivityHidesAfterOneSecond() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val fixture = ZoomOverlayFixture()
+    setContent { fixture.Content() }
+    mainClock.advanceTimeByFrame()
+
+    mainClock.advanceTimeBy(900)
+    runOnIdle { assertTrue(fixture.state.visible) }
+
+    mainClock.advanceTimeBy(200)
+    runOnIdle { assertFalse(fixture.state.visible) }
+  }
+
+  @Test
+  fun landmarkReturnsToPercentageAfterOneSecondAndHidesAfterTwoSeconds() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val fixture = ZoomOverlayFixture()
+    setContent { fixture.Content() }
+    mainClock.advanceTimeByFrame()
+    runOnIdle { fixture.state.expireVisibility(fixture.state.visibilityRequest) }
+
+    runOnIdle { fixture.controller.setDisplayZoom(1f, fixture.layoutSpec, fixture.viewportWidth) }
+    mainClock.advanceTimeByFrame()
+    runOnIdle { assertEquals(EditorZoomLandmark.Unit, fixture.state.announcedLandmark) }
+
+    mainClock.advanceTimeBy(900)
+    runOnIdle { assertEquals(EditorZoomLandmark.Unit, fixture.state.announcedLandmark) }
+    runOnIdle { assertTrue(fixture.state.visible) }
+
+    mainClock.advanceTimeBy(200)
+    runOnIdle { assertEquals(null, fixture.state.announcedLandmark) }
+    runOnIdle { assertTrue(fixture.state.visible) }
+
+    mainClock.advanceTimeBy(700)
+    runOnIdle { assertTrue(fixture.state.visible) }
+
+    mainClock.advanceTimeBy(300)
+    runOnIdle { assertFalse(fixture.state.visible) }
+  }
+
+  private class ZoomOverlayFixture(
+    private val pointerCapable: Boolean = false,
+    private val onToggleZoom: () -> Unit = {},
+    private val onRequestEditorFocus: () -> Unit = {},
+  ) {
+    val state = EditorZoomIndicatorState()
+    val controller = EditorZoomController()
+    val layoutSpec = EditorDocumentLayoutSpec.Continuous(maxWidth = 400f)
+    val viewportWidth = 500f
+
+    init {
+      controller.syncLayout(layoutSpec = layoutSpec, viewportWidth = viewportWidth)
+      controller.setDisplayZoom(1.2f, layoutSpec = layoutSpec, viewportWidth = viewportWidth)
+      if (pointerCapable) state.onPanePointerEnter(landmark = null)
+    }
+
+    @androidx.compose.runtime.Composable
+    fun Content() {
+      CompositionLocalProvider(
+        LocalEditorZoomController provides controller,
+        LocalAppColors provides LightColors,
+      ) {
+        Box(Modifier.size(240.dp)) {
+          EditorZoomOverlay(
+            state = state,
+            nonTouchPointerActive = pointerCapable,
+            onZoomOut = { false },
+            onZoomIn = { false },
+            onToggleZoom = {
+              onToggleZoom()
+              null
+            },
+            onRequestEditorFocus = onRequestEditorFocus,
+            modifier = Modifier.testTag(OverlayTag),
+          )
+        }
+      }
+    }
+  }
+}
+
+private const val OverlayTag = "editor-zoom-overlay"
+private const val SurfaceTag = "editor-surface"
+
+private data object SharePointerInputWithSiblingsForTestElement :
+  ModifierNodeElement<SharePointerInputWithSiblingsForTestNode>() {
+  override fun create(): SharePointerInputWithSiblingsForTestNode =
+    SharePointerInputWithSiblingsForTestNode()
+
+  override fun update(node: SharePointerInputWithSiblingsForTestNode) = Unit
+}
+
+private class SharePointerInputWithSiblingsForTestNode : Modifier.Node(), PointerInputModifierNode {
+  override fun sharePointerInputWithSiblings(): Boolean = true
+
+  override fun onPointerEvent(pointerEvent: PointerEvent, pass: PointerEventPass, bounds: IntSize) =
+    Unit
+
+  override fun onCancelPointerInput() = Unit
+}
+
+private fun Modifier.sharePointerInputWithSiblingsForTest(): Modifier =
+  this then SharePointerInputWithSiblingsForTestElement

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -85,6 +85,7 @@
   // 이 View 인스턴스가 소유한다. 공유 컨텍스트에 두면 {#key ctx.editor}로 View가 교체될 때
   // 새 인스턴스가 옛 인스턴스의 host를 읽어버린다 (새 브랜치 생성이 옛 브랜치 파괴보다 먼저다).
   let surfaceHost = $state<EditorSurfaceHost>();
+  let editorViewSurface = $state<HTMLElement>();
 
   setupEditorScroll(ctx);
   setupEditorPublication(ctx, () => surfaceHost);
@@ -229,6 +230,9 @@
   let readyFired = false;
   let viewportEditor: (typeof ctx)['editor'];
   let viewportLayoutType: 'continuous' | 'paginated' | undefined;
+  let viewportClientWidth: number | undefined;
+  let viewportClientHeight: number | undefined;
+  let lastViewportScaleFactor: number | undefined;
 
   $effect(() => {
     const editor = ctx.editor;
@@ -244,15 +248,21 @@
       : physicalWidth;
 
     untrack(() => {
-      const committedLayoutChanged = viewportEditor === editor && viewportLayoutType !== layoutMode?.type;
+      const sameEditor = viewportEditor === editor;
+      const committedLayoutChanged = sameEditor && viewportLayoutType !== layoutMode?.type;
+      const physicalViewportChanged =
+        sameEditor && (viewportClientWidth !== width || viewportClientHeight !== height || lastViewportScaleFactor !== viewportScaleFactor);
       viewportLayoutType = layoutMode?.type;
-      if (viewportEditor === editor && !committedLayoutChanged) {
+      viewportClientWidth = width;
+      viewportClientHeight = height;
+      lastViewportScaleFactor = viewportScaleFactor;
+      if (sameEditor && !committedLayoutChanged) {
         editor.resizeViewport(effectiveWidth, height, viewportScaleFactor);
       } else {
         viewportEditor = editor;
         editor.resizeViewportNow(effectiveWidth, height, viewportScaleFactor);
       }
-      ctx.scroll?.reconcileViewportResize();
+      if (physicalViewportChanged) ctx.scroll?.reconcileViewportResize();
     });
 
     if (!readyFired && editor.isPublished(editor.appliedRevision, { requireFrame: true })) {
@@ -323,6 +333,7 @@
 />
 
 <div
+  bind:this={editorViewSurface}
   style:--editor-layout-background={layoutBackground}
   class={css(
     {
@@ -415,13 +426,7 @@
     {/if}
 
     {#if ctx.editor}
-      <EditorZoom
-        {active}
-        attachViewportAnchor={(point) => ctx.scroll?.attachViewportAnchorAt(point)}
-        editor={ctx.editor}
-        layout={zoomLayout}
-        viewportWidth={clientWidth ?? 0}
-      >
+      <EditorZoom {active} editor={ctx.editor} {editorViewSurface} layout={zoomLayout} scroll={ctx.scroll} viewportWidth={clientWidth ?? 0}>
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
           bind:this={ctx.editor.extensionAreaEl}

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.svelte.ts
@@ -1,3 +1,4 @@
+import { prefersReducedMotion } from '@typie/ui/state';
 import { tick } from 'svelte';
 import {
   clampDocumentLayoutZoom,
@@ -11,15 +12,19 @@ import {
   RENDER_ZOOM_SCALE_RATIO_THRESHOLD,
   renderZoomForDisplay,
   resolveDirectDocumentZoom,
+  resolveDocumentZoomIndicator,
+  resolveDocumentZoomLandmark,
+  resolveDocumentZoomStepTarget,
   zoomDiffers,
   zoomEquals,
 } from '$lib/editor-ffi/zoom';
 import { ZOOM_MAX_MOTION_SECONDS, ZoomMotion } from '$lib/editor-ffi/zoom-motion';
 import type { ScrollViewport } from '@typie/ui/utils';
 import type { Editor } from '$lib/editor-ffi/editor.svelte';
-import type { DocumentZoomLayout } from '$lib/editor-ffi/zoom';
+import type { DocumentZoomLandmark, DocumentZoomLayout } from '$lib/editor-ffi/zoom';
 
 type ZoomAnchor = { page: number; x: number; y: number; focalX: number; focalY: number };
+type ZoomCommandAnchor = { anchor: ZoomAnchor | null; attached: boolean };
 type DirectZoomKind = 'touch' | 'wheel';
 type ZoomMotionPlayback = 'animated' | 'immediate';
 
@@ -47,12 +52,14 @@ type EditorZoomControllerOptions = {
   layout: () => DocumentZoomLayout | null;
   viewportWidth: () => number;
   getScrollViewport: () => ScrollViewport | null | undefined;
-  attachViewportAnchor?: (point: Pick<ZoomAnchor, 'page' | 'x' | 'y'>) => void;
+  resolvePendingViewportAnchor?: () => ZoomAnchor | null;
+  resolveViewportAnchor?: () => ZoomAnchor | null;
+  beginViewportZoom?: (point: Pick<ZoomAnchor, 'page' | 'x' | 'y'>) => void;
+  updateViewportZoomAttachment?: (desiredScroll: { left: number; top: number }) => void;
 };
 
 export class EditorZoomController {
   static readonly WHEEL_RAW_ZOOM_RESET_MS = 32;
-  static readonly KEYBOARD_ZOOM_STEP = 0.1;
 
   #initializedLayoutKey: string | null = null;
   #renderZoomTimer: ReturnType<typeof setTimeout> | null = null;
@@ -63,6 +70,8 @@ export class EditorZoomController {
   #activeMotion: ActiveZoomMotion | null = null;
   #cancelAnimationFrame: (() => void) | null = null;
   #applyQueue: Promise<unknown> = Promise.resolve();
+  #pendingCommandAnchor: ZoomAnchor | null = null;
+  #commandRevision = 0;
   #options: EditorZoomControllerOptions;
 
   displayZoom = $state(1);
@@ -72,9 +81,14 @@ export class EditorZoomController {
     this.#options = options;
   }
 
-  async #stepZoomByKeyboard(delta: number): Promise<void> {
-    if (!this.#options.layout()) return;
-    await this.#setZoomWithAnchor(this.displayZoom + delta, this.#createZoomAnchorFromViewportCenter());
+  async #stepZoomByKeyboard(direction: -1 | 1): Promise<boolean> {
+    const layout = this.#options.layout();
+    if (!layout) return false;
+    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
+    const indicatorZoom = resolveDocumentZoomIndicator(this.displayZoom, layout);
+    const targetZoom = resolveDocumentZoomStepTarget({ zoom: indicatorZoom, direction, layout, viewportWidth });
+    if (targetZoom === null) return false;
+    return this.#setZoomWithAnchor(targetZoom, this.#createZoomAnchorFromViewportCenter(), false);
   }
 
   #createZoomAnchorFromClient(clientX: number, clientY: number): ZoomAnchor | null {
@@ -86,11 +100,20 @@ export class EditorZoomController {
     return { ...resolved, focalX: clientX - rect.left, focalY: clientY - rect.top };
   }
 
-  #createZoomAnchorFromViewportCenter(): ZoomAnchor | null {
+  #createZoomAnchorFromViewportCenter(): ZoomCommandAnchor {
+    if (this.#pendingCommandAnchor) return { anchor: this.#pendingCommandAnchor, attached: true };
+    const pending = this.#options.resolvePendingViewportAnchor?.();
+    if (pending) return { anchor: pending, attached: true };
     const viewport = this.#options.getScrollViewport();
-    if (!viewport) return null;
+    if (!viewport) return { anchor: null, attached: false };
     const rect = viewport.getRect();
-    return this.#createZoomAnchorFromClient(rect.left + (rect.right - rect.left) / 2, rect.top + (rect.bottom - rect.top) / 2);
+    const focalX = (rect.right - rect.left) / 2;
+    const focalY = (rect.bottom - rect.top) / 2;
+    const current = this.#options.resolveViewportAnchor?.();
+    if (current && Math.abs(current.focalX - focalX) <= 0.5 && Math.abs(current.focalY - focalY) <= 0.5) {
+      return { anchor: current, attached: true };
+    }
+    return { anchor: this.#createZoomAnchorFromClient(rect.left + focalX, rect.top + focalY), attached: false };
   }
 
   #resolveFocalInViewport(clientX: number, clientY: number): { x: number; y: number } | null {
@@ -100,9 +123,22 @@ export class EditorZoomController {
     return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : null;
   }
 
-  async #setZoomWithAnchor(nextZoom: number, anchor: ZoomAnchor | null): Promise<void> {
-    this.setZoom(nextZoom);
-    await this.#syncZoomAnchor(anchor, this.displayZoom);
+  async #setZoomWithAnchor(nextZoom: number, requestedAnchor: ZoomCommandAnchor, snapToLandmarks = true): Promise<boolean> {
+    const commandAnchor = this.#pendingCommandAnchor ?? (requestedAnchor.anchor ? { ...requestedAnchor.anchor } : null);
+    if (commandAnchor && !this.#pendingCommandAnchor && !requestedAnchor.attached) this.#options.beginViewportZoom?.(commandAnchor);
+    this.#pendingCommandAnchor = commandAnchor;
+    const revision = ++this.#commandRevision;
+    const previousZoom = this.displayZoom;
+    this.setZoom(nextZoom, { preserveCommand: true, snapToLandmarks });
+    const appliedZoom = this.displayZoom;
+    await this.#syncZoomAnchor(commandAnchor, appliedZoom, () => this.#commandRevision === revision);
+    if (this.#commandRevision === revision) this.#pendingCommandAnchor = null;
+    return zoomDiffers(previousZoom, this.displayZoom);
+  }
+
+  #invalidateCommand(): void {
+    this.#commandRevision += 1;
+    this.#pendingCommandAnchor = null;
   }
 
   #clearWheelReleaseTimer(): void {
@@ -169,15 +205,20 @@ export class EditorZoomController {
     if (pageCount === 0 || anchor.page < 0 || anchor.page >= pageCount) return false;
     await tick();
     if (!isCurrent()) return false;
-    const pageEl = this.#options.editor.pageEls[anchor.page];
+    const resolvedAnchor = this.#options.resolveViewportAnchor?.() ?? anchor;
+    const pageEl = this.#options.editor.pageEls[resolvedAnchor.page];
     if (!pageEl) return false;
     const pageRect = pageEl.getBoundingClientRect();
     const scrollRect = viewport.getRect();
-    const deltaX = pageRect.left + anchor.x * zoom - (scrollRect.left + anchor.focalX);
-    const deltaY = pageRect.top + anchor.y * zoom - (scrollRect.top + anchor.focalY);
+    const deltaX = pageRect.left + resolvedAnchor.x * zoom - (scrollRect.left + resolvedAnchor.focalX);
+    const deltaY = pageRect.top + resolvedAnchor.y * zoom - (scrollRect.top + resolvedAnchor.focalY);
     if (![deltaX, deltaY].every(Number.isFinite)) return false;
+    const desiredScroll = {
+      left: viewport.getScrollLeft() + deltaX,
+      top: viewport.getScrollTop() + deltaY,
+    };
     if (Math.abs(deltaX) > 0.5 || Math.abs(deltaY) > 0.5) viewport.scrollBy(deltaX, deltaY);
-    this.#options.attachViewportAnchor?.(anchor);
+    this.#options.updateViewportZoomAttachment?.(desiredScroll);
     return true;
   }
 
@@ -282,13 +323,26 @@ export class EditorZoomController {
     return this.#activeMotion !== null;
   }
 
+  get landmark(): DocumentZoomLandmark | null {
+    const layout = this.#options.layout();
+    if (!layout) return null;
+    const viewportWidth = this.#options.viewportWidth();
+    return resolveDocumentZoomLandmark({
+      zoom: resolveDocumentZoomIndicator(this.displayZoom, layout),
+      layout,
+      viewportWidth,
+    });
+  }
+
   destroy(): void {
+    this.#invalidateCommand();
     this.#cancelInteractiveMotion();
     this.#clearRenderZoomTimer();
     this.#renderZoomMismatchStartedAt = null;
   }
 
-  setZoom(nextZoom: number, { commitRender = false } = {}): void {
+  setZoom(nextZoom: number, { commitRender = false, preserveCommand = false, snapToLandmarks = true } = {}): void {
+    if (!preserveCommand) this.#invalidateCommand();
     this.#cancelInteractiveMotion();
     this.#clearRenderZoomTimer();
     const layout = this.#options.layout();
@@ -302,7 +356,9 @@ export class EditorZoomController {
       return;
     }
     const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
-    const clamped = clampDocumentLayoutZoom({ zoom: nextZoom, layout, viewportWidth });
+    const clamped = snapToLandmarks
+      ? clampDocumentLayoutZoom({ zoom: nextZoom, layout, viewportWidth })
+      : clampDocumentZoom(nextZoom, computeDocumentZoomBounds(layout));
     if (zoomDiffers(this.displayZoom, clamped)) this.displayZoom = clamped;
     if (commitRender) this.#commitLatestRenderZoom(Date.now());
     else this.#scheduleRenderZoom();
@@ -320,22 +376,28 @@ export class EditorZoomController {
     const key = layoutKey(layout);
     if (this.#initializedLayoutKey === key) return;
     this.#initializedLayoutKey = key;
-    this.setZoom(computeInitialDocumentZoom(layout, viewportWidth), { commitRender: true });
+    const initialZoom = computeInitialDocumentZoom(layout, viewportWidth);
+    this.setZoom(initialZoom, { commitRender: true });
   }
 
   clampCurrentZoomToBounds(): void {
     if (this.hasActiveDirectZoom || this.hasActiveMotion) return;
     const layout = this.#options.layout();
     if (!layout) return;
-    const viewportWidth = this.#options.viewportWidth() > 0 ? this.#options.viewportWidth() : 1;
-    const clamped = clampDocumentLayoutZoom({ zoom: this.displayZoom, layout, viewportWidth });
-    if (zoomDiffers(clamped, this.displayZoom)) this.setZoom(clamped, { commitRender: true });
+    const nextZoom = clampDocumentZoom(this.displayZoom, computeDocumentZoomBounds(layout));
+    if (zoomDiffers(nextZoom, this.displayZoom)) {
+      this.setZoom(nextZoom, {
+        commitRender: true,
+        preserveCommand: true,
+      });
+    }
   }
 
   beginDirectZoom(kind: DirectZoomKind, clientX: number, clientY: number, timestampMs: number): boolean {
     const layout = this.#options.layout();
     const focal = this.#resolveFocalInViewport(clientX, clientY);
     if (!layout || !focal) return false;
+    this.#invalidateCommand();
     this.#cancelInteractiveMotion();
     this.#directSession = {
       kind,
@@ -345,6 +407,7 @@ export class EditorZoomController {
       snapZoom: resolveDirectSnapZoom(this.displayZoom, layout, this.#options.viewportWidth()),
       lastTimestampMs: normalizeTimestamp(timestampMs),
     };
+    if (this.#directSession.anchor) this.#options.beginViewportZoom?.(this.#directSession.anchor);
     return true;
   }
 
@@ -381,7 +444,7 @@ export class EditorZoomController {
     await this.#applyQueue;
     if (this.#directSession !== session) return;
     this.#directSession = null;
-    const reduceMotion = prefersReducedMotion();
+    const reduceMotion = prefersReducedMotion.current;
     await this.#finishOrRecover(session, reduceMotion ? 'immediate' : 'animated');
   }
 
@@ -389,11 +452,12 @@ export class EditorZoomController {
     if (kind && this.#directSession?.kind !== kind) return;
     const current = this.#directSession;
     this.#cancelInteractiveMotion();
-    if (current) void this.#finishOrRecover(current, prefersReducedMotion() ? 'immediate' : 'animated');
+    if (current) void this.#finishOrRecover(current, prefersReducedMotion.current ? 'immediate' : 'animated');
     else this.#scheduleRenderZoom(true);
   }
 
   interruptForDirectPan(): void {
+    this.#invalidateCommand();
     if (this.#directSession) {
       const kind = this.#directSession.kind;
       this.#directSession.anchor = null;
@@ -429,17 +493,42 @@ export class EditorZoomController {
     await this.updateDirectZoom('wheel', nextRawZoom, event.clientX, event.clientY, event.timeStamp);
   }
 
-  async zoomInByKeyboard(): Promise<void> {
-    await this.#stepZoomByKeyboard(EditorZoomController.KEYBOARD_ZOOM_STEP);
+  async zoomInByKeyboard(): Promise<boolean> {
+    return this.#stepZoomByKeyboard(1);
   }
 
-  async zoomOutByKeyboard(): Promise<void> {
-    await this.#stepZoomByKeyboard(-EditorZoomController.KEYBOARD_ZOOM_STEP);
+  async zoomOutByKeyboard(): Promise<boolean> {
+    return this.#stepZoomByKeyboard(-1);
   }
 
   async resetByKeyboard(): Promise<void> {
     if (!this.#options.layout()) return;
     await this.#setZoomWithAnchor(1, this.#createZoomAnchorFromViewportCenter());
+  }
+
+  get indicatorToggleTarget(): number | null {
+    const layout = this.#options.layout();
+    if (!layout) return null;
+    const viewportWidth = this.#options.viewportWidth();
+    const landmark = this.landmark;
+    const bounds = computeDocumentZoomBounds(layout);
+    const unitZoom = clampDocumentZoom(1, bounds);
+    const fitWidthZoom = computeDocumentFitWidthZoom(layout, viewportWidth);
+    const targetZoom = landmark === 'unit' ? fitWidthZoom : unitZoom;
+    return zoomEquals(this.displayZoom, targetZoom) ? null : targetZoom;
+  }
+
+  get indicatorToggleTargetLandmark(): DocumentZoomLandmark | null {
+    const layout = this.#options.layout();
+    const targetZoom = this.indicatorToggleTarget;
+    if (!layout || targetZoom === null) return null;
+    return resolveDocumentZoomLandmark({ zoom: targetZoom, layout, viewportWidth: this.#options.viewportWidth() });
+  }
+
+  async toggleZoomByIndicator(): Promise<boolean> {
+    const targetZoom = this.indicatorToggleTarget;
+    if (targetZoom === null) return false;
+    return this.#setZoomWithAnchor(targetZoom, this.#createZoomAnchorFromViewportCenter());
   }
 }
 
@@ -476,10 +565,6 @@ function resolveDirectSnapZoom(zoom: number, layout: DocumentZoomLayout, viewpor
 
 function nowMilliseconds(): number {
   return globalThis.performance?.now() ?? Date.now();
-}
-
-function prefersReducedMotion(): boolean {
-  return typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
 function requestZoomAnimationFrame(callback: (timestampMs: number) => void): () => void {

--- a/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-zoom.test.ts
@@ -149,6 +149,172 @@ describe('EditorZoomController continuous timing', () => {
   });
 });
 
+describe('EditorZoomController indicator toggle', () => {
+  const createToggleController = (viewportWidth: number): EditorZoomController => {
+    const editor = {
+      clientToLocal: vi.fn(() => null),
+      pageSizes: [],
+      pageEls: [],
+    } as unknown as Editor;
+    const controller = new EditorZoomController({
+      editor,
+      layout: () => defaultLayout,
+      viewportWidth: () => viewportWidth,
+      getScrollViewport: () => null,
+    });
+    controllers.push(controller);
+    return controller;
+  };
+
+  it('toggles fit-width to unit and unit to fit-width', async () => {
+    const controller = createToggleController(500);
+    controller.syncInitialZoom();
+
+    expect(controller.displayZoom).toBe(0.5);
+    await expect(controller.toggleZoomByIndicator()).resolves.toBe(true);
+    expect(controller.displayZoom).toBe(1);
+
+    await expect(controller.toggleZoomByIndicator()).resolves.toBe(true);
+    expect(controller.displayZoom).toBe(0.5);
+  });
+
+  it('returns any unnamed zoom to unit', async () => {
+    const controller = createToggleController(500);
+    controller.setZoom(1.4, { commitRender: true });
+
+    await expect(controller.toggleZoomByIndicator()).resolves.toBe(true);
+    expect(controller.displayZoom).toBe(1);
+  });
+
+  it('does nothing when unit and fit-width are the same zoom', async () => {
+    const controller = createToggleController(1000);
+    controller.syncInitialZoom();
+
+    await expect(controller.toggleZoomByIndicator()).resolves.toBe(false);
+    expect(controller.displayZoom).toBe(1);
+  });
+
+  it('reports a bound when the requested fit zoom is clamped', async () => {
+    const controller = createToggleController(2500);
+    controller.syncInitialZoom();
+    controller.setZoom(1, { commitRender: true });
+
+    await expect(controller.toggleZoomByIndicator()).resolves.toBe(true);
+    expect(controller.displayZoom).toBe(2);
+  });
+
+  it('reuses one viewport anchor for rapid toggles before layout catches up', async () => {
+    let scrollTop = 300;
+    const scrollBy = vi.fn((_deltaX: number, deltaY: number) => {
+      scrollTop += deltaY;
+    });
+    const viewport = {
+      getRect: () => ({ left: 0, top: 0, right: 500, bottom: 500 }),
+      getScrollLeft: () => 0,
+      getScrollTop: () => scrollTop,
+      scrollBy,
+    };
+    const clientToLocal = vi.fn().mockReturnValueOnce({ page: 0, x: 250, y: 550 }).mockReturnValue({ page: 0, x: 250, y: 900 });
+    const beginViewportZoom = vi.fn();
+    const updateViewportZoomAttachment = vi.fn();
+    const editor = {
+      clientToLocal,
+      pageSizes: [{ width: 1000, height: 2000 }],
+      pageEls: [{ getBoundingClientRect: () => ({ left: 0, top: -scrollTop }) }],
+    } as unknown as Editor;
+    const controller = new EditorZoomController({
+      editor,
+      layout: () => defaultLayout,
+      viewportWidth: () => 500,
+      getScrollViewport: () => viewport as unknown as ScrollViewport,
+      beginViewportZoom,
+      updateViewportZoomAttachment,
+    });
+    controllers.push(controller);
+
+    const fit = controller.toggleZoomByIndicator();
+    const unit = controller.toggleZoomByIndicator();
+
+    expect(clientToLocal).toHaveBeenCalledOnce();
+    await Promise.all([fit, unit]);
+    expect(beginViewportZoom).toHaveBeenCalledOnce();
+    expect(updateViewportZoomAttachment).toHaveBeenCalledOnce();
+  });
+
+  it('keeps settled indicator toggles reversible by retaining the scroll owner viewport anchor', async () => {
+    let scrollTop = 300;
+    const controllerRef: { current?: EditorZoomController } = {};
+    let activeAnchor = { page: 0, x: 250, y: 550, focalX: 250, focalY: 250 };
+    const viewport = {
+      getRect: () => ({ left: 0, top: 0, right: 500, bottom: 500 }),
+      getScrollLeft: () => 0,
+      getScrollTop: () => scrollTop,
+      scrollBy: (_deltaX: number, deltaY: number) => {
+        scrollTop += deltaY;
+      },
+    };
+    const clientToLocal = vi.fn(() => ({
+      page: 0,
+      x: 250,
+      y: (scrollTop + 250) / (controllerRef.current?.displayZoom ?? 1) + 0.25,
+    }));
+    const editor = {
+      clientToLocal,
+      pageSizes: [{ width: 1000, height: 2000 }],
+      pageEls: [{ getBoundingClientRect: () => ({ left: 0, top: -scrollTop }) }],
+    } as unknown as Editor;
+    const beginViewportZoom = vi.fn((point: { page: number; x: number; y: number }) => {
+      activeAnchor = { ...point, focalX: 250, focalY: 250 };
+    });
+    const controller = new EditorZoomController({
+      editor,
+      layout: () => defaultLayout,
+      viewportWidth: () => 500,
+      getScrollViewport: () => viewport as unknown as ScrollViewport,
+      beginViewportZoom,
+      resolveViewportAnchor: () => activeAnchor,
+    });
+    controllerRef.current = controller;
+    controllers.push(controller);
+
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      await controller.toggleZoomByIndicator();
+      await controller.toggleZoomByIndicator();
+    }
+
+    expect(clientToLocal).not.toHaveBeenCalled();
+    expect(beginViewportZoom).not.toHaveBeenCalled();
+    expect(scrollTop).toBeCloseTo(300);
+  });
+
+  it('does not resnap a settled zoom when the viewport resizes', async () => {
+    let viewportWidth = 500;
+    const editor = {
+      clientToLocal: vi.fn(() => null),
+      pageSizes: [],
+      pageEls: [],
+    } as unknown as Editor;
+    const controller = new EditorZoomController({
+      editor,
+      layout: () => ({ type: 'continuous', maxWidth: 600 }),
+      viewportWidth: () => viewportWidth,
+      getScrollViewport: () => null,
+    });
+    controllers.push(controller);
+    controller.syncInitialZoom();
+
+    controller.setZoom(0.79, { commitRender: true });
+    expect(controller.displayZoom).toBe(0.78125);
+    expect(controller.landmark).toBe('fit-width');
+
+    viewportWidth = 480;
+    controller.clampCurrentZoomToBounds();
+
+    expect(controller.displayZoom).toBe(0.78125);
+    expect(controller.landmark).toBeNull();
+  });
+});
+
 const wheelEvent = ({
   metaKey = false,
   ctrlKey = false,
@@ -183,6 +349,70 @@ afterEach(() => {
   controllers.length = 0;
   vi.useRealTimers();
   vi.unstubAllGlobals();
+});
+
+describe('EditorZoomController keyboard steps', () => {
+  it('moves to the next ten-percent grid line instead of adding ten percent', async () => {
+    const controller = createController();
+
+    controller.setZoom(0.53, { commitRender: true });
+    expect(await controller.zoomInByKeyboard()).toBe(true);
+    expect(controller.displayZoom).toBeCloseTo(0.6);
+
+    controller.setZoom(0.53, { commitRender: true });
+    expect(await controller.zoomOutByKeyboard()).toBe(true);
+    expect(controller.displayZoom).toBeCloseTo(0.5);
+  });
+
+  it('stops at intervening landmarks as well as ten-percent grid lines', async () => {
+    const layout = { type: 'paginated', pageWidth: 1000 } as const;
+    const editor = {
+      clientToLocal: vi.fn(() => null),
+      pageSizes: [],
+      pageEls: [],
+    } as unknown as Editor;
+    const controller = new EditorZoomController({
+      editor,
+      layout: () => layout,
+      viewportWidth: () => 520,
+      getScrollViewport: () => null,
+    });
+    controllers.push(controller);
+
+    controller.setZoom(0.45, { commitRender: true });
+    await controller.zoomInByKeyboard();
+    expect(controller.displayZoom).toBeCloseTo(0.5);
+    await controller.zoomInByKeyboard();
+    expect(controller.displayZoom).toBeCloseTo(0.52);
+
+    controller.setZoom(0.58, { commitRender: true });
+    await controller.zoomOutByKeyboard();
+    expect(controller.displayZoom).toBeCloseTo(0.52);
+  });
+
+  it('reports whether a minimum or maximum step changed the applied zoom', async () => {
+    const controller = createController();
+
+    controller.setZoom(0.1, { commitRender: true });
+    expect(await controller.zoomOutByKeyboard()).toBe(false);
+    expect(await controller.zoomInByKeyboard()).toBe(true);
+
+    controller.setZoom(2, { commitRender: true });
+    expect(await controller.zoomInByKeyboard()).toBe(false);
+    expect(await controller.zoomOutByKeyboard()).toBe(true);
+  });
+
+  it('keeps an outward keyboard step unavailable during elastic overshoot', async () => {
+    const controller = createController();
+
+    expect(controller.beginDirectZoom('touch', 0, 0, 0)).toBe(true);
+    await controller.updateDirectZoom('touch', 0.05, 0, 0, 250);
+    const overshootZoom = controller.displayZoom;
+    expect(overshootZoom).toBeLessThan(0.1);
+
+    expect(await controller.zoomOutByKeyboard()).toBe(false);
+    expect(controller.displayZoom).toBe(overshootZoom);
+  });
 });
 
 describe('EditorZoomController direct zoom detents', () => {
@@ -287,6 +517,8 @@ describe('EditorZoomController direct zoom detents', () => {
     const scrollBy = vi.fn();
     const viewport = {
       getRect: () => ({ left: 0, top: 0, right: 1000, bottom: 1000 }),
+      getScrollLeft: () => 0,
+      getScrollTop: () => 0,
       scrollBy,
     };
     const editor = {
@@ -318,6 +550,8 @@ describe('EditorZoomController direct zoom detents', () => {
     const scrollBy = vi.fn();
     const viewport = {
       getRect: () => ({ left: 0, top: 0, right: 1000, bottom: 1000 }),
+      getScrollLeft: () => 0,
+      getScrollTop: () => 0,
       scrollBy,
     };
     const editor = {
@@ -371,6 +605,8 @@ describe('EditorZoomController.handleWheel', () => {
     const scrollBy = vi.fn();
     const viewport = {
       getRect: () => ({ left: 0, top: 0, right: 1000, bottom: 1000 }),
+      getScrollLeft: () => 0,
+      getScrollTop: () => 0,
       scrollBy,
     };
     const editor = {

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { IS_MAC } from '$lib/editor-ffi/constants';
-  import { resolveDocumentZoomIndicator } from '$lib/editor-ffi/zoom';
+  import { computeDocumentZoomBounds, resolveDocumentZoomIndicator, zoomEquals } from '$lib/editor-ffi/zoom';
   import { EditorZoomController } from '../editor-zoom.svelte';
   import ZoomOverlay from './ZoomOverlay.svelte';
   import type { Snippet } from 'svelte';
   import type { Editor } from '$lib/editor-ffi/editor.svelte';
-  import type { DocumentZoomLayout } from '$lib/editor-ffi/zoom';
+  import type { EditorScrollScope } from '$lib/editor-ffi/scroll.svelte';
+  import type { DocumentZoomLandmark, DocumentZoomLayout } from '$lib/editor-ffi/zoom';
 
   type Props = {
     editor: Editor;
     active?: boolean;
     layout: DocumentZoomLayout | null;
     viewportWidth: number;
-    attachViewportAnchor?: (point: { page: number; x: number; y: number }) => void;
+    editorViewSurface: HTMLElement | undefined;
+    scroll: EditorScrollScope | undefined;
     children?: Snippet;
   };
 
@@ -31,12 +33,14 @@
 
   type PinchContact = Pick<Touch, 'clientX' | 'clientY'>;
 
-  let { editor, active = true, layout, viewportWidth, attachViewportAnchor, children }: Props = $props();
+  let { editor, active = true, layout, viewportWidth, editorViewSurface, scroll, children }: Props = $props();
 
   let pinchSession = $state<PinchSession | null>(null);
   let pinchQueuedUpdate = $state<PinchUpdate | null>(null);
   let suppressPinchUntilAllUp = false;
   let pinchFlushPromise: Promise<void> | null = null;
+  let boundaryAttemptRequest = $state(0);
+  let boundaryAttemptLandmark = $state<DocumentZoomLandmark | null>(null);
   const scrollContainer = $derived(editor.scrollContainerEl);
 
   const zoom = new EditorZoomController({
@@ -44,13 +48,42 @@
     layout: () => layout,
     viewportWidth: () => viewportWidth,
     getScrollViewport: () => editor.scrollViewport,
-    attachViewportAnchor: (point) => attachViewportAnchor?.(point),
+    resolvePendingViewportAnchor: () => scroll?.resolvePendingViewportZoomAnchor() ?? null,
+    resolveViewportAnchor: () => scroll?.resolveViewportZoomAnchor() ?? null,
+    beginViewportZoom: (point) => scroll?.beginViewportZoomAt(point),
+    updateViewportZoomAttachment: (desiredScroll) => scroll?.updateViewportZoomAttachment(desiredScroll),
   });
 
   const zoomEnabled = $derived(layout !== null);
   const displayZoom = $derived(zoomEnabled ? zoom.displayZoom : 1);
   const renderZoom = $derived(zoomEnabled ? zoom.renderZoom : 1);
   const indicatorZoom = $derived(layout ? resolveDocumentZoomIndicator(displayZoom, layout) : 1);
+  const landmark = $derived(zoom.landmark);
+  const bounds = $derived(layout ? computeDocumentZoomBounds(layout) : null);
+  const atMinimum = $derived(bounds ? zoomEquals(indicatorZoom, bounds.min) : false);
+  const atMaximum = $derived(bounds ? zoomEquals(indicatorZoom, bounds.max) : false);
+  const toggleTargetLandmark = $derived(zoom.indicatorToggleTargetLandmark);
+
+  function requestBoundaryAttempt(nextLandmark: 'minimum' | 'maximum') {
+    boundaryAttemptLandmark = nextLandmark;
+    boundaryAttemptRequest += 1;
+  }
+
+  async function zoomIn(): Promise<boolean> {
+    const changed = await zoom.zoomInByKeyboard();
+    if (!changed && atMaximum) requestBoundaryAttempt('maximum');
+    return changed;
+  }
+
+  async function zoomOut(): Promise<boolean> {
+    const changed = await zoom.zoomOutByKeyboard();
+    if (!changed && atMinimum) requestBoundaryAttempt('minimum');
+    return changed;
+  }
+
+  async function toggleZoom(): Promise<void> {
+    await zoom.toggleZoomByIndicator();
+  }
 
   $effect(() => {
     editor.displayZoom = displayZoom;
@@ -102,13 +135,13 @@
 
     if (isZoomInShortcut(event)) {
       event.preventDefault();
-      void zoom.zoomInByKeyboard();
+      void zoomIn();
       return;
     }
 
     if (isZoomOutShortcut(event)) {
       event.preventDefault();
-      void zoom.zoomOutByKeyboard();
+      void zoomOut();
       return;
     }
 
@@ -318,8 +351,23 @@
 
 <svelte:window onkeydowncapture={handleBrowserZoomShortcut} />
 
+<ZoomOverlay
+  {atMaximum}
+  {atMinimum}
+  {boundaryAttemptLandmark}
+  {boundaryAttemptRequest}
+  {displayZoom}
+  {editorViewSurface}
+  enabled={zoomEnabled}
+  {indicatorZoom}
+  {landmark}
+  onToggleZoom={toggleZoom}
+  onZoomIn={zoomIn}
+  onZoomOut={zoomOut}
+  {scrollContainer}
+  {toggleTargetLandmark}
+/>
+
 <div class={css({ display: 'contents' })}>
   {@render children?.()}
 </div>
-
-<ZoomOverlay {displayZoom} enabled={zoomEnabled} {indicatorZoom} {scrollContainer} />

--- a/apps/website/src/lib/editor-ffi/components/ui/ZoomOverlay.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/ZoomOverlay.svelte
@@ -1,122 +1,605 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
+  import { token } from '@typie/styled-system/tokens';
+  import { hoverIntent, portal, tooltip } from '@typie/ui/actions';
+  import { Icon } from '@typie/ui/components';
+  import { prefersReducedMotion as reducedMotionPreference } from '@typie/ui/state';
+  import { fade } from 'svelte/transition';
+  import FileCheckCornerIcon from '~icons/lucide/file-check-corner';
+  import GalleryHorizontalIcon from '~icons/lucide/gallery-horizontal';
+  import MinusIcon from '~icons/lucide/minus';
+  import PlusIcon from '~icons/lucide/plus';
+  import SearchIcon from '~icons/lucide/search';
+  import ZoomInIcon from '~icons/lucide/zoom-in';
+  import ZoomOutIcon from '~icons/lucide/zoom-out';
   import { zoomDiffers } from '$lib/editor-ffi/zoom';
+  import type { DocumentZoomLandmark } from '$lib/editor-ffi/zoom';
 
   type Props = {
     enabled: boolean;
     displayZoom: number;
     indicatorZoom: number;
+    landmark: DocumentZoomLandmark | null;
+    atMinimum: boolean;
+    atMaximum: boolean;
+    toggleTargetLandmark: DocumentZoomLandmark | null;
+    boundaryAttemptRequest?: number;
+    boundaryAttemptLandmark?: DocumentZoomLandmark | null;
     scrollContainer?: HTMLElement;
+    editorViewSurface: HTMLElement | undefined;
+    onZoomOut: () => unknown | Promise<unknown>;
+    onZoomIn: () => unknown | Promise<unknown>;
+    onToggleZoom: () => unknown | Promise<unknown>;
   };
 
+  type ZoomRangeState = 'in-range' | 'below-minimum' | 'above-maximum';
+
   const ZOOM_OVERLAY_VISIBLE_MS = 1000;
+  const ZOOM_OVERLAY_LANDMARK_VISIBLE_MS = 2000;
+  const ZOOM_LANDMARK_VISIBLE_MS = 1000;
+  const ZOOM_OVERLAY_HOVER_INTENT_DELAY_MS = 400;
   const ZOOM_OVERLAY_FADE_MS = 180;
+  const ZOOM_VALUE_TRANSITION_MS = 120;
+  const ACTIVE_SURFACE = token('colors.surface.muted');
+  const SUBTLE_BORDER = token('colors.border.subtle');
+  const DEFAULT_BORDER = token('colors.border.default');
+  const PASSIVE_BLUR_LAYERS = [
+    { blur: 0.5, mask: 'linear-gradient(to right, transparent 0, black 2px, black 6px, transparent 8px)' },
+    { blur: 1.5, mask: 'linear-gradient(to right, transparent 6px, black 8px, black 12px, transparent 14px)' },
+    { blur: 2.5, mask: 'linear-gradient(to right, transparent 12px, black 14px, black 18px, transparent 20px)' },
+    { blur: 4, mask: 'linear-gradient(to right, transparent 18px, black 20px)' },
+  ] as const;
+  const LANDMARK_LABELS: Record<DocumentZoomLandmark, string> = {
+    minimum: '최소',
+    'fit-width': '맞춤',
+    unit: '원본',
+    maximum: '최대',
+  };
+  const LANDMARK_ICONS = {
+    minimum: ZoomOutIcon,
+    'fit-width': GalleryHorizontalIcon,
+    unit: FileCheckCornerIcon,
+    maximum: ZoomInIcon,
+  } as const;
 
-  let { enabled, displayZoom, indicatorZoom, scrollContainer }: Props = $props();
+  let {
+    enabled,
+    displayZoom,
+    indicatorZoom,
+    landmark,
+    atMinimum,
+    atMaximum,
+    toggleTargetLandmark,
+    boundaryAttemptRequest = 0,
+    boundaryAttemptLandmark = null,
+    scrollContainer,
+    editorViewSurface,
+    onZoomOut,
+    onZoomIn,
+    onToggleZoom,
+  }: Props = $props();
 
-  let visible = $state(false);
+  let transientVisible = $state(false);
+  let hovered = $state(false);
+  let indicatorHoverIntended = false;
+  let focusWithin = $state(false);
+  let valueHovered = $state(false);
+  let valueFocused = $state(false);
+  let announcedLandmark = $state<DocumentZoomLandmark | null>(null);
+  let landmarkHeld = $state(false);
   let hideTimer: ReturnType<typeof setTimeout> | null = null;
+  let landmarkTimer: ReturnType<typeof setTimeout> | null = null;
+  let touchClickSuppressionTimer: ReturnType<typeof setTimeout> | null = null;
+  let suppressTouchClick = false;
   let lastZoom: number | null = null;
+  let lastLandmark: DocumentZoomLandmark | null | undefined;
+  let lastRangeState: ZoomRangeState | undefined;
+  let lastBoundaryAttemptRequest = 0;
+  let snapFeedbackRequest = $state(0);
+  let snapFeedbackLandmark = $state<DocumentZoomLandmark | null>(null);
   let wasEnabled = $state(false);
-  let overlayLeft = $state(20);
-  let overlayBottom = $state(20);
+  const prefersReducedMotion = $derived(reducedMotionPreference.current);
+
+  const visible = $derived(enabled && (transientVisible || landmarkHeld || hovered || focusWithin));
+  const engaged = $derived(hovered || focusWithin);
+  const surfaceColor = $derived(engaged ? ACTIVE_SURFACE : 'color-mix(in srgb, var(--editor-layout-background) 72%, transparent)');
+  const passiveBlurTransition = $derived(prefersReducedMotion || engaged ? 'none' : 'backdrop-filter 320ms cubic-bezier(0, 0, 0.2, 1)');
+  const edgeColor = $derived(
+    engaged
+      ? `color-mix(in srgb, ${ACTIVE_SURFACE} 36%, ${DEFAULT_BORDER} 64%)`
+      : `color-mix(in srgb, var(--editor-layout-background) 40%, ${SUBTLE_BORDER} 60%)`,
+  );
+  const zoomPercent = $derived(Math.round(indicatorZoom * 100));
+  const displayedLandmark = $derived(valueHovered || valueFocused ? landmark : announcedLandmark);
+  const displayedValue = $derived(displayedLandmark ? LANDMARK_LABELS[displayedLandmark] : `${zoomPercent}%`);
+  const displayedIcon = $derived(displayedLandmark ? LANDMARK_ICONS[displayedLandmark] : SearchIcon);
+  const toggleAvailable = $derived(toggleTargetLandmark !== null);
+  const toggleLabel = $derived.by(() => {
+    switch (toggleTargetLandmark) {
+      case 'fit-width': {
+        return '화면에 맞추기';
+      }
+      case 'unit': {
+        return '원본 크기로 돌아가기';
+      }
+      case 'minimum': {
+        return '최소 배율로 축소';
+      }
+      case 'maximum': {
+        return '최대 배율로 확대';
+      }
+      default: {
+        return '원본 크기가 화면에 맞춰져 있어요';
+      }
+    }
+  });
+  const toggleKeys = $derived(toggleTargetLandmark === 'unit' ? (['Mod', '0'] as ['Mod', '0']) : undefined);
+
+  function handleValuePointerEnter() {
+    valueHovered = true;
+  }
+
+  function handleValuePointerLeave() {
+    valueHovered = false;
+  }
+
+  function handleValueFocus() {
+    valueFocused = true;
+  }
+
+  function handleValueBlur() {
+    valueFocused = false;
+  }
+
+  function clearHideTimer() {
+    if (!hideTimer) return;
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+
+  function clearLandmarkTimer() {
+    if (!landmarkTimer) return;
+    clearTimeout(landmarkTimer);
+    landmarkTimer = null;
+  }
 
   function showTemporarily() {
-    visible = true;
-    if (hideTimer) {
-      clearTimeout(hideTimer);
+    transientVisible = true;
+    clearHideTimer();
+    hideTimer = setTimeout(
+      () => {
+        transientVisible = false;
+        hideTimer = null;
+      },
+      announcedLandmark ? ZOOM_OVERLAY_LANDMARK_VISIBLE_MS : ZOOM_OVERLAY_VISIBLE_MS,
+    );
+  }
+
+  function handleIndicatorPointerEnter() {
+    indicatorHoverIntended = false;
+    if (visible) hovered = true;
+  }
+
+  function handleIndicatorHoverIntent() {
+    indicatorHoverIntended = true;
+    hovered = true;
+  }
+
+  function handleIndicatorPointerLeave() {
+    const shouldLinger = hovered && indicatorHoverIntended;
+    hovered = false;
+    if (shouldLinger) showTemporarily();
+    indicatorHoverIntended = false;
+  }
+
+  function handleIndicatorFocusIn() {
+    focusWithin = true;
+  }
+
+  function handleIndicatorFocusOut(event: FocusEvent & { currentTarget: HTMLDivElement }) {
+    const nextFocusWithin = event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget);
+    if (focusWithin && !nextFocusWithin) showTemporarily();
+    focusWithin = nextFocusWithin;
+  }
+
+  function handleIndicatorPointerDown(event: PointerEvent) {
+    if (event.pointerType !== 'touch') {
+      event.preventDefault();
+      return;
     }
-    hideTimer = setTimeout(() => {
-      visible = false;
-      hideTimer = null;
-    }, ZOOM_OVERLAY_VISIBLE_MS);
+    if (visible) return;
+    suppressTouchClick = true;
+    showTemporarily();
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  function clearTouchClickSuppression() {
+    if (touchClickSuppressionTimer) {
+      clearTimeout(touchClickSuppressionTimer);
+      touchClickSuppressionTimer = null;
+    }
+    suppressTouchClick = false;
+  }
+
+  function handleIndicatorClickCapture(event: MouseEvent) {
+    if (!suppressTouchClick) return;
+    event.preventDefault();
+    event.stopPropagation();
+    clearTouchClickSuppression();
+  }
+
+  function handleIndicatorPointerUp(event: PointerEvent) {
+    if (!suppressTouchClick || event.pointerType !== 'touch') return;
+    if (touchClickSuppressionTimer) clearTimeout(touchClickSuppressionTimer);
+    touchClickSuppressionTimer = setTimeout(clearTouchClickSuppression, 0);
+  }
+
+  function handleIndicatorPointerCancel(event: PointerEvent) {
+    if (event.pointerType === 'touch') clearTouchClickSuppression();
+  }
+
+  function announceLandmark(next: DocumentZoomLandmark | null, held = false) {
+    clearLandmarkTimer();
+    announcedLandmark = next;
+    landmarkHeld = next !== null && held;
+    if (!next || landmarkHeld) return;
+    landmarkTimer = setTimeout(() => {
+      announcedLandmark = null;
+      landmarkTimer = null;
+    }, ZOOM_LANDMARK_VISIBLE_MS);
+  }
+
+  function resolveZoomRangeState(): ZoomRangeState {
+    if (!zoomDiffers(displayZoom, indicatorZoom)) return 'in-range';
+    return displayZoom < indicatorZoom ? 'below-minimum' : 'above-maximum';
+  }
+
+  function rangeLandmark(state: ZoomRangeState): DocumentZoomLandmark | null {
+    if (state === 'below-minimum') return 'minimum';
+    if (state === 'above-maximum') return 'maximum';
+    return null;
+  }
+
+  function requestSnapFeedback(nextLandmark: DocumentZoomLandmark) {
+    snapFeedbackLandmark = nextLandmark;
+    snapFeedbackRequest += 1;
+  }
+
+  function handleToggleZoom() {
+    void onToggleZoom();
   }
 
   $effect(() => {
     const entered = enabled && !wasEnabled;
     wasEnabled = enabled;
-    const prev = lastZoom;
+    const previousZoom = lastZoom;
     lastZoom = displayZoom;
-    const shouldShow = prev === null || zoomDiffers(prev, displayZoom);
-    if (enabled && (entered || shouldShow)) {
-      showTemporarily();
-    }
+    const initialObservation = previousZoom === null;
+    const zoomChanged = !initialObservation && zoomDiffers(previousZoom, displayZoom);
+    if (enabled && (zoomChanged || (entered && landmark !== 'unit'))) showTemporarily();
+    if (!enabled) transientVisible = false;
+  });
+
+  $effect(() => {
+    const currentRangeState = resolveZoomRangeState();
+    const previousRangeState = lastRangeState;
+    const currentLandmark = landmark;
+    const previousLandmark = lastLandmark;
+
     if (!enabled) {
-      visible = false;
-    }
-  });
-
-  $effect(() => {
-    return () => {
-      if (!hideTimer) {
-        return;
-      }
-
-      clearTimeout(hideTimer);
-      hideTimer = null;
-    };
-  });
-
-  $effect(() => {
-    const el = scrollContainer;
-
-    const syncOverlayPosition = () => {
-      if (!el) {
-        overlayLeft = 20;
-        overlayBottom = 20;
-        return;
-      }
-
-      const rect = el.getBoundingClientRect();
-      overlayLeft = rect.left + 20;
-      overlayBottom = Math.max(20, window.innerHeight - rect.bottom + 20);
-    };
-
-    syncOverlayPosition();
-
-    if (!el) {
+      lastRangeState = undefined;
+      lastLandmark = undefined;
+      clearLandmarkTimer();
+      announcedLandmark = null;
+      landmarkHeld = false;
       return;
     }
 
-    const observer = new ResizeObserver(syncOverlayPosition);
-    observer.observe(el);
-    // eslint-disable-next-line unicorn/prefer-observer-apis -- overlay is positioned relative to window.innerHeight, which ResizeObserver does not track
-    window.addEventListener('resize', syncOverlayPosition);
+    lastRangeState = currentRangeState;
+    lastLandmark = currentLandmark;
 
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('resize', syncOverlayPosition);
-    };
+    if (previousRangeState === undefined || previousLandmark === undefined) return;
+
+    if (currentRangeState !== previousRangeState) {
+      if (currentRangeState !== 'in-range') {
+        announceLandmark(rangeLandmark(currentRangeState), true);
+        showTemporarily();
+      } else if (previousRangeState !== 'in-range') {
+        const recoveredLandmark = rangeLandmark(previousRangeState) as DocumentZoomLandmark;
+        announceLandmark(recoveredLandmark);
+        requestSnapFeedback(recoveredLandmark);
+        showTemporarily();
+      }
+      return;
+    }
+
+    if (currentRangeState === 'in-range' && currentLandmark !== previousLandmark) {
+      announceLandmark(currentLandmark);
+      if (currentLandmark) requestSnapFeedback(currentLandmark);
+      showTemporarily();
+    }
   });
 
-  const zoomPercent = $derived(Math.round(indicatorZoom * 100));
+  $effect(() => {
+    const request = boundaryAttemptRequest;
+    const requestLandmark = boundaryAttemptLandmark;
+    if (request === lastBoundaryAttemptRequest || request <= 0) return;
+    lastBoundaryAttemptRequest = request;
+    if (requestLandmark !== 'minimum' && requestLandmark !== 'maximum') return;
+    if (landmark !== requestLandmark || resolveZoomRangeState() !== 'in-range') return;
+    announceLandmark(requestLandmark);
+    showTemporarily();
+  });
+
+  $effect(() => {
+    const el = editorViewSurface?.closest<HTMLElement>('[data-pane-id]') ?? editorViewSurface ?? scrollContainer;
+    if (!el) return;
+    const handlePointerEnter = () => {
+      if (enabled && landmark !== 'unit') showTemporarily();
+    };
+    el.addEventListener('pointerenter', handlePointerEnter);
+    return () => el.removeEventListener('pointerenter', handlePointerEnter);
+  });
+
+  $effect(() => {
+    return () => {
+      clearHideTimer();
+      clearLandmarkTimer();
+      clearTouchClickSuppression();
+    };
+  });
 </script>
 
-{#if enabled}
+{#if enabled && editorViewSurface}
   <div
-    style:left={`${overlayLeft}px`}
-    style:bottom={`${overlayBottom}px`}
-    style:opacity={visible ? '1' : '0'}
-    style:transition={`opacity ${ZOOM_OVERLAY_FADE_MS}ms ease-out`}
     class={css({
-      pointerEvents: 'none',
-      position: 'fixed',
-      zIndex: 'menu',
-      borderRadius: '8px',
-      borderWidth: '1px',
-      borderColor: 'border.strong',
-      backgroundColor: 'surface.subtle',
-      opacity: '95',
-      paddingX: '12px',
-      paddingY: '8px',
-      fontSize: '12px',
-      fontWeight: 'medium',
-      color: 'text.default',
-      transition: 'opacity',
+      position: 'absolute',
+      top: '0',
+      right: '0',
+      zIndex: '5',
+      width: '[fit-content]',
+      paddingLeft: '24px',
     })}
-    aria-hidden={!visible}
-    role="status"
+    role="presentation"
+    use:hoverIntent={{
+      delay: ZOOM_OVERLAY_HOVER_INTENT_DELAY_MS,
+      samples: 1,
+      onEnter: handleIndicatorPointerEnter,
+      onIntent: handleIndicatorHoverIntent,
+      onLeave: handleIndicatorPointerLeave,
+    }}
+    use:portal={editorViewSurface}
   >
-    {zoomPercent}%
+    <div
+      style:opacity={visible ? '1' : '0'}
+      style:transition={prefersReducedMotion ? 'none' : `opacity ${ZOOM_OVERLAY_FADE_MS}ms ease-out`}
+      class={css({
+        position: 'relative',
+        isolation: 'isolate',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '2px',
+        paddingX: '8px',
+        paddingY: '4px',
+        fontSize: '12px',
+        fontWeight: 'medium',
+        color: engaged ? 'text.default' : 'text.subtle',
+      })}
+      aria-label="페이지 배율"
+      onclickcapture={handleIndicatorClickCapture}
+      onfocusin={handleIndicatorFocusIn}
+      onfocusout={handleIndicatorFocusOut}
+      onpointercancel={handleIndicatorPointerCancel}
+      onpointerdown={handleIndicatorPointerDown}
+      onpointerup={handleIndicatorPointerUp}
+      role="group"
+    >
+      {#each PASSIVE_BLUR_LAYERS as layer (layer.blur)}
+        <div
+          style:backdrop-filter={`blur(${visible ? layer.blur : 0}px)`}
+          style:mask-image={layer.mask}
+          style:opacity={engaged ? '0' : '1'}
+          style:transition={passiveBlurTransition}
+          class={css({
+            position: 'absolute',
+            top: '0',
+            right: '0',
+            bottom: '0',
+            left: '-16px',
+            zIndex: '[-2]',
+            pointerEvents: 'none',
+          })}
+          aria-hidden="true"
+          data-zoom-indicator-blur={layer.blur}
+        ></div>
+      {/each}
+      <div
+        style:background-color={surfaceColor}
+        style:transition={prefersReducedMotion ? 'none' : 'background-color 180ms ease-out'}
+        class={css({
+          position: 'absolute',
+          top: '0',
+          right: '0',
+          bottom: '0',
+          left: '-24px',
+          zIndex: '[-1]',
+          pointerEvents: 'none',
+          maskImage: '[linear-gradient(to right, transparent 0, black 24px 100%)]',
+        })}
+        aria-hidden="true"
+        data-zoom-indicator-surface
+      ></div>
+      <div
+        style:background-color={edgeColor}
+        style:transition={prefersReducedMotion ? 'none' : 'background-color 180ms ease-out'}
+        class={css({
+          position: 'absolute',
+          right: '0',
+          bottom: '0',
+          left: '-24px',
+          zIndex: '[-1]',
+          height: '1px',
+          pointerEvents: 'none',
+          maskImage: '[linear-gradient(to right, transparent 0, black 24px 100%)]',
+        })}
+        aria-hidden="true"
+        data-zoom-indicator-edge
+      ></div>
+      <button
+        class={css({
+          display: 'grid',
+          placeItems: 'center',
+          size: '24px',
+          color: 'text.subtle',
+          cursor: 'pointer',
+          borderRadius: '8px',
+          _hover: { backgroundColor: 'interactive.hover', color: 'text.default' },
+          _focusVisible: { outline: '2px solid token(colors.border.focus)', outlineOffset: '-2px' },
+          '&[data-at-zoom-boundary="true"]': { color: 'text.faint', _hover: { color: 'text.faint' } },
+        })}
+        aria-label={atMinimum ? '최소 배율입니다' : '페이지 축소'}
+        data-at-zoom-boundary={atMinimum}
+        onclick={onZoomOut}
+        tabindex={visible ? 0 : -1}
+        type="button"
+        use:tooltip={{
+          message: atMinimum ? '최소 배율입니다' : '페이지 축소',
+          keys: atMinimum ? undefined : ['Mod', '-'],
+          placement: 'bottom',
+        }}
+      >
+        <Icon icon={MinusIcon} size={14} />
+      </button>
+
+      <button
+        class={css({
+          position: 'relative',
+          width: '56px',
+          height: '24px',
+          paddingX: '4px',
+          textAlign: 'center',
+          cursor: toggleAvailable ? 'pointer' : 'default',
+          border: '1px solid transparent',
+          borderRadius: '8px',
+          _hover: { backgroundColor: 'interactive.hover' },
+          _focusVisible: { outline: '2px solid token(colors.border.focus)', outlineOffset: '-2px' },
+        })}
+        aria-label={toggleLabel}
+        onblur={handleValueBlur}
+        onclick={() => toggleAvailable && handleToggleZoom()}
+        onfocus={handleValueFocus}
+        onpointerenter={handleValuePointerEnter}
+        onpointerleave={handleValuePointerLeave}
+        tabindex={visible ? 0 : -1}
+        type="button"
+        use:tooltip={{ message: toggleLabel, keys: toggleKeys, placement: 'bottom' }}
+      >
+        {#if snapFeedbackRequest > 0 && snapFeedbackLandmark}
+          {#key snapFeedbackRequest}
+            <span
+              style:border-color={DEFAULT_BORDER}
+              class="zoom-snap-feedback"
+              aria-hidden="true"
+              data-reduced-motion={prefersReducedMotion}
+              data-zoom-snap-feedback
+              data-zoom-snap-landmark={snapFeedbackLandmark}
+            ></span>
+          {/key}
+        {/if}
+        <span
+          class={css({ position: 'relative', display: 'block', width: 'full', height: '[1.25em]' })}
+          aria-live="polite"
+          data-zoom-value-kind={displayedLandmark ? 'landmark' : 'percentage'}
+        >
+          {#key displayedLandmark ? 'landmark' : 'percentage'}
+            <span
+              class={css({
+                position: 'absolute',
+                inset: '0',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '4px',
+                whiteSpace: 'nowrap',
+              })}
+              in:fade={{ duration: prefersReducedMotion ? 0 : ZOOM_VALUE_TRANSITION_MS }}
+              out:fade={{ duration: prefersReducedMotion ? 0 : ZOOM_VALUE_TRANSITION_MS }}
+            >
+              <Icon icon={displayedIcon} size={14} />
+              <span>{displayedValue}</span>
+            </span>
+          {/key}
+        </span>
+      </button>
+
+      <button
+        class={css({
+          display: 'grid',
+          placeItems: 'center',
+          size: '24px',
+          color: 'text.subtle',
+          cursor: 'pointer',
+          borderRadius: '8px',
+          _hover: { backgroundColor: 'interactive.hover', color: 'text.default' },
+          _focusVisible: { outline: '2px solid token(colors.border.focus)', outlineOffset: '-2px' },
+          '&[data-at-zoom-boundary="true"]': { color: 'text.faint', _hover: { color: 'text.faint' } },
+        })}
+        aria-label={atMaximum ? '최대 배율입니다' : '페이지 확대'}
+        data-at-zoom-boundary={atMaximum}
+        onclick={onZoomIn}
+        tabindex={visible ? 0 : -1}
+        type="button"
+        use:tooltip={{
+          message: atMaximum ? '최대 배율입니다' : '페이지 확대',
+          keys: atMaximum ? undefined : ['Mod', '+'],
+          placement: 'bottom',
+        }}
+      >
+        <Icon icon={PlusIcon} size={14} />
+      </button>
+    </div>
   </div>
 {/if}
+
+<style>
+  .zoom-snap-feedback {
+    position: absolute;
+    inset: -1px;
+    z-index: 1;
+    border: 2px solid;
+    border-radius: 8px;
+    pointer-events: none;
+    animation: zoom-snap-border-flash 380ms ease-out both;
+  }
+
+  .zoom-snap-feedback[data-reduced-motion='true'] {
+    border-width: 1px;
+    animation: zoom-snap-border-reduced 280ms steps(1) both;
+  }
+
+  @keyframes zoom-snap-border-flash {
+    0% {
+      opacity: 0;
+    }
+    18% {
+      opacity: 1;
+    }
+    48% {
+      opacity: 0.72;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+
+  @keyframes zoom-snap-border-reduced {
+    0%,
+    99% {
+      opacity: 0.7;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+</style>

--- a/apps/website/src/lib/editor-ffi/components/ui/zoom-overlay-test-root.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/zoom-overlay-test-root.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import ZoomOverlay from './ZoomOverlay.svelte';
+  import type { Component } from 'svelte';
+  import type { DocumentZoomLandmark } from '$lib/editor-ffi/zoom';
+
+  type Props = {
+    initialEnabled?: boolean;
+    initialZoom?: number;
+    initialIndicatorZoom?: number;
+    initialLandmark?: DocumentZoomLandmark | null;
+  };
+
+  type TestableProps = {
+    enabled: boolean;
+    displayZoom: number;
+    indicatorZoom: number;
+    landmark: DocumentZoomLandmark | null;
+    atMinimum: boolean;
+    atMaximum: boolean;
+    toggleTargetLandmark: DocumentZoomLandmark | null;
+    boundaryAttemptRequest: number;
+    boundaryAttemptLandmark: DocumentZoomLandmark | null;
+    scrollContainer: HTMLElement;
+    editorViewSurface: HTMLElement;
+    onZoomOut: () => void;
+    onZoomIn: () => void;
+    onToggleZoom: () => Promise<unknown>;
+  };
+
+  const TestableZoomOverlay = ZoomOverlay as unknown as Component<TestableProps>;
+
+  let { initialEnabled = true, initialZoom = 1.25, initialIndicatorZoom = initialZoom, initialLandmark = null }: Props = $props();
+  let enabled = $state(initialEnabled);
+  let displayZoom = $state(initialZoom);
+  let indicatorZoom = $state(initialIndicatorZoom);
+  let landmark = $state<DocumentZoomLandmark | null>(initialLandmark);
+  let boundaryAttemptRequest = $state(0);
+  let boundaryAttemptLandmark = $state<DocumentZoomLandmark | null>(null);
+  let editorViewSurface = $state<HTMLElement>();
+  let scrollContainer = $state<HTMLElement>();
+
+  const toggleTargetLandmark = $derived<DocumentZoomLandmark | null>(landmark === 'unit' ? 'fit-width' : 'unit');
+  const noOp: () => void = () => null;
+
+  export function setZoom(nextDisplayZoom: number, nextIndicatorZoom: number, nextLandmark: DocumentZoomLandmark | null) {
+    displayZoom = nextDisplayZoom;
+    indicatorZoom = nextIndicatorZoom;
+    landmark = nextLandmark;
+  }
+
+  export function setEnabled(nextEnabled: boolean) {
+    enabled = nextEnabled;
+  }
+
+  export function requestBoundaryAttempt(nextLandmark: DocumentZoomLandmark) {
+    boundaryAttemptLandmark = nextLandmark;
+    boundaryAttemptRequest += 1;
+  }
+</script>
+
+<div data-pane-id="zoom-overlay-test-pane">
+  <div bind:this={editorViewSurface} style="position: relative; width: 300px">
+    <div bind:this={scrollContainer}></div>
+    {#if editorViewSurface && scrollContainer}
+      <TestableZoomOverlay
+        atMaximum={landmark === 'maximum'}
+        atMinimum={landmark === 'minimum'}
+        {boundaryAttemptLandmark}
+        {boundaryAttemptRequest}
+        {displayZoom}
+        {editorViewSurface}
+        {enabled}
+        {indicatorZoom}
+        {landmark}
+        onToggleZoom={async () => null}
+        onZoomIn={noOp}
+        onZoomOut={noOp}
+        {scrollContainer}
+        {toggleTargetLandmark}
+      />
+    {/if}
+  </div>
+</div>

--- a/apps/website/src/lib/editor-ffi/components/ui/zoom-overlay.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/zoom-overlay.browser.test.ts
@@ -1,0 +1,464 @@
+import '../../../../app.css';
+
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ZoomOverlayTestRoot from './zoom-overlay-test-root.svelte';
+import ZoomOverlay from './ZoomOverlay.svelte';
+import type { Component } from 'svelte';
+import type { DocumentZoomLandmark } from '$lib/editor-ffi/zoom';
+
+type TestProps = {
+  enabled: boolean;
+  displayZoom: number;
+  indicatorZoom: number;
+  landmark: DocumentZoomLandmark | null;
+  atMinimum: boolean;
+  atMaximum: boolean;
+  toggleTargetLandmark: DocumentZoomLandmark | null;
+  scrollContainer: HTMLElement;
+  editorViewSurface: HTMLElement;
+  onZoomOut: () => void;
+  onZoomIn: () => void;
+  onToggleZoom: () => Promise<unknown>;
+};
+
+const TestableZoomOverlay = ZoomOverlay as unknown as Component<TestProps>;
+const TRANSIENT_VISIBLE_MS = 1000;
+const HOVER_INTENT_SETTLE_MS = 100;
+let mounted: Record<string, unknown> | undefined;
+
+const enter = (element: HTMLElement) => element.dispatchEvent(new PointerEvent('pointerenter'));
+const leave = (element: HTMLElement) => element.dispatchEvent(new PointerEvent('pointerleave'));
+
+async function mountOverlay(
+  {
+    displayZoom = 1,
+    indicatorZoom = displayZoom,
+    landmark = null,
+    atMinimum = false,
+    atMaximum = false,
+    toggleTargetLandmark = landmark === 'unit' ? 'fit-width' : 'unit',
+    onZoomOut = () => null,
+    onZoomIn = () => null,
+    onToggleZoom = async () => null,
+  }: Partial<TestProps> = {},
+  { withinPane = true }: { withinPane?: boolean } = {},
+) {
+  const scrollContainer = document.createElement('div');
+  scrollContainer.dataset.testid = 'editor-pane';
+  scrollContainer.getBoundingClientRect = () => new DOMRect(40, 30, 300, 200);
+  const header = document.createElement('div');
+  header.dataset.testid = 'editor-header';
+  const editorViewSurface = document.createElement('div');
+  editorViewSurface.style.position = 'relative';
+  editorViewSurface.style.width = '300px';
+  editorViewSurface.append(header, scrollContainer);
+  const paneContainer = document.createElement('div');
+  paneContainer.dataset.paneId = 'pane-1';
+  const toolbar = document.createElement('div');
+  toolbar.dataset.testid = 'editor-toolbar';
+  if (withinPane) {
+    paneContainer.append(toolbar, editorViewSurface);
+    document.body.append(paneContainer);
+  } else {
+    document.body.append(editorViewSurface);
+  }
+  mounted = mount(TestableZoomOverlay, {
+    target: scrollContainer,
+    props: {
+      enabled: true,
+      displayZoom,
+      indicatorZoom,
+      landmark,
+      atMinimum,
+      atMaximum,
+      toggleTargetLandmark,
+      scrollContainer,
+      editorViewSurface,
+      onZoomOut,
+      onZoomIn,
+      onToggleZoom,
+    },
+  });
+  await tick();
+  const overlay = document.querySelector<HTMLElement>('[role="group"][aria-label="페이지 배율"]');
+  if (!overlay) throw new Error('Missing zoom overlay');
+  return { overlay, paneContainer, scrollContainer, editorViewSurface, toolbar };
+}
+
+async function expireTransientVisibility() {
+  await vi.advanceTimersByTimeAsync(TRANSIENT_VISIBLE_MS);
+  await tick();
+}
+
+afterEach(async () => {
+  if (mounted) await unmount(mounted);
+  mounted = undefined;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  document.body.replaceChildren();
+});
+
+describe('zoom overlay visibility', () => {
+  it('keeps an initial unit zoom hidden while revealing an initial non-unit zoom', async () => {
+    const unit = await mountOverlay({ displayZoom: 1, indicatorZoom: 1, landmark: 'unit' });
+    expect(unit.overlay.style.opacity).toBe('0');
+
+    await unmount(mounted as Record<string, unknown>);
+    mounted = undefined;
+    document.body.replaceChildren();
+
+    const nonUnit = await mountOverlay({ displayZoom: 1.25, indicatorZoom: 1.25, landmark: null });
+    expect(nonUnit.overlay.style.opacity).toBe('1');
+  });
+
+  it('keeps unit zoom hidden when the editor enables after its initial layout arrives', async () => {
+    const host = mount(ZoomOverlayTestRoot, {
+      target: document.body,
+      props: { initialEnabled: false, initialZoom: 1, initialLandmark: null },
+    });
+    mounted = host;
+    await tick();
+
+    enter(document.querySelector<HTMLElement>('[data-pane-id="zoom-overlay-test-pane"]') as HTMLElement);
+    host.setZoom(1, 1, 'unit');
+    host.setEnabled(true);
+    await tick();
+
+    expect(document.querySelector<HTMLElement>('[role="group"][aria-label="페이지 배율"]')?.style.opacity).toBe('0');
+  });
+
+  it('uses the unzoomed editor surface coordinate system', async () => {
+    const { overlay, editorViewSurface } = await mountOverlay();
+    const anchor = overlay.parentElement;
+
+    expect(anchor?.parentElement).toBe(editorViewSurface);
+    expect(getComputedStyle(anchor as HTMLElement).position).toBe('absolute');
+    expect(getComputedStyle(anchor as HTMLElement).top).toBe('0px');
+    expect(getComputedStyle(anchor as HTMLElement).right).toBe('0px');
+    expect(getComputedStyle(anchor as HTMLElement).zIndex).toBe('5');
+    expect(anchor?.getBoundingClientRect().right).toBe(editorViewSurface.getBoundingClientRect().right);
+  });
+
+  it('suppresses editor entry at unit zoom but reveals a non-unit pane', async () => {
+    vi.useFakeTimers();
+    let fixture = await mountOverlay({ displayZoom: 1, indicatorZoom: 1, landmark: 'unit' });
+    await expireTransientVisibility();
+
+    enter(fixture.paneContainer);
+    await tick();
+    expect(fixture.overlay.style.opacity).toBe('0');
+
+    await unmount(mounted as Record<string, unknown>);
+    mounted = undefined;
+    document.body.replaceChildren();
+    fixture = await mountOverlay({ displayZoom: 1.25, indicatorZoom: 1.25 });
+    await expireTransientVisibility();
+
+    enter(fixture.paneContainer);
+    await tick();
+    expect(fixture.overlay.style.opacity).toBe('1');
+  });
+
+  it('does not restart pane entry visibility when moving from toolbar to editor surface', async () => {
+    vi.useFakeTimers();
+    const { overlay, paneContainer, editorViewSurface } = await mountOverlay({ displayZoom: 1.25, indicatorZoom: 1.25 });
+    await expireTransientVisibility();
+
+    enter(paneContainer);
+    await vi.advanceTimersByTimeAsync(TRANSIENT_VISIBLE_MS - 500);
+    enter(editorViewSurface);
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(overlay.style.opacity).toBe('0');
+  });
+
+  it('falls back to the editor surface when no pane container exists', async () => {
+    vi.useFakeTimers();
+    const { overlay, editorViewSurface } = await mountOverlay({ displayZoom: 1.25, indicatorZoom: 1.25 }, { withinPane: false });
+    await expireTransientVisibility();
+
+    enter(editorViewSurface);
+    await tick();
+
+    expect(overlay.style.opacity).toBe('1');
+  });
+
+  it('stays hidden during an incidental pass that leaves before hover intent', async () => {
+    vi.useFakeTimers();
+    const { overlay } = await mountOverlay({ displayZoom: 1.25, indicatorZoom: 1.25 });
+    await expireTransientVisibility();
+    const hitRegion = overlay.parentElement as HTMLElement;
+
+    enter(hitRegion);
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS - 1);
+    expect(overlay.style.opacity).toBe('0');
+
+    leave(hitRegion);
+    await tick();
+    expect(overlay.style.opacity).toBe('0');
+
+    await vi.advanceTimersByTimeAsync(TRANSIENT_VISIBLE_MS);
+
+    expect(overlay.style.opacity).toBe('0');
+  });
+
+  it('stays visible after hover intent is established', async () => {
+    vi.useFakeTimers();
+    const { overlay } = await mountOverlay({ displayZoom: 1.25, indicatorZoom: 1.25 });
+    await expireTransientVisibility();
+    const hitRegion = overlay.parentElement as HTMLElement;
+
+    enter(hitRegion);
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS - 1);
+    expect(overlay.style.opacity).toBe('0');
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(overlay.style.opacity).toBe('1');
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(overlay.style.opacity).toBe('1');
+
+    leave(hitRegion);
+    await tick();
+    expect(overlay.style.opacity).toBe('1');
+
+    await vi.advanceTimersByTimeAsync(TRANSIENT_VISIBLE_MS - 1);
+    expect(overlay.style.opacity).toBe('1');
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(overlay.style.opacity).toBe('0');
+  });
+
+  it('lingers after keyboard focus leaves the indicator', async () => {
+    vi.useFakeTimers();
+    const { overlay } = await mountOverlay({ displayZoom: 1.25, indicatorZoom: 1.25 });
+    await expireTransientVisibility();
+    const value = document.querySelector<HTMLButtonElement>('[aria-label="원본 크기로 돌아가기"]');
+
+    value?.focus();
+    await tick();
+    expect(overlay.style.opacity).toBe('1');
+
+    value?.blur();
+    await tick();
+    expect(overlay.style.opacity).toBe('1');
+
+    await vi.advanceTimersByTimeAsync(TRANSIENT_VISIBLE_MS - 1);
+    expect(overlay.style.opacity).toBe('1');
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(overlay.style.opacity).toBe('0');
+  });
+});
+
+describe('zoom overlay controls', () => {
+  it('reveals on the first hidden touch and activates only on the next touch', async () => {
+    const onToggleZoom = vi.fn(async () => null);
+    const { overlay } = await mountOverlay({ landmark: 'unit', onToggleZoom });
+    const value = document.querySelector<HTMLButtonElement>('[aria-label="화면에 맞추기"]');
+
+    value?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, pointerType: 'touch' }));
+    value?.click();
+    await tick();
+    expect(overlay.style.opacity).toBe('1');
+    expect(onToggleZoom).not.toHaveBeenCalled();
+
+    value?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, pointerType: 'touch' }));
+    value?.click();
+    await tick();
+    expect(onToggleZoom).toHaveBeenCalledOnce();
+  });
+
+  it('does not present a landmark from an asynchronously completed toggle command', async () => {
+    const toggle = Promise.withResolvers<DocumentZoomLandmark | null>();
+    const onToggleZoom = vi.fn(() => toggle.promise);
+    await mountOverlay({ landmark: 'unit', onToggleZoom });
+    const value = document.querySelector<HTMLButtonElement>('[aria-label="화면에 맞추기"]');
+
+    value?.click();
+    toggle.resolve('fit-width');
+    await tick();
+
+    expect(value?.textContent).toContain('100%');
+    expect(value?.textContent).not.toContain('맞춤');
+  });
+
+  it('keeps an at-boundary control actionable with explanatory semantics', async () => {
+    const onZoomOut = vi.fn(() => false);
+    await mountOverlay({
+      displayZoom: 0.2,
+      indicatorZoom: 0.2,
+      landmark: 'minimum',
+      atMinimum: true,
+      onZoomOut,
+    });
+    const zoomOut = document.querySelector<HTMLButtonElement>('button[data-at-zoom-boundary="true"]');
+
+    expect(zoomOut?.getAttribute('aria-label')).toBe('최소 배율입니다');
+    zoomOut?.click();
+    await tick();
+
+    expect(onZoomOut).toHaveBeenCalledOnce();
+  });
+
+  it('shows the current landmark while the value is hovered and keeps unnamed percentages', async () => {
+    await mountOverlay({ displayZoom: 1, indicatorZoom: 1, landmark: 'unit' });
+    let value = document.querySelector<HTMLButtonElement>('[aria-label="화면에 맞추기"]');
+    expect(value).not.toBeNull();
+    enter(value as HTMLButtonElement);
+    await tick();
+    expect(value?.textContent).toContain('원본');
+
+    await unmount(mounted as Record<string, unknown>);
+    mounted = undefined;
+    document.body.replaceChildren();
+    const fixture = await mountOverlay({ displayZoom: 1.25, indicatorZoom: 1.25, landmark: null });
+    value = document.querySelector<HTMLButtonElement>('[aria-label="원본 크기로 돌아가기"]');
+    enter(value as HTMLButtonElement);
+    await tick();
+    expect(value?.textContent).toContain('125%');
+    expect(fixture.overlay.style.opacity).toBe('1');
+  });
+
+  it('describes a clamped fit action by its actual maximum landmark', async () => {
+    await mountOverlay({ landmark: 'unit', toggleTargetLandmark: 'maximum' });
+
+    expect(document.querySelector('[aria-label="최대 배율로 확대"]')).not.toBeNull();
+  });
+});
+
+describe('zoom overlay snap feedback', () => {
+  it('starts once on applied landmark entry and restarts only after leaving it', async () => {
+    const host = mount(ZoomOverlayTestRoot, { target: document.body });
+    mounted = host;
+    await tick();
+    expect(document.querySelector('[data-zoom-snap-feedback]')).toBeNull();
+
+    host.setZoom(1, 1, 'unit');
+    await tick();
+    const firstFeedback = document.querySelector('[data-zoom-snap-feedback]');
+    expect(firstFeedback).not.toBeNull();
+
+    host.setZoom(1, 1, 'unit');
+    await tick();
+    expect(document.querySelector('[data-zoom-snap-feedback]')).toBe(firstFeedback);
+
+    host.setZoom(0.95, 0.95, null);
+    await tick();
+    host.setZoom(1, 1, 'unit');
+    await tick();
+    expect(document.querySelector('[data-zoom-snap-feedback]')).not.toBe(firstFeedback);
+  });
+
+  it('uses the applied bound landmark for snap feedback', async () => {
+    const host = mount(ZoomOverlayTestRoot, { target: document.body, props: { initialZoom: 1, initialLandmark: 'unit' } });
+    mounted = host;
+    await tick();
+    expect(document.querySelector('[data-zoom-snap-feedback]')).toBeNull();
+
+    host.setZoom(2, 2, 'maximum');
+    await tick();
+    expect(document.querySelector<HTMLElement>('[data-zoom-snap-feedback]')?.dataset.zoomSnapLandmark).toBe('maximum');
+  });
+
+  it('restarts only the hidden overlay and boundary label for an unchanged minimum attempt', async () => {
+    vi.useFakeTimers();
+    const host = mount(ZoomOverlayTestRoot, {
+      target: document.body,
+      props: { initialZoom: 0.2, initialIndicatorZoom: 0.2, initialLandmark: 'minimum' },
+    });
+    mounted = host;
+    await tick();
+    const overlay = document.querySelector<HTMLElement>('[role="group"][aria-label="페이지 배율"]');
+    await expireTransientVisibility();
+    expect(overlay?.style.opacity).toBe('0');
+
+    host.requestBoundaryAttempt('minimum');
+    await tick();
+
+    expect(overlay?.style.opacity).toBe('1');
+    expect(document.querySelector('[aria-live="polite"]')?.textContent).toContain('최소');
+    expect(document.querySelector('[data-zoom-snap-feedback]')).toBeNull();
+  });
+
+  it('announces overshoot once and restarts its label when it returns to range', async () => {
+    vi.useFakeTimers();
+    const host = mount(ZoomOverlayTestRoot, { target: document.body });
+    mounted = host;
+    await tick();
+
+    host.setZoom(0.15, 0.2, 'minimum');
+    await tick();
+    expect(document.querySelector('[aria-live="polite"]')?.textContent).toContain('최소');
+    expect(document.querySelector('[data-zoom-snap-feedback]')).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(2900);
+    host.setZoom(0.14, 0.2, 'minimum');
+    await vi.advanceTimersByTimeAsync(220);
+    expect(document.querySelector<HTMLElement>('[role="group"][aria-label="페이지 배율"]')?.style.opacity).toBe('1');
+    expect(document.querySelector('[aria-live="polite"]')?.textContent).toContain('최소');
+
+    host.setZoom(0.2, 0.2, 'minimum');
+    await tick();
+    const recoveryFeedback = document.querySelector('[data-zoom-snap-feedback]');
+    expect(recoveryFeedback).not.toBeNull();
+    expect(document.querySelector('[aria-live="polite"]')?.textContent).toContain('최소');
+
+    host.setZoom(0.15, 0.2, 'minimum');
+    await tick();
+    expect(document.querySelector('[aria-live="polite"]')?.textContent).toContain('최소');
+    expect(document.querySelector('[data-zoom-snap-feedback]')).toBe(recoveryFeedback);
+  });
+
+  it('keeps the recovered boundary landmark visible for one second', async () => {
+    vi.useFakeTimers();
+    const host = mount(ZoomOverlayTestRoot, { target: document.body });
+    mounted = host;
+    await tick();
+
+    host.setZoom(0.15, 0.2, 'minimum');
+    await vi.advanceTimersByTimeAsync(500);
+    host.setZoom(0.2, 0.2, 'minimum');
+    await tick();
+
+    const displayedValue = () => document.querySelector<HTMLElement>('[aria-live="polite"]');
+    expect(displayedValue()?.textContent).toContain('최소');
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(displayedValue()?.dataset.zoomValueKind).toBe('landmark');
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(displayedValue()?.dataset.zoomValueKind).toBe('percentage');
+  });
+
+  it('prioritizes direct side-to-side overshoot over landmark snap feedback', async () => {
+    const host = mount(ZoomOverlayTestRoot, { target: document.body });
+    mounted = host;
+    await tick();
+
+    host.setZoom(0.15, 0.2, 'minimum');
+    await tick();
+    host.setZoom(2.1, 2, 'maximum');
+    await tick();
+
+    expect(document.querySelector('[aria-live="polite"]')?.textContent).toContain('최대');
+    expect(document.querySelector('[data-zoom-snap-feedback]')).toBeNull();
+  });
+
+  it('uses recovery precedence when overshoot returns directly to another landmark', async () => {
+    vi.useFakeTimers();
+    const host = mount(ZoomOverlayTestRoot, { target: document.body });
+    mounted = host;
+    await tick();
+
+    host.setZoom(0.15, 0.2, 'minimum');
+    await vi.advanceTimersByTimeAsync(1000);
+    host.setZoom(1, 1, 'unit');
+    await tick();
+
+    const feedback = document.querySelector<HTMLElement>('[data-zoom-snap-feedback]');
+    expect(feedback?.dataset.zoomSnapLandmark).toBe('minimum');
+    expect(document.querySelector('[aria-live="polite"]')?.textContent).toContain('최소');
+  });
+});

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
@@ -18,11 +18,12 @@
   import SelectionHandles from './components/SelectionHandles.svelte';
   import EditorZoom from './components/ui/EditorZoom.svelte';
   import ViewportOverlay from './components/ViewportOverlay.svelte';
-  import { PAGE_GAP } from './constants';
+  import { CONTINUOUS_MIN_WIDTH, PAGE_GAP } from './constants';
   import { setupEditorContext } from './editor.svelte';
   import { setupEditorPublication } from './editor-publication.svelte';
   import { EditorSurfaceHost } from './editor-surface-host.svelte';
   import { setupEditorScroll } from './scroll.svelte';
+  import { resolveContinuousLayoutViewportWidth } from './zoom';
   import type { MouseEventHandler } from 'svelte/elements';
   import type { Editor } from './editor.svelte';
   import type { DocumentZoomLayout } from './zoom';
@@ -37,6 +38,7 @@
     useWindowScroll?: boolean;
     userId: string;
     withZoom?: boolean;
+    withViewportLifecycle?: boolean;
     headerHeight?: number;
     contentInsetLeft?: number;
     contentInsetRight?: number;
@@ -52,6 +54,7 @@
     useWindowScroll = false,
     userId,
     withZoom = false,
+    withViewportLifecycle = false,
     headerHeight = 0,
     contentInsetLeft = 0,
     contentInsetRight = 0,
@@ -74,6 +77,8 @@
   let viewportWidth = $state(360);
   let ready = false;
   let publishedReady = false;
+  let viewportInitialized = false;
+  let lastViewportWidth: number | undefined;
   const isPaginated = $derived(editor.rootAttrs?.layout_mode.type === 'paginated');
   const pageWidth = $derived(editor.pageSizes[0]?.width ?? 0);
   const zoomLayout: DocumentZoomLayout | null = $derived.by(() => {
@@ -103,6 +108,27 @@
       surfaceHost = undefined;
       host.destroy();
     };
+  });
+
+  $effect(() => {
+    if (!withViewportLifecycle) return;
+    const width = viewportWidth;
+    const renderZoom = editor.renderZoom;
+    const isContinuous = editor.rootAttrs?.layout_mode.type === 'continuous';
+    const physicalWidth = isContinuous ? Math.max(CONTINUOUS_MIN_WIDTH, width) : width;
+    const effectiveWidth = isContinuous
+      ? resolveContinuousLayoutViewportWidth({ viewportWidth: physicalWidth, committedZoom: renderZoom })
+      : physicalWidth;
+    untrack(() => {
+      const physicalViewportChanged = viewportInitialized && lastViewportWidth !== width;
+      lastViewportWidth = width;
+      if (viewportInitialized) editor.resizeViewport(effectiveWidth, 180, 1);
+      else {
+        viewportInitialized = true;
+        editor.resizeViewportNow(effectiveWidth, 180, 1);
+      }
+      if (physicalViewportChanged) ctx.scroll?.reconcileViewportResize();
+    });
   });
 
   $effect(() => {
@@ -189,13 +215,7 @@
     <div style:height={`${headerHeight}px`} data-editor-test-header></div>
   {/if}
   {#if withZoom}
-    <EditorZoom
-      active
-      attachViewportAnchor={(point) => ctx.scroll?.attachViewportAnchorAt(point)}
-      {editor}
-      layout={zoomLayout}
-      {viewportWidth}
-    >
+    <EditorZoom active {editor} editorViewSurface={scrollRoot} layout={zoomLayout} scroll={ctx.scroll} {viewportWidth}>
       {@render editorContent()}
     </EditorZoom>
   {:else}

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -271,6 +271,7 @@ async function mountEditor(
     readOnly?: boolean;
     typewriterEnabled?: boolean;
     withZoom?: boolean;
+    withViewportLifecycle?: boolean;
     displayZoom?: number;
     contentInsetLeft?: number;
     contentInsetRight?: number;
@@ -293,6 +294,7 @@ async function mountEditor(
       typewriterEnabled: options.typewriterEnabled,
       userId: `frame-sync-${crypto.randomUUID()}`,
       withZoom: options.withZoom,
+      withViewportLifecycle: options.withViewportLifecycle,
       contentInsetLeft: options.contentInsetLeft,
       contentInsetRight: options.contentInsetRight,
     },
@@ -1348,6 +1350,75 @@ describe('web editor frame synchronization', () => {
     expect(attachSurfaceSpy.mock.calls.filter(([page]) => page === 0).length).toBeGreaterThan(0);
     expect(editor.published?.frames.get(0)?.canvas.isConnected).toBe(true);
     expectActualCanvas(editor, 0);
+  });
+
+  it('leaves keyboard focus on zoom indicator controls after they run', async () => {
+    const { editor } = await mountEditor(doc('zoom focus'), { withZoom: true });
+    editor.focus();
+    expect(document.activeElement).toBe(editor.inputEl);
+
+    const zoomIn = document.querySelector<HTMLButtonElement>('[aria-label="페이지 확대"]');
+    expect(zoomIn).not.toBeNull();
+    zoomIn?.focus();
+    expect(document.activeElement).toBe(zoomIn);
+    zoomIn?.click();
+    await expect.poll(() => editor.displayZoom).toBeGreaterThan(1);
+    expect(document.activeElement).toBe(zoomIn);
+
+    const value = document.querySelector<HTMLButtonElement>('[aria-label="원본 크기로 돌아가기"]');
+    expect(value).not.toBeNull();
+    value?.focus();
+    expect(document.activeElement).toBe(value);
+    value?.click();
+    await expect.poll(() => editor.displayZoom).toBeCloseTo(1);
+    expect(document.activeElement).toBe(value);
+  });
+
+  it('preserves editor focus during mouse pointer zoom controls', async () => {
+    const { editor } = await mountEditor(doc('zoom pointer focus'), { withZoom: true });
+    editor.focus();
+    expect(document.activeElement).toBe(editor.inputEl);
+
+    const value = document.querySelector<HTMLButtonElement>('[role="group"][aria-label="페이지 배율"] button:nth-of-type(2)');
+    expect(value).not.toBeNull();
+    if (!value) throw new Error('Expected the zoom indicator value button');
+    const previousZoom = editor.displayZoom;
+    const pointerDown = new PointerEvent('pointerdown', { bubbles: true, cancelable: true, pointerType: 'mouse' });
+    value.dispatchEvent(pointerDown);
+
+    expect(pointerDown.defaultPrevented).toBe(true);
+    value.click();
+    await expect.poll(() => editor.displayZoom).not.toBeCloseTo(previousZoom);
+    expect(document.activeElement).toBe(editor.inputEl);
+  });
+
+  it('keeps a manually scrolled viewport fixed across settled unit and fit toggles', async () => {
+    const { editor, scrollRoot } = await mountEditor(continuousDoc('viewport anchor reflow '.repeat(300)), {
+      withZoom: true,
+      withViewportLifecycle: true,
+    });
+    await waitForPresentation(editor);
+    editor.focus();
+    scrollRoot.scrollTop = scrollRoot.scrollHeight / 2;
+    scrollRoot.dispatchEvent(new Event('scroll'));
+    await nextAnimationFrame();
+
+    const value = document.querySelector<HTMLButtonElement>('[role="group"][aria-label="페이지 배율"] button:nth-of-type(2)');
+    expect(value).not.toBeNull();
+    if (!value) throw new Error('Expected the zoom indicator value button');
+    const initialScrollTop = scrollRoot.scrollTop;
+
+    for (let click = 0; click < 2; click += 1) {
+      value.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, pointerType: 'mouse' }));
+      value.click();
+      await expect.poll(() => Math.abs(editor.renderZoom - editor.displayZoom)).toBeLessThan(0.005);
+      await waitForPresentation(editor);
+      await nextAnimationFrame();
+    }
+
+    expect(editor.displayZoom).toBeCloseTo(1);
+    expect(scrollRoot.scrollTop).toBeCloseTo(initialScrollTop, 0);
+    expect(document.activeElement).toBe(editor.inputEl);
   });
 
   it('stops zoom on the first pinch pointer release and keeps the survivor zoom-owned until all-up', async () => {

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -819,6 +819,39 @@ describe('EditorScrollScope', () => {
     expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 300, top: 220, behavior: 'instant' });
   });
 
+  it('lets direct zoom replace a pending command viewport anchor', () => {
+    const snapshot = selectionSnapshot(false, {
+      page_idx: 0,
+      rect: { x: 0, y: 0, width: 1, height: 1 },
+    });
+    const { editor, scope } = setup(snapshot);
+    const commandAnchor = { type: 'node' as const, node: 'command', offset_x: 0, offset_y: 0 };
+    const directAnchor = { type: 'node' as const, node: 'direct', offset_x: 0, offset_y: 0 };
+    editor.captureViewportAnchorAt = vi.fn((_revision, point) => ({
+      identity: point.x === 100 ? commandAnchor : directAnchor,
+      geometry: {
+        point: { page_idx: 0, x: point.x, y: point.y },
+        rect: undefined,
+      },
+    }));
+    editor.resolveViewportAnchor = vi.fn((_revision, identity) => ({
+      type: 'resolved' as const,
+      geometry: {
+        point: {
+          page_idx: 0,
+          x: identity === commandAnchor ? 100 : 400,
+          y: identity === commandAnchor ? 100 : 300,
+        },
+        rect: undefined,
+      },
+    }));
+
+    scope.attachViewportAnchorAt({ page: 0, x: 100, y: 100 }, { left: 80, top: 80 });
+    scope.beginViewportZoomAt({ page: 0, x: 400, y: 300 });
+
+    expect(scope.resolveViewportZoomAnchor()).toMatchObject({ x: 400, y: 300 });
+  });
+
   it('measures the document track once without reading every page during direct scroll reconciliation', () => {
     const snapshot = trackedSnapshot('unused', {
       page_idx: 0,
@@ -1001,9 +1034,10 @@ describe('EditorScrollScope', () => {
 
     expect(scope.prepareViewportAnchorPublication(initial)).toEqual({
       type: 'ready',
-      geometry: { pointX: 0, pointY: 200 },
+      geometry: { pointX: 0, pointY: 200, rect: undefined },
       targetScrollLeft: null,
       targetScrollTop: 0,
+      attachmentAchieved: true,
     });
   });
 
@@ -1043,9 +1077,10 @@ describe('EditorScrollScope', () => {
 
     expect(scope.prepareViewportAnchorPublication(candidate)).toEqual({
       type: 'ready',
-      geometry: { pointX: 0, pointY: 500 },
+      geometry: { pointX: 0, pointY: 500, rect: undefined },
       targetScrollLeft: null,
       targetScrollTop: 0,
+      attachmentAchieved: true,
     });
     expect(scrollTo).not.toHaveBeenCalled();
   });
@@ -1102,6 +1137,7 @@ describe('EditorScrollScope', () => {
       geometry: null,
       targetScrollLeft: null,
       targetScrollTop: null,
+      attachmentAchieved: false,
     });
   });
 
@@ -1121,7 +1157,13 @@ describe('EditorScrollScope', () => {
 
     const publication = scope.prepareViewportAnchorPublication(candidate);
 
-    expect(publication).toEqual({ type: 'ready', geometry: null, targetScrollLeft: null, targetScrollTop: 0 });
+    expect(publication).toEqual({
+      type: 'ready',
+      geometry: null,
+      targetScrollLeft: null,
+      targetScrollTop: 0,
+      attachmentAchieved: false,
+    });
     scope.applyViewportAnchorPublication(publication);
     expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 0, top: 0, behavior: 'instant' });
     expect(getScrollTop()).toBe(0);
@@ -1146,6 +1188,7 @@ describe('EditorScrollScope', () => {
       geometry: null,
       targetScrollLeft: null,
       targetScrollTop: null,
+      attachmentAchieved: false,
     });
   });
 
@@ -1167,6 +1210,7 @@ describe('EditorScrollScope', () => {
       geometry: { pointX: 0, pointY: 320 },
       targetScrollLeft: null,
       targetScrollTop: 220,
+      attachmentAchieved: true,
     });
     expect(scope.applyPending(request, snapshot, { type: 'scroll_to', y: 580 })).toBe(true);
 
@@ -1225,6 +1269,7 @@ describe('EditorScrollScope', () => {
       geometry: { pointX: 0, pointY: 320 },
       targetScrollLeft: null,
       targetScrollTop: 220,
+      attachmentAchieved: true,
     });
     expect(scope.applyPending(request, snapshot, { type: 'no_scroll' })).toBe(true);
 

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -13,12 +13,17 @@ import {
 import { SmoothScrollMotion } from './smooth-scroll-motion';
 import { EditorViewportAnchorState, resolveViewportAnchorGeometry, viewportCenterAnchorPoint } from './viewport-anchor';
 import { resolveContinuousViewPadding } from './zoom';
-import type { PageRect, ViewportAnchorResolution } from '@typie/editor-ffi/browser';
+import type { PageRect, ViewportAnchor, ViewportAnchorResolution } from '@typie/editor-ffi/browser';
 import type { Editor, EditorContext, EditorSnapshot } from './editor.svelte';
 import type { EditorRequest } from './editor-update';
 import type { VerticalSpan } from './required-surface-pages';
 import type { EditorVisibleArea, RevealTargetSpan, ScrollContainerMetrics } from './scroll';
-import type { EditorViewportAnchorGeometry, EditorViewportAnchorLayout, EditorViewportAnchorRevealOrigin } from './viewport-anchor';
+import type {
+  EditorViewportAnchorGeometry,
+  EditorViewportAnchorLayout,
+  EditorViewportAnchorRevealOrigin,
+  EditorViewportScrollPosition,
+} from './viewport-anchor';
 
 export type EditorScrollRevealPolicy = 'cursor_guard' | 'pointer_cursor_guard' | 'typewriter' | 'reveal';
 type ResolvedEditorScrollRevealPolicy = Exclude<EditorScrollRevealPolicy, 'pointer_cursor_guard'>;
@@ -43,6 +48,7 @@ export type EditorViewportAnchorPublication =
       geometry: EditorViewportAnchorGeometry | null;
       targetScrollLeft: number | null;
       targetScrollTop: number | null;
+      attachmentAchieved: boolean;
     }
   | { type: 'unavailable' };
 
@@ -298,7 +304,7 @@ export class EditorScrollScope {
 
   prepareViewportAnchorPublication(snapshot: EditorSnapshot): EditorViewportAnchorPublication {
     const viewport = this.#editor.scrollViewport;
-    if (!viewport) return { type: 'ready', geometry: null, targetScrollLeft: null, targetScrollTop: null };
+    if (!viewport) return { type: 'ready', geometry: null, targetScrollLeft: null, targetScrollTop: null, attachmentAchieved: false };
     const metrics = this.#viewportMetrics(snapshot, true);
     if (!metrics) return { type: 'unavailable' };
     const selectionCapture = this.#editor.captureSelectionViewportAnchor(snapshot.revision);
@@ -327,6 +333,7 @@ export class EditorScrollScope {
       geometry: null,
       targetScrollLeft: clampedScrollLeft === metrics.scrollLeft ? null : clampedScrollLeft,
       targetScrollTop: clampedScrollTop === metrics.scrollTop ? null : clampedScrollTop,
+      attachmentAchieved: false,
     });
 
     const resolution = this.#resolveCandidateViewportAnchor(snapshot);
@@ -365,11 +372,13 @@ export class EditorScrollScope {
       metrics.scrollLeft,
       metrics.maximumScrollLeft,
     );
+    if (!targetScroll.attachmentAchieved) this.#viewportAnchor.deferAttachment();
     return {
       type: 'ready',
       geometry,
-      targetScrollLeft: targetScroll.left === metrics.scrollLeft ? null : targetScroll.left,
-      targetScrollTop: targetScroll.top,
+      targetScrollLeft: targetScroll.scroll.left === metrics.scrollLeft ? null : targetScroll.scroll.left,
+      targetScrollTop: targetScroll.scroll.top,
+      attachmentAchieved: targetScroll.attachmentAchieved,
     };
   }
 
@@ -377,7 +386,7 @@ export class EditorScrollScope {
     if (publication.type !== 'ready') return;
     const viewport = this.#editor.scrollViewport;
     if (publication.targetScrollLeft === null && publication.targetScrollTop === null) {
-      if (viewport && publication.geometry) {
+      if (viewport && publication.geometry && publication.attachmentAchieved) {
         this.#viewportAnchor.acceptGeometry(publication.geometry, {
           left: viewport.getScrollLeft(),
           top: viewport.getScrollTop(),
@@ -409,10 +418,11 @@ export class EditorScrollScope {
       this.#ensureViewportAnchor();
       return;
     }
-    this.#viewportAnchor.acceptGeometry(publication.geometry, {
-      left: viewport.getScrollLeft(),
-      top: viewport.getScrollTop(),
-    });
+    const actualScroll = { left: viewport.getScrollLeft(), top: viewport.getScrollTop() };
+    const reachedPublicationTarget = Math.abs(actualScroll.left - targetLeft) <= 1 && Math.abs(actualScroll.top - targetTop) <= 1;
+    if (reachedPublicationTarget && publication.attachmentAchieved) {
+      this.#viewportAnchor.acceptGeometry(publication.geometry, actualScroll);
+    }
   }
 
   observeViewportScroll(): void {
@@ -617,7 +627,7 @@ export class EditorScrollScope {
     this.#editor.requestPublication();
   }
 
-  attachViewportAnchorAt(point: { page: number; x: number; y: number }): void {
+  attachViewportAnchorAt(point: { page: number; x: number; y: number }, desiredScroll?: EditorViewportScrollPosition): void {
     const snapshot = this.#editor.published?.snapshot;
     const metrics = this.#viewportMetrics(snapshot);
     if (!snapshot || !metrics) return;
@@ -629,12 +639,57 @@ export class EditorScrollScope {
     if (!capture) return;
     const geometry = resolveViewportAnchorGeometry(capture.geometry, metrics.layout);
     if (!geometry) return;
-    this.#viewportAnchor.attachViewport(capture.identity, geometry, {
-      left: metrics.scrollLeft,
-      top: metrics.scrollTop,
-    });
+    const actualScroll = { left: metrics.scrollLeft, top: metrics.scrollTop };
+    const attachmentScroll = desiredScroll ?? actualScroll;
+    const attachmentPending =
+      Math.abs(attachmentScroll.left - actualScroll.left) > 1 || Math.abs(attachmentScroll.top - actualScroll.top) > 1;
+    this.#viewportAnchor.attachViewport(capture.identity, geometry, attachmentScroll, attachmentPending);
     this.#expectedScrollLeft = metrics.scrollLeft;
     this.#expectedScrollTop = metrics.scrollTop;
+  }
+
+  beginViewportZoomAt(point: { page: number; x: number; y: number }): void {
+    this.attachViewportAnchorAt(point);
+  }
+
+  updateViewportZoomAttachment(desiredScroll: EditorViewportScrollPosition): void {
+    const attachment = this.#viewportAnchor.viewportAttachment;
+    const snapshot = this.#editor.published?.snapshot;
+    const metrics = this.#viewportMetrics(snapshot);
+    if (!attachment || !snapshot || !metrics) return;
+    const resolution = this.#editor.resolveViewportAnchor(snapshot.revision, attachment.identity);
+    if (resolution.type !== 'resolved') return;
+    const geometry = resolveViewportAnchorGeometry(resolution.geometry, metrics.layout);
+    if (!geometry) return;
+    const actualScroll = { left: metrics.scrollLeft, top: metrics.scrollTop };
+    const attachmentPending = Math.abs(desiredScroll.left - actualScroll.left) > 1 || Math.abs(desiredScroll.top - actualScroll.top) > 1;
+    this.#viewportAnchor.reattachViewport(geometry, desiredScroll, attachmentPending);
+    this.#expectedScrollLeft = metrics.scrollLeft;
+    this.#expectedScrollTop = metrics.scrollTop;
+  }
+
+  resolvePendingViewportZoomAnchor(): { page: number; x: number; y: number; focalX: number; focalY: number } | null {
+    return this.#resolveViewportZoomAnchor(this.#viewportAnchor.pendingViewportAttachment);
+  }
+
+  resolveViewportZoomAnchor(): { page: number; x: number; y: number; focalX: number; focalY: number } | null {
+    return this.#resolveViewportZoomAnchor(this.#viewportAnchor.viewportAttachment);
+  }
+
+  #resolveViewportZoomAnchor(
+    attachment: { identity: ViewportAnchor; focalX: number; focalY: number } | null,
+  ): { page: number; x: number; y: number; focalX: number; focalY: number } | null {
+    const snapshot = this.#editor.published?.snapshot;
+    if (!attachment || !snapshot) return null;
+    const resolution = this.#editor.resolveViewportAnchor(snapshot.revision, attachment.identity);
+    if (resolution.type !== 'resolved') return null;
+    return {
+      page: resolution.geometry.point.page_idx,
+      x: resolution.geometry.point.x,
+      y: resolution.geometry.point.y,
+      focalX: attachment.focalX,
+      focalY: attachment.focalY,
+    };
   }
 
   scrollIntoView(options: EditorScrollIntoViewOptions, admission?: EditorRequest): Promise<void> | undefined {

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
@@ -58,8 +58,8 @@ describe('EditorViewportAnchorState', () => {
     state.attach(identity, { pointX: 100, pointY: 200 }, { left: 20, top: 100 });
 
     expect(state.publicationScroll({ pointX: 260, pointY: 320 }, { left: 20, top: 100 }, { left: 500, top: 500 })).toEqual({
-      left: 180,
-      top: 220,
+      scroll: { left: 180, top: 220 },
+      attachmentAchieved: true,
     });
   });
 
@@ -68,8 +68,8 @@ describe('EditorViewportAnchorState', () => {
     state.attach(identity, { pointX: 0, pointY: 200 }, { left: 0, top: 100 });
 
     expect(state.publicationScroll({ pointX: 0, pointY: 200 }, { left: 0, top: 100 }, { left: 0, top: 500 })).toEqual({
-      left: 0,
-      top: 100,
+      scroll: { left: 0, top: 100 },
+      attachmentAchieved: true,
     });
   });
 
@@ -99,17 +99,34 @@ describe('EditorViewportAnchorState', () => {
     expect(state.resizeScroll(geometry, 100, 300, 1000, { topInset: 0, bottomInset: 100 })).toBe(130);
   });
 
-  it('records the achieved attachment after publication clamping', () => {
+  it('preserves the desired attachment until publication bounds can reach it', () => {
     const state = new EditorViewportAnchorState();
     state.attach(identity, { pointX: 200, pointY: 200 }, { left: 100, top: 100 });
     const candidate = { pointX: 800, pointY: 800 };
 
-    const clamped = state.publicationScroll(candidate, { left: 100, top: 100 }, { left: 500, top: 500 });
-    state.acceptGeometry(candidate, clamped);
+    const constrained = state.publicationScroll(candidate, { left: 100, top: 100 }, { left: 500, top: 500 });
 
-    expect(clamped).toEqual({ left: 500, top: 500 });
-    expect(state.pointAttachmentX).toBe(300);
-    expect(state.pointAttachmentY).toBe(300);
+    expect(constrained).toEqual({ scroll: { left: 500, top: 500 }, attachmentAchieved: false });
+    expect(state.publicationScroll(candidate, constrained.scroll, { left: 1000, top: 1000 })).toEqual({
+      scroll: { left: 700, top: 700 },
+      attachmentAchieved: true,
+    });
+    expect(state.pointAttachmentX).toBe(100);
+    expect(state.pointAttachmentY).toBe(100);
+  });
+
+  it('updates a zoom attachment without replacing its stable viewport identity', () => {
+    const state = new EditorViewportAnchorState();
+    state.attachViewport(viewportIdentity, { pointX: 200, pointY: 300 }, { left: 100, top: 200 });
+
+    expect(state.reattachViewport({ pointX: 320, pointY: 440 }, { left: 220, top: 340 })).toBe(true);
+
+    expect(state.identity).toBe(viewportIdentity);
+    expect(state.viewportAttachment).toEqual({ identity: viewportIdentity, focalX: 100, focalY: 100 });
+    expect(state.publicationScroll({ pointX: 400, pointY: 500 }, { left: 220, top: 340 }, { left: 500, top: 500 })).toEqual({
+      scroll: { left: 300, top: 400 },
+      attachmentAchieved: true,
+    });
   });
 
   it('finishes a provisional selection reveal where the measured rect would have revealed initially', () => {
@@ -118,7 +135,10 @@ describe('EditorViewportAnchorState', () => {
     const measured = { pointX: 0, pointY: 600, rect: { top: 500, bottom: 700 } };
     state.attachSelection(identity, provisional, { left: 0, top: 161 });
 
-    expect(state.publicationRevealScroll(measured, 161, 400, 1000, visibleArea)).toEqual({ left: 0, top: 360 });
+    expect(state.publicationRevealScroll(measured, 161, 400, 1000, visibleArea)).toEqual({
+      scroll: { left: 0, top: 360 },
+      attachmentAchieved: true,
+    });
   });
 
   it('reactivates a preferred selection rect after direct scrolling returns it inside the cursor guard', () => {
@@ -139,7 +159,7 @@ describe('EditorViewportAnchorState', () => {
 
     expect(state.tryReactivatePreferredSelection(selectionGeometry, { left: 120, top: 100 }, 300, visibleArea)).toBe(true);
     expect(state.pointAttachmentX).toBe(80);
-    expect(state.publicationScroll(selectionGeometry, { left: 120, top: 100 }, { left: 500, top: 500 }).left).toBe(120);
+    expect(state.publicationScroll(selectionGeometry, { left: 120, top: 100 }, { left: 500, top: 500 }).scroll.left).toBe(120);
   });
 
   it('does not reactivate a preferred selection without a compact rect inside the guard', () => {

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.ts
@@ -17,8 +17,10 @@ export type EditorViewportAnchorGeometry = {
 
 type ActiveViewportAnchor = {
   identity: ViewportAnchor;
+  source: 'selection' | 'viewport';
   pointAttachmentX: number;
   pointAttachmentY: number;
+  attachmentPending: boolean;
   rect?: { top: number; bottom: number };
   revealOrigin?: EditorViewportAnchorRevealOrigin;
 };
@@ -36,6 +38,11 @@ export type EditorViewportAnchorLayout = {
 
 export type EditorViewportScrollPosition = { left: number; top: number };
 
+export type EditorViewportAnchorScroll = {
+  scroll: EditorViewportScrollPosition;
+  attachmentAchieved: boolean;
+};
+
 export type EditorViewportCenterMetrics = {
   scrollLeft: number;
   scrollTop: number;
@@ -52,12 +59,16 @@ export class EditorViewportAnchorState {
     geometry: EditorViewportAnchorGeometry,
     scroll: EditorViewportScrollPosition,
     revealOrigin?: EditorViewportAnchorRevealOrigin,
+    source: ActiveViewportAnchor['source'] = 'viewport',
+    attachmentPending = false,
   ): void {
     if (![geometry.pointX, geometry.pointY, scroll.left, scroll.top].every(Number.isFinite)) return;
     this.#active = {
       identity,
+      source,
       pointAttachmentX: geometry.pointX - scroll.left,
       pointAttachmentY: geometry.pointY - scroll.top,
+      attachmentPending,
       rect: geometry.rect,
       revealOrigin,
     };
@@ -77,6 +88,17 @@ export class EditorViewportAnchorState {
 
   get preferredSelectionIdentity(): ViewportAnchor | null {
     return this.#preferredSelection;
+  }
+
+  get pendingViewportAttachment(): { identity: ViewportAnchor; focalX: number; focalY: number } | null {
+    const attachment = this.viewportAttachment;
+    return this.#active?.attachmentPending ? attachment : null;
+  }
+
+  get viewportAttachment(): { identity: ViewportAnchor; focalX: number; focalY: number } | null {
+    const active = this.#active;
+    if (!active || active.source !== 'viewport') return null;
+    return { identity: active.identity, focalX: active.pointAttachmentX, focalY: active.pointAttachmentY };
   }
 
   clear(): void {
@@ -99,11 +121,23 @@ export class EditorViewportAnchorState {
     revealOrigin?: EditorViewportAnchorRevealOrigin,
   ): void {
     this.#preferredSelection = identity;
-    this.#attachActive(identity, geometry, scroll, revealOrigin);
+    this.#attachActive(identity, geometry, scroll, revealOrigin, 'selection');
   }
 
-  attachViewport(identity: ViewportAnchor, geometry: EditorViewportAnchorGeometry, scroll: EditorViewportScrollPosition): void {
-    this.#attachActive(identity, geometry, scroll);
+  attachViewport(
+    identity: ViewportAnchor,
+    geometry: EditorViewportAnchorGeometry,
+    scroll: EditorViewportScrollPosition,
+    attachmentPending = false,
+  ): void {
+    this.#attachActive(identity, geometry, scroll, undefined, 'viewport', attachmentPending);
+  }
+
+  reattachViewport(geometry: EditorViewportAnchorGeometry, scroll: EditorViewportScrollPosition, attachmentPending = false): boolean {
+    const active = this.#active;
+    if (!active || active.source !== 'viewport') return false;
+    this.#attachActive(active.identity, geometry, scroll, undefined, 'viewport', attachmentPending);
+    return true;
   }
 
   adoptSelection(
@@ -118,7 +152,7 @@ export class EditorViewportAnchorState {
     const activate =
       !preserveActiveAnchor && (this.#active !== null || this.canRetainAfterDirectScroll(geometry, scroll.top, clientHeight, visibleArea));
     this.#preferredSelection = identity;
-    if (activate) this.#attachActive(identity, geometry, scroll);
+    if (activate) this.#attachActive(identity, geometry, scroll, undefined, 'selection');
   }
 
   clearPreferredSelection(): void {
@@ -146,7 +180,7 @@ export class EditorViewportAnchorState {
     ) {
       return false;
     }
-    this.#attachActive(identity, geometry, scroll);
+    this.#attachActive(identity, geometry, scroll, undefined, 'selection');
     return true;
   }
 
@@ -154,7 +188,7 @@ export class EditorViewportAnchorState {
     geometry: EditorViewportAnchorGeometry,
     currentScroll: EditorViewportScrollPosition,
     maximumScroll: EditorViewportScrollPosition,
-  ): EditorViewportScrollPosition {
+  ): EditorViewportAnchorScroll {
     const active = this.#active;
     if (
       !active ||
@@ -162,11 +196,19 @@ export class EditorViewportAnchorState {
       maximumScroll.left < 0 ||
       maximumScroll.top < 0
     ) {
-      return currentScroll;
+      return { scroll: currentScroll, attachmentAchieved: false };
     }
+    const desiredScroll = {
+      left: geometry.pointX - active.pointAttachmentX,
+      top: geometry.pointY - active.pointAttachmentY,
+    };
+    const scroll = {
+      left: clamp(desiredScroll.left, 0, maximumScroll.left),
+      top: clamp(desiredScroll.top, 0, maximumScroll.top),
+    };
     return {
-      left: clamp(geometry.pointX - active.pointAttachmentX, 0, maximumScroll.left),
-      top: clamp(geometry.pointY - active.pointAttachmentY, 0, maximumScroll.top),
+      scroll,
+      attachmentAchieved: scroll.left === desiredScroll.left && scroll.top === desiredScroll.top,
     };
   }
 
@@ -179,7 +221,7 @@ export class EditorViewportAnchorState {
     resolveReveal?: (origin: EditorViewportAnchorRevealOrigin) => number | null,
     currentScrollLeft = 0,
     maximumScrollLeft = 0,
-  ): EditorViewportScrollPosition {
+  ): EditorViewportAnchorScroll {
     const exact = this.publicationScroll(
       geometry,
       { left: currentScrollLeft, top: currentScrollTop },
@@ -189,14 +231,29 @@ export class EditorViewportAnchorState {
     const revealOrigin = this.#active?.revealOrigin;
     if (revealOrigin) {
       const reveal = resolveReveal?.(revealOrigin);
-      if (reveal !== null && reveal !== undefined) return { ...exact, top: clamp(reveal, 0, Math.max(0, scrollHeight - clientHeight)) };
+      if (reveal !== null && reveal !== undefined) {
+        return {
+          scroll: { ...exact.scroll, top: clamp(reveal, 0, Math.max(0, scrollHeight - clientHeight)) },
+          attachmentAchieved: true,
+        };
+      }
     }
-    return { ...exact, top: this.resizeScroll(geometry, exact.top, clientHeight, scrollHeight, visibleArea) };
+    return {
+      scroll: {
+        ...exact.scroll,
+        top: this.resizeScroll(geometry, exact.scroll.top, clientHeight, scrollHeight, visibleArea),
+      },
+      attachmentAchieved: true,
+    };
   }
 
   acceptGeometry(geometry: EditorViewportAnchorGeometry, scroll: EditorViewportScrollPosition): void {
     const active = this.#active;
-    if (active) this.#attachActive(active.identity, geometry, scroll, active.revealOrigin);
+    if (active) this.#attachActive(active.identity, geometry, scroll, active.revealOrigin, active.source);
+  }
+
+  deferAttachment(): void {
+    if (this.#active) this.#active = { ...this.#active, attachmentPending: true };
   }
 
   finishRevealConvergence(): void {

--- a/apps/website/src/lib/editor-ffi/zoom.test.ts
+++ b/apps/website/src/lib/editor-ffi/zoom.test.ts
@@ -7,6 +7,7 @@ import {
   resolveContinuousViewPadding,
   resolveDirectDocumentZoom,
   resolveDocumentZoomIndicator,
+  resolveDocumentZoomLandmark,
 } from './zoom';
 
 describe('continuous document zoom policy', () => {
@@ -47,5 +48,38 @@ describe('continuous document zoom policy', () => {
   it('reports only the normal range to the zoom indicator', () => {
     expect(resolveDocumentZoomIndicator(2.08, layout)).toBe(2);
     expect(resolveDocumentZoomIndicator(0.1, layout)).toBe(computeDocumentZoomBounds(layout).min);
+  });
+});
+
+describe('document zoom landmarks', () => {
+  const layout = { type: 'paginated', pageWidth: 1000 } as const;
+
+  it.each([
+    [0.1, 500, 'minimum'],
+    [0.5, 500, 'fit-width'],
+    [0.75, 500, null],
+    [1, 500, 'unit'],
+    [2, 500, 'maximum'],
+  ] as const)('resolves zoom %s in viewport %s as %s', (zoom, viewportWidth, expected) => {
+    expect(resolveDocumentZoomLandmark({ zoom, layout, viewportWidth })).toBe(expected);
+  });
+
+  it('prefers unit over fit-width and fit-width over a bound', () => {
+    expect(resolveDocumentZoomLandmark({ zoom: 1, layout, viewportWidth: 1000 })).toBe('unit');
+    expect(resolveDocumentZoomLandmark({ zoom: 0.1, layout, viewportWidth: 100 })).toBe('fit-width');
+  });
+
+  it('does not call a clamped fit-width target a fit landmark', () => {
+    expect(resolveDocumentZoomLandmark({ zoom: 0.1, layout, viewportWidth: 50 })).toBe('minimum');
+    expect(resolveDocumentZoomLandmark({ zoom: 2, layout, viewportWidth: 2500 })).toBe('maximum');
+  });
+
+  it.each([
+    [NaN, 500, layout],
+    [1, 0, layout],
+    [1, NaN, layout],
+    [1, 500, { type: 'paginated', pageWidth: NaN } as const],
+  ])('does not name invalid zoom or layout input', (zoom, viewportWidth, invalidLayout) => {
+    expect(resolveDocumentZoomLandmark({ zoom, layout: invalidLayout, viewportWidth })).toBeNull();
   });
 });

--- a/apps/website/src/lib/editor-ffi/zoom.ts
+++ b/apps/website/src/lib/editor-ffi/zoom.ts
@@ -11,6 +11,7 @@ export const RENDER_ZOOM_MIN_COMMIT_INTERVAL_MS = 160;
 export const RENDER_ZOOM_MAX_COMMIT_DELAY_MS = 300;
 export const RENDER_ZOOM_SCALE_RATIO_THRESHOLD = 1.18;
 export const ZOOM_EPSILON = 0.0001;
+const DISCRETE_ZOOM_STEP = 0.1;
 
 export type ZoomBounds = {
   min: number;
@@ -18,6 +19,8 @@ export type ZoomBounds = {
 };
 
 export type DocumentZoomLayout = { type: 'continuous'; maxWidth: number } | { type: 'paginated'; pageWidth: number };
+
+export type DocumentZoomLandmark = 'minimum' | 'fit-width' | 'unit' | 'maximum';
 
 export function documentZoomWidth(layout: DocumentZoomLayout): number {
   const width = layout.type === 'continuous' ? layout.maxWidth + CONTINUOUS_VIEW_PADDING * 2 : layout.pageWidth;
@@ -80,6 +83,31 @@ export function clampDocumentLayoutZoom({
   return snapped ?? clamped;
 }
 
+export function resolveDocumentZoomStepTarget({
+  zoom,
+  direction,
+  layout,
+  viewportWidth,
+}: {
+  zoom: number;
+  direction: -1 | 1;
+  layout: DocumentZoomLayout;
+  viewportWidth: number;
+}): number | null {
+  const bounds = computeDocumentZoomBounds(layout);
+  const current = clampDocumentZoom(zoom, bounds);
+  const candidates = [bounds.min, computeDocumentFitWidthZoom(layout, viewportWidth), clampDocumentZoom(1, bounds), bounds.max];
+  const firstGridIndex = Math.ceil((bounds.min - ZOOM_EPSILON) / DISCRETE_ZOOM_STEP);
+  const lastGridIndex = Math.floor((bounds.max + ZOOM_EPSILON) / DISCRETE_ZOOM_STEP);
+  for (let index = firstGridIndex; index <= lastGridIndex; index += 1) {
+    candidates.push(index * DISCRETE_ZOOM_STEP);
+  }
+
+  const ordered = [...new Set(candidates.map((candidate) => clampDocumentZoom(candidate, bounds)))].toSorted((a, b) => a - b);
+  if (direction > 0) return ordered.find((candidate) => candidate > current + ZOOM_EPSILON) ?? null;
+  return ordered.findLast((candidate) => candidate < current - ZOOM_EPSILON) ?? null;
+}
+
 export function resolveDirectDocumentZoom(zoom: number, layout: DocumentZoomLayout): number {
   const bounds = computeDocumentZoomBounds(layout);
   return elasticDisplayZoom(zoom, bounds) ?? bounds.min;
@@ -87,6 +115,30 @@ export function resolveDirectDocumentZoom(zoom: number, layout: DocumentZoomLayo
 
 export function resolveDocumentZoomIndicator(displayZoom: number, layout: DocumentZoomLayout): number {
   return clampDocumentZoom(displayZoom, computeDocumentZoomBounds(layout));
+}
+
+export function resolveDocumentZoomLandmark({
+  zoom,
+  layout,
+  viewportWidth,
+}: {
+  zoom: number;
+  layout: DocumentZoomLayout;
+  viewportWidth: number;
+}): DocumentZoomLandmark | null {
+  const layoutWidth = layout.type === 'continuous' ? layout.maxWidth : layout.pageWidth;
+  if (!Number.isFinite(zoom) || zoom <= 0 || !Number.isFinite(layoutWidth) || layoutWidth <= 0) return null;
+  if (!Number.isFinite(viewportWidth) || viewportWidth <= 0) return null;
+
+  const bounds = computeDocumentZoomBounds(layout);
+  const unitZoom = clampDocumentZoom(1, bounds);
+  if (zoomEquals(zoom, unitZoom)) return 'unit';
+
+  const naturalFitWidthZoom = viewportWidth / documentZoomWidth(layout);
+  if (naturalFitWidthZoom >= bounds.min && naturalFitWidthZoom <= bounds.max && zoomEquals(zoom, naturalFitWidthZoom)) return 'fit-width';
+  if (zoomEquals(zoom, bounds.min)) return 'minimum';
+  if (zoomEquals(zoom, bounds.max)) return 'maximum';
+  return null;
 }
 
 export function resolveContinuousLayoutViewportWidth({

--- a/apps/website/src/lib/hover-intent.test.ts
+++ b/apps/website/src/lib/hover-intent.test.ts
@@ -43,6 +43,20 @@ describe('hoverIntent', () => {
     action?.destroy?.();
   });
 
+  it('supports a single low-speed sample for compact hover targets', async () => {
+    const onIntent = vi.fn();
+    const action = hoverIntent(element, { delay: 400, samples: 1, onIntent });
+
+    pointer(element, 'pointerenter', 10, 10);
+    await vi.advanceTimersByTimeAsync(99);
+    expect(onIntent).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onIntent).toHaveBeenCalledOnce();
+
+    action?.destroy?.();
+  });
+
   it('fires synchronously when the delay is zero', () => {
     const onIntent = vi.fn();
     const action = hoverIntent(element, { delay: 0, onIntent });

--- a/packages/ui/src/actions/hover-intent.svelte.ts
+++ b/packages/ui/src/actions/hover-intent.svelte.ts
@@ -7,6 +7,8 @@ export type HoverIntentParameter = {
   intentEnabled?: boolean;
   /** Maximum movement in pixels per 100ms that counts as low-speed movement. */
   sensitivity?: number;
+  /** Consecutive low-speed samples required before intent is established. */
+  samples?: number;
   onEnter?: (event: PointerEvent) => void;
   onIntent: (event: PointerEvent) => void;
   onLeave?: (event: PointerEvent) => void;
@@ -14,7 +16,9 @@ export type HoverIntentParameter = {
 
 const SAMPLE_INTERVAL_MS = 100;
 const DEFAULT_SENSITIVITY = 6;
-const REQUIRED_LOW_SPEED_SAMPLES = 2;
+const DEFAULT_SAMPLES = 2;
+
+const resolveSamples = (value: number | undefined) => Math.max(1, Math.floor(value ?? DEFAULT_SAMPLES));
 
 export const hoverIntent: Action<HTMLElement, HoverIntentParameter> = (element, parameter) => {
   let current = parameter;
@@ -57,7 +61,7 @@ export const hoverIntent: Action<HTMLElement, HoverIntentParameter> = (element, 
     previousY = pointerY;
     previousSampleTime = now;
 
-    if (lowSpeedSamples >= REQUIRED_LOW_SPEED_SAMPLES) fireIntent(pointerEvent);
+    if (lowSpeedSamples >= resolveSamples(current.samples)) fireIntent(pointerEvent);
     else sampleTimer = setTimeout(sample, SAMPLE_INTERVAL_MS);
   };
 
@@ -118,12 +122,13 @@ export const hoverIntent: Action<HTMLElement, HoverIntentParameter> = (element, 
       const intentWasEnabled = current.intentEnabled !== false;
       const delayChanged = next.delay !== current.delay;
       const sensitivityChanged = next.sensitivity !== current.sensitivity;
+      const samplesChanged = next.samples !== current.samples;
       current = next;
       const intentIsEnabled = current.intentEnabled !== false;
       if (!intentIsEnabled) {
         clearDetection();
         intended = false;
-      } else if (hovered && !intended && pointerEvent && (!intentWasEnabled || delayChanged || sensitivityChanged)) {
+      } else if (hovered && !intended && pointerEvent && (!intentWasEnabled || delayChanged || sensitivityChanged || samplesChanged)) {
         startDetection(pointerEvent);
       }
     },


### PR DESCRIPTION
- 웹과 앱의 에디터 뷰 우상단에 줌 인디케이터를 추가했습니다.
- 배율 변경 시 인디케이터를 일시적으로 표시하고, 포인터로 직접 조작할 때 확대·축소 버튼을 제공합니다.
  - 웹에서는 각 버튼의 동작과 단축키를 툴팁으로 안내합니다.
  - 앱에서는 마우스·트랙패드가 있는 환경에서만 포인터 조작 UI를 표시하며, 터치로 숨겨진 오버레이를 드러내지 않습니다.
- 배율 표시를 누르면 `원본`과 `맞춤`을 전환합니다.
- `최소`, `맞춤`, `원본`, `최대` 배율에 도달하거나 범위를 넘겼다가 복귀하면 랜드마크 라벨과 스냅 피드백을 표시합니다.
- 확대·축소 버튼과 `Mod -/+`가 10% 단위 및 인접한 랜드마크 중 가장 가까운 다음 지점으로 이동하도록 변경했습니다.
- 앱의 버튼 조작과 스냅에 햅틱 피드백을 적용했습니다.
- 인디케이터 조작 후 기존 에디터 포커스 복귀 흐름을 사용하도록 연결하고, 숨겨진 오버레이가 에디터 입력을 가로채지 않도록 했습니다.
- 일시 표시와 직접 조작 상태를 시각적으로 구분하고, 라벨 전환·스냅 효과·progressive blur가 reduced motion 설정을 따르도록 했습니다.
- 빠른 원본↔맞춤 전환과 지연된 레이아웃 갱신 중에도 사용자가 보고 있던 문서 위치를 유지하도록 뷰포트 앵커의 적용·완료 처리를 개선했습니다.
- 직접 줌 조작 중에만 스냅을 적용하여, 맞춤 배율 근처에서 pane 크기가 바뀔 때 반복적으로 스냅되는 현상을 방지했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>