### PR TITLE
Menu가 reduced motion을 존중

### DIFF
--- a/packages/ui/src/actions/floating.svelte.ts
+++ b/packages/ui/src/actions/floating.svelte.ts
@@ -139,27 +139,30 @@ export function createFloatingActions(options?: CreateFloatingActionsOptions): C
   let cleanupClickHandler: (() => void) | undefined;
 
   const updatePosition: UpdatePosition = async () => {
-    if (!referenceElement || !floatingElement) {
+    const reference = referenceElement;
+    const floating = floatingElement;
+    const arrowEl = arrowElement;
+    if (!reference || !floating) {
       return;
     }
 
     const middleware = options?.middleware ?? createDefaultMiddleware();
 
-    const { x, y, placement, strategy, middlewareData } = await computePosition(referenceElement, floatingElement, {
+    const { x, y, placement, strategy, middlewareData } = await computePosition(reference, floating, {
       strategy: 'absolute',
       placement: options?.placement,
       middleware: [
         !!options?.offset && offset(options.offset),
         ...middleware,
-        !!options?.arrow && arrowElement && arrow({ element: arrowElement, padding: 16 }),
+        !!options?.arrow && arrowEl && arrow({ element: arrowEl, padding: 16 }),
       ],
     });
 
-    if (!referenceElement || !floatingElement) {
+    if (referenceElement !== reference || floatingElement !== floating || arrowElement !== arrowEl) {
       return;
     }
 
-    Object.assign(floatingElement.style, {
+    Object.assign(floating.style, {
       position: strategy,
       top: `${y}px`,
       left: `${x}px`,
@@ -167,7 +170,7 @@ export function createFloatingActions(options?: CreateFloatingActionsOptions): C
 
     if (middlewareData.hide) {
       const isHidden = middlewareData.hide.referenceHidden || middlewareData.hide.escaped;
-      Object.assign(floatingElement.style, {
+      Object.assign(floating.style, {
         visibility: isHidden ? 'hidden' : 'visible',
         // Reset position when hidden to prevent overflow
         top: isHidden ? '0' : `${y}px`,
@@ -175,7 +178,7 @@ export function createFloatingActions(options?: CreateFloatingActionsOptions): C
       });
     }
 
-    if (arrowElement && middlewareData.arrow) {
+    if (arrowEl && middlewareData.arrow) {
       const { x, y } = middlewareData.arrow;
 
       const side = match(placement)
@@ -192,10 +195,10 @@ export function createFloatingActions(options?: CreateFloatingActionsOptions): C
         .with('right', 'right-start', 'right-end', () => 'rotate(-45deg)')
         .exhaustive();
 
-      Object.assign(arrowElement.style, {
+      Object.assign(arrowEl.style, {
         left: x === undefined ? '' : `${x}px`,
         top: y === undefined ? '' : `${y}px`,
-        [side]: `${-arrowElement.offsetHeight / 2}px`,
+        [side]: `${-arrowEl.offsetHeight / 2}px`,
         transform,
         visibility: middlewareData.bubble?.bubbled ? 'hidden' : 'visible',
       });
@@ -230,18 +233,28 @@ export function createFloatingActions(options?: CreateFloatingActionsOptions): C
   };
 
   const mount = async () => {
-    if (!referenceElement || !floatingElement) {
+    const reference = referenceElement;
+    const floating = floatingElement;
+    const arrowEl = arrowElement;
+    if (!reference || !floating) {
       return;
     }
 
     await updatePosition();
+    if (referenceElement !== reference || floatingElement !== floating || arrowElement !== arrowEl) {
+      return;
+    }
 
     if (options?.disableAutoUpdate !== true) {
       cleanupAutoUpdate?.();
-      cleanupAutoUpdate = autoUpdate(referenceElement, floatingElement, updatePosition, { animationFrame: true });
+      cleanupAutoUpdate = autoUpdate(reference, floating, updatePosition, { animationFrame: true });
     }
 
     setTimeout(() => {
+      if (referenceElement !== reference || floatingElement !== floating || arrowElement !== arrowEl) {
+        return;
+      }
+
       cleanupClickHandler?.();
 
       cleanupClickHandler = on(window, 'click', handleClick);

--- a/packages/ui/src/components/Menu.svelte
+++ b/packages/ui/src/components/Menu.svelte
@@ -6,6 +6,7 @@
   import { afterNavigate } from '$app/navigation';
   import { createFloatingActions, deactivateFocusTrap, focusTrap, portal, updateFocusTrapContainers } from '../actions';
   import { tryAppContext } from '../context';
+  import { prefersReducedMotion } from '../state/reduced-motion.svelte';
   import { createHoverFocusHandler, pushEscapeHandler } from '../utils';
   import type { OffsetOptions, Placement } from '@floating-ui/dom';
   import type { SystemStyleObject } from '@typie/styled-system/types';
@@ -289,7 +290,7 @@
       // NOTE: 우클릭으로 연 경우 buttonEl이 없으며 포커스 되돌리지 않음
       returnFocusOnDeactivate: !!buttonEl,
     }}
-    transition:scale={{ start: 0.95, duration: 150 }}
+    transition:scale={{ start: 0.95, duration: prefersReducedMotion.current ? 0 : 150 }}
   >
     {#if action}
       <li>


### PR DESCRIPTION
공용 Menu의 scale transition이 reduced motion 설정과 관계없이 150ms로 동작하고 있었습니다.

transition을 즉시 완료하면 floating element가 비동기 위치 계산 중 제거되거나 교체될 수 있으므로, 관련 lifecycle 처리도 함께 보완합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>