### PR TITLE
집중 모드 컨트롤을 컨텍스트 바로 이동

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/Editor.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Editor.svelte
@@ -16,6 +16,7 @@
     contentInsetRight?: number;
     contentMotion?: { fromX: number; duration: number; easing: string };
     breadcrumb?: Snippet<[EditorContextBarSegmentRenderProps]>;
+    viewControls?: Snippet<[EditorContextBarSegmentRenderProps]>;
     header?: Snippet;
     footer?: Snippet;
     children?: Snippet;
@@ -32,6 +33,7 @@
     contentInsetRight = 0,
     contentMotion,
     breadcrumb,
+    viewControls,
     header,
     footer,
     children,
@@ -62,6 +64,7 @@
     {header}
     {onReady}
     {useWindowScroll}
+    {viewControls}
     {viewer}
   >
     {#if children}

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -2,6 +2,7 @@
   import { createFragment } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { token } from '@typie/styled-system/tokens';
+  import { VerticalDivider } from '@typie/ui/components';
   import { getThemeContext } from '@typie/ui/context';
   import { Toast } from '@typie/ui/notification';
   import { elementScrollViewport, windowScrollViewport } from '@typie/ui/utils';
@@ -62,6 +63,7 @@
     /** 최종 레이아웃으로 바뀐 본문을 이전 화면 위치에서 합성하는 일회성 모션. */
     contentMotion?: { fromX: number; duration: number; easing: string };
     breadcrumb?: Snippet<[EditorContextBarSegmentRenderProps]>;
+    viewControls?: Snippet<[EditorContextBarSegmentRenderProps]>;
     onReady?: () => void;
     header?: Snippet;
     footer?: Snippet;
@@ -78,6 +80,7 @@
     contentInsetRight = 0,
     contentMotion,
     breadcrumb,
+    viewControls: additionalViewControls,
     onReady,
     header,
     footer,
@@ -557,6 +560,10 @@
             {#snippet viewControls({ state, presentation }: EditorContextBarSegmentRenderProps)}
               <div class={css({ display: 'flex', alignItems: 'center' })} aria-label="보기 제어" role="group">
                 <EditorZoomControls {...controls} segment={state} visible={presentation.visible} />
+                {#if controls.enabled && additionalViewControls}
+                  <VerticalDivider style={css.raw({ height: '12px' })} />
+                {/if}
+                {@render additionalViewControls?.({ state, presentation })}
               </div>
             {/snippet}
           </EditorContextBar>

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorContextBar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorContextBar.svelte
@@ -89,12 +89,14 @@
   let lanePointerY = $state(0);
   let laneExpansionMaskedSegments = $state<ContextBarSegmentId[]>([]);
   let fadingTransientSegments = $state<ContextBarSegmentId[]>([]);
+  let transientExitPresentation = $state<ContextBarPresentation>();
   let laneHoverIntent: ActionReturn<HoverIntentParameter> | undefined;
   let laneDwellTimer: ReturnType<typeof setTimeout> | undefined;
   let laneExpansionTimer: ReturnType<typeof setTimeout> | undefined;
   let hiddenSegmentIntentTimer: ReturnType<typeof setTimeout> | undefined;
   let hiddenSegmentIntentTarget: ContextBarSegmentId | undefined;
   let hiddenSegmentEngaged: ContextBarSegmentId | undefined;
+  let transientExitTimer: ReturnType<typeof setTimeout> | undefined;
   const fadingTransientTimers = new SvelteMap<ContextBarSegmentId, ReturnType<typeof setTimeout>>();
   let initialRevealComplete = false;
 
@@ -104,6 +106,7 @@
     viewControls: { visible: false, tone: 'transient' },
   });
   let previousPresentation = presentation;
+  const surfaceMaskPresentation = $derived(transientExitPresentation ?? presentation);
 
   const unifiedPairVisible = $derived(presentation.unified);
   const unifiedSurfaceVisible = $derived(unifiedPairVisible && laneHoverPhase !== 'expanding');
@@ -146,7 +149,9 @@
       ? LANE_SPOT_EXPAND_MS
       : laneHoverPhase === 'preview' || laneHoverPhase === 'spot'
         ? LANE_SPOT_ENTER_MS
-        : 320,
+        : transientExitPresentation
+          ? CONTEXT_BAR_FADE_OUT_MS
+          : 320,
   );
 
   function toneColor(tone: ContextBarSegmentPresentation['tone']): string {
@@ -185,11 +190,14 @@
   function unifiedTransientMask(): string {
     if (!breadcrumbGeometry || !viewControlsGeometry) return 'linear-gradient(transparent, transparent)';
     const hasTransientSegment =
-      presentation.breadcrumb.tone === 'transient' || presentation.viewControls.tone === 'transient' || fadingTransientSegments.length > 0;
+      surfaceMaskPresentation.breadcrumb.tone === 'transient' ||
+      surfaceMaskPresentation.viewControls.tone === 'transient' ||
+      fadingTransientSegments.length > 0;
     if (hasTransientSegment) return 'linear-gradient(black, black)';
 
-    const breadcrumbEngaged = presentation.breadcrumb.tone === 'engaged' && !fadingTransientSegments.includes('breadcrumb');
-    const viewControlsEngaged = presentation.viewControls.tone === 'engaged' && !fadingTransientSegments.includes('viewControls');
+    const breadcrumbEngaged = surfaceMaskPresentation.breadcrumb.tone === 'engaged' && !fadingTransientSegments.includes('breadcrumb');
+    const viewControlsEngaged =
+      surfaceMaskPresentation.viewControls.tone === 'engaged' && !fadingTransientSegments.includes('viewControls');
     if (!breadcrumbEngaged && !viewControlsEngaged) return 'linear-gradient(black, black)';
 
     const width = viewControlsGeometry.right - breadcrumbGeometry.left;
@@ -218,7 +226,7 @@
 
   function segmentLaneMask(segment: ContextBarSegmentId, transientOnly: boolean): string | undefined {
     const geometry = segment === 'breadcrumb' ? breadcrumbGeometry : viewControlsGeometry;
-    const segmentPresentation = presentation[segment];
+    const segmentPresentation = surfaceMaskPresentation[segment];
     if (
       !geometry ||
       !segmentPresentation.visible ||
@@ -264,8 +272,10 @@
   function laneBlurMasks(): string[] {
     const masks = [laneSpotMask('--context-bar-lane-spot-opacity')];
     const hasTransientSegment =
-      presentation.breadcrumb.tone === 'transient' || presentation.viewControls.tone === 'transient' || fadingTransientSegments.length > 0;
-    if (unifiedSurfaceVisible) {
+      surfaceMaskPresentation.breadcrumb.tone === 'transient' ||
+      surfaceMaskPresentation.viewControls.tone === 'transient' ||
+      fadingTransientSegments.length > 0;
+    if (unifiedSurfaceVisible || transientExitPresentation?.unified) {
       if (hasTransientSegment) masks.push('linear-gradient(black, black)');
       return masks;
     }
@@ -286,7 +296,7 @@
       masks.push(fadingMask ?? (engagedSegment ? outsideEngagedSegmentMask(engagedSegment) : 'linear-gradient(transparent, transparent)'));
       return masks;
     }
-    if (unifiedSurfaceVisible) {
+    if (unifiedSurfaceVisible || transientExitPresentation?.unified) {
       masks.push(unifiedTransientMask());
       return masks;
     }
@@ -353,6 +363,22 @@
     for (const timer of fadingTransientTimers.values()) clearTimeout(timer);
     fadingTransientTimers.clear();
     fadingTransientSegments = [];
+  }
+
+  function clearTransientSurfaceExit(): void {
+    clearTimeout(transientExitTimer);
+    transientExitTimer = undefined;
+    transientExitPresentation = undefined;
+  }
+
+  function startTransientSurfaceExit(previous: ContextBarPresentation): void {
+    clearTransientSurfaceExit();
+    if (prefersReducedMotion.current) return;
+    transientExitPresentation = previous;
+    transientExitTimer = setTimeout(() => {
+      transientExitTimer = undefined;
+      transientExitPresentation = undefined;
+    }, CONTEXT_BAR_FADE_OUT_MS);
   }
 
   function releaseHiddenSegmentHover(): void {
@@ -569,6 +595,13 @@
       breadcrumb: breadcrumb ? breadcrumbState.activity : { transient: false, hovered: false, focused: false, holds: [] },
       viewControls: viewControlsState.activity,
     });
+    const hadTransientSurface =
+      (previousPresentation.breadcrumb.visible && previousPresentation.breadcrumb.tone === 'transient') ||
+      (previousPresentation.viewControls.visible && previousPresentation.viewControls.tone === 'transient');
+    const nextHidden = !nextPresentation.breadcrumb.visible && !nextPresentation.viewControls.visible;
+    if (hadTransientSurface && nextHidden) startTransientSurfaceExit(previousPresentation);
+    else if (!nextHidden) clearTransientSurfaceExit();
+
     for (const segment of ['breadcrumb', 'viewControls'] as const) {
       if (
         previousPresentation[segment].visible &&
@@ -633,6 +666,7 @@
     return () => {
       clearHiddenSegmentIntent();
       clearFadingTransientSegments();
+      clearTransientSurfaceExit();
       stopLaneInteraction(false);
       breadcrumbState.destroy();
       viewControlsState.destroy();
@@ -680,6 +714,8 @@
     style:background={TRANSIENT_SURFACE}
     style:mask-image={laneSurfaceMask}
     style:mask-composite={laneSurfaceMaskComposite}
+    style:opacity={laneBlurVisible ? '1' : '0'}
+    style:transition={prefersReducedMotion.current ? 'none' : `opacity ${laneBlurVisible ? 0 : CONTEXT_BAR_FADE_OUT_MS}ms ease-out`}
     class={css({ position: 'absolute', inset: '0', zIndex: '[-1]', pointerEvents: 'none' })}
     aria-hidden="true"
     data-context-bar-full-lane={unifiedSurfaceVisible}

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorFocusModeControl.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorFocusModeControl.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { tooltip } from '@typie/ui/actions';
+  import { Icon } from '@typie/ui/components';
+  import Maximize2Icon from '~icons/lucide/maximize-2';
+  import Minimize2Icon from '~icons/lucide/minimize-2';
+  import { CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from './editor-context-bar.svelte';
+  import type { EditorContextBarSegmentState } from './editor-context-bar.svelte';
+
+  type Props = {
+    enabled: boolean;
+    segment: EditorContextBarSegmentState;
+    visible: boolean;
+    onToggle: () => unknown;
+  };
+
+  let { enabled, segment, visible, onToggle }: Props = $props();
+  let observedEnabled: boolean | undefined;
+
+  const label = $derived(enabled ? '집중 모드 끄기' : '집중 모드 켜기');
+  const shortcut = $derived(enabled ? (['Esc'] as ['Esc']) : (['Mod', 'Shift', 'M'] as ['Mod', 'Shift', 'M']));
+
+  $effect(() => {
+    const current = enabled;
+    if (observedEnabled !== undefined && observedEnabled !== current) {
+      segment.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+    }
+    observedEnabled = current;
+  });
+</script>
+
+<div class={css({ display: 'flex', alignItems: 'center', paddingX: '8px', paddingY: '4px' })}>
+  <button
+    class={css({
+      display: 'grid',
+      placeItems: 'center',
+      size: '24px',
+      borderRadius: '8px',
+      cursor: 'pointer',
+      _supportHover: { backgroundColor: 'interactive.hover', color: 'text.default' },
+      _focusVisible: { outline: '2px solid token(colors.border.focus)', outlineOffset: '-2px' },
+    })}
+    aria-label={label}
+    aria-pressed={enabled}
+    data-editor-focus-mode-control
+    onclick={onToggle}
+    onpointerdown={(event) => event.preventDefault()}
+    tabindex={visible ? 0 : -1}
+    type="button"
+    use:tooltip={{ message: label, keys: shortcut, placement: 'bottom' }}
+  >
+    <Icon icon={enabled ? Minimize2Icon : Maximize2Icon} size={14} />
+  </button>
+</div>

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorZoomControls.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorZoomControls.svelte
@@ -215,8 +215,7 @@
     lastZoom = displayZoom;
     const initialObservation = previousZoom === null;
     const zoomChanged = !initialObservation && zoomDiffers(previousZoom, displayZoom);
-    if (enabled && (zoomChanged || (entered && landmark !== 'unit'))) showTemporarily();
-    if (!enabled) segment.hideTransient();
+    if (enabled && (zoomChanged || entered)) showTemporarily();
   });
 
   $effect(() => {

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar-test-root.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar-test-root.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { VerticalDivider } from '@typie/ui/components';
   import { CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from './editor-context-bar.svelte';
   import EditorBreadcrumb from './EditorBreadcrumb.svelte';
   import EditorContextBar from './EditorContextBar.svelte';
+  import EditorFocusModeControl from './EditorFocusModeControl.svelte';
   import EditorZoomControls from './EditorZoomControls.svelte';
   import type { DocumentZoomLandmark } from '$lib/editor-ffi/zoom';
   import type { EditorContextBarSegmentRenderProps } from './EditorContextBar.svelte';
@@ -45,6 +47,7 @@
   let landmark = $state<DocumentZoomLandmark | null>(initialLandmark);
   let boundaryAttemptRequest = $state(0);
   let boundaryAttemptLandmark = $state<DocumentZoomLandmark | null>(null);
+  let focusMode = $state(false);
   let editorViewSurface = $state<HTMLElement>();
   let scrollContainer = $state<HTMLElement>();
   let currentSurfaceWidth = $state(surfaceWidth);
@@ -63,6 +66,10 @@
 
   export function setEnabled(nextEnabled: boolean) {
     enabled = nextEnabled;
+  }
+
+  export function setFocusMode(nextEnabled: boolean) {
+    focusMode = nextEnabled;
   }
 
   export function requestBoundaryAttempt(nextLandmark: DocumentZoomLandmark) {
@@ -88,22 +95,33 @@
     {#if mode === 'zoom' && editorViewSurface && scrollContainer}
       <EditorContextBar {editorViewSurface} interactiveViewControlsWhenHidden showViewControlsOnPaneEntry={enabled && landmark !== 'unit'}>
         {#snippet viewControls({ state, presentation }: EditorContextBarSegmentRenderProps)}
-          <EditorZoomControls
-            atMaximum={landmark === 'maximum'}
-            atMinimum={landmark === 'minimum'}
-            {boundaryAttemptLandmark}
-            {boundaryAttemptRequest}
-            {displayZoom}
-            {enabled}
-            {indicatorZoom}
-            {landmark}
-            {onToggleZoom}
-            {onZoomIn}
-            {onZoomOut}
-            segment={state}
-            {toggleTargetLandmark}
-            visible={presentation.visible}
-          />
+          <div style="display: flex; align-items: center">
+            <EditorZoomControls
+              atMaximum={landmark === 'maximum'}
+              atMinimum={landmark === 'minimum'}
+              {boundaryAttemptLandmark}
+              {boundaryAttemptRequest}
+              {displayZoom}
+              {enabled}
+              {indicatorZoom}
+              {landmark}
+              {onToggleZoom}
+              {onZoomIn}
+              {onZoomOut}
+              segment={state}
+              {toggleTargetLandmark}
+              visible={presentation.visible}
+            />
+            {#if enabled}
+              <VerticalDivider style={{ height: '12px' }} />
+            {/if}
+            <EditorFocusModeControl
+              enabled={focusMode}
+              onToggle={() => (focusMode = !focusMode)}
+              segment={state}
+              visible={presentation.visible}
+            />
+          </div>
         {/snippet}
       </EditorContextBar>
     {:else if mode === 'context-bar' && editorViewSurface}

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.browser.test.ts
@@ -23,6 +23,7 @@ const HOVER_INTENT_SETTLE_MS = 100;
 const LANE_SPOT_DWELL_MS = 500;
 const LANE_SPOT_EXPAND_MS = 1000;
 const SURFACE_FADE_IN_MS = 180;
+const SURFACE_FADE_OUT_MS = 400;
 let mounted: Record<string, unknown> | undefined;
 
 const enter = (element: HTMLElement) => element.dispatchEvent(new PointerEvent('pointerenter'));
@@ -84,7 +85,7 @@ async function mountOverlay(
   const editorViewSurface = document.querySelector<HTMLElement>('[data-testid="context-bar-underlay"]')?.parentElement;
   const toolbar = document.querySelector<HTMLElement>('[data-testid="editor-toolbar"]');
   if (!overlay || !scrollContainer || !editorViewSurface || !toolbar) throw new Error('Missing editor view-controls fixture');
-  return { overlay, paneContainer: paneContainer ?? editorViewSurface, scrollContainer, editorViewSurface, toolbar };
+  return { overlay, paneContainer: paneContainer ?? editorViewSurface, scrollContainer, editorViewSurface, toolbar, host: mounted };
 }
 
 async function expireTransientVisibility() {
@@ -111,6 +112,25 @@ describe('editor context bar', () => {
     await expireTransientVisibility();
     expect(breadcrumb.style.opacity).toBe('0');
     expect(viewControls.style.opacity).toBe('0');
+  });
+
+  it('keeps the transient surface mask while the context bar fades out', async () => {
+    vi.useFakeTimers();
+    const { breadcrumb, viewControls } = await mountContextBar({ viewControlsPaneEntry: false });
+    const surface = document.querySelector<HTMLElement>('[data-context-bar-lane-surface]');
+    const blur = document.querySelector<HTMLElement>('[data-context-bar-blur-layer]');
+
+    await expireTransientVisibility();
+
+    expect(breadcrumb.style.opacity).toBe('0');
+    expect(viewControls.style.opacity).toBe('0');
+    expect(surface?.style.opacity).toBe('0');
+    expect(surface?.style.maskImage).toContain('linear-gradient(black, black)');
+    expect(blur?.style.maskImage).toContain('linear-gradient(black, black)');
+
+    await vi.advanceTimersByTimeAsync(SURFACE_FADE_OUT_MS);
+    expect(surface?.style.maskImage).not.toContain('linear-gradient(black, black)');
+    expect(blur?.style.maskImage).not.toContain('linear-gradient(black, black)');
   });
 
   it('preserves view controls and lets a long breadcrumb consume only the remaining width', async () => {
@@ -455,7 +475,24 @@ describe('editor context bar', () => {
   });
 });
 
-describe('editor zoom controls visibility', () => {
+describe('editor view controls visibility', () => {
+  it('reveals view controls when focus mode changes outside the control', async () => {
+    vi.useFakeTimers();
+    const { host, overlay } = await mountOverlay({ displayZoom: 1, indicatorZoom: 1, landmark: 'unit' });
+    const focusModeControl = () => document.querySelector<HTMLButtonElement>('[data-editor-focus-mode-control]');
+
+    expect(focusModeControl()?.ariaLabel).toBe('집중 모드 켜기');
+    await expireTransientVisibility();
+    expect(overlay.style.opacity).toBe('0');
+
+    (host as { setFocusMode: (enabled: boolean) => void }).setFocusMode(true);
+    await tick();
+
+    expect(overlay.style.opacity).toBe('1');
+    expect(focusModeControl()?.ariaLabel).toBe('집중 모드 끄기');
+    expect(focusModeControl()?.tabIndex).toBe(0);
+  });
+
   it('reveals an initial unit zoom for one transient window', async () => {
     vi.useFakeTimers();
     const unit = await mountOverlay({ displayZoom: 1, indicatorZoom: 1, landmark: 'unit' });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -20,7 +20,6 @@
   import LightbulbIcon from '~icons/lucide/lightbulb';
   import LockIcon from '~icons/lucide/lock';
   import LockOpenIcon from '~icons/lucide/lock-open';
-  import Maximize2Icon from '~icons/lucide/maximize-2';
   import MessageSquareTextIcon from '~icons/lucide/message-square-text';
   import SettingsIcon from '~icons/lucide/settings';
   import SpellCheckIcon from '~icons/lucide/spell-check';
@@ -30,6 +29,7 @@
   import { Editor as EditorComponent, EditorFailureOverlay } from '$lib/editor-ffi/components';
   import { CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from '$lib/editor-ffi/components/ui/editor-context-bar.svelte';
   import EditorBreadcrumb from '$lib/editor-ffi/components/ui/EditorBreadcrumb.svelte';
+  import EditorFocusModeControl from '$lib/editor-ffi/components/ui/EditorFocusModeControl.svelte';
   import { CONTINUOUS_MIN_WIDTH, CONTINUOUS_VIEW_PADDING, IS_MAC } from '$lib/editor-ffi/constants';
   import { browserScaleFactor, Editor, getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { createAssetHydrator } from '$lib/editor-ffi/handlers/asset-hydration';
@@ -812,6 +812,12 @@
 
   const currentViewZenModeEnabled = $derived(app.preference.current.zenModeEnabled && pane.id === paneGroup.state.current.focusedPaneId);
 
+  function toggleZenMode() {
+    const enabled = !app.preference.current.zenModeEnabled;
+    app.preference.current.zenModeEnabled = enabled;
+    mixpanel.track(enabled ? 'zen_mode_enabled' : 'zen_mode_disabled', { via: 'document' });
+  }
+
   $effect(() => {
     const editor = ctx.liveEditor;
     if (editor) {
@@ -1162,31 +1168,6 @@
                 {/if}
               {/if}
 
-              <button
-                class={center({
-                  borderRadius: '4px',
-                  size: '24px',
-                  color: 'text.faint',
-                  transition: 'common',
-                  _hover: { color: 'text.subtle', backgroundColor: 'surface.muted' },
-                })}
-                onclick={() => {
-                  app.preference.current.zenModeEnabled = !app.preference.current.zenModeEnabled;
-                  if (app.preference.current.zenModeEnabled) {
-                    mixpanel.track('zen_mode_enabled', { via: 'document' });
-                  } else {
-                    mixpanel.track('zen_mode_disabled', { via: 'document' });
-                  }
-                }}
-                onpointerdown={(e) => e.preventDefault()}
-                type="button"
-                use:tooltip={{
-                  message: app.preference.current.zenModeEnabled ? '집중 모드 끄기' : '집중 모드 켜기',
-                  keys: ['Mod', 'Shift', 'M'],
-                }}
-              >
-                <Icon icon={Maximize2Icon} size={16} />
-              </button>
               <CloseButton>
                 <Icon icon={XIcon} size={16} />
               </CloseButton>
@@ -1352,11 +1333,19 @@
                                     {/each}
                                     <li class={flex({ alignItems: 'center', gap: '4px' })} aria-current="page">
                                       <EntityIcon entity$key={entity} size={14} />
-                                      <span>{localTitle || '제목 없음'}</span>
+                                      <span>{localTitle || '(제목 없음)'}</span>
                                     </li>
                                   </ol>
                                 </nav>
                               </EditorBreadcrumb>
+                            {/snippet}
+                            {#snippet viewControls({ state, presentation }: EditorContextBarSegmentRenderProps)}
+                              <EditorFocusModeControl
+                                enabled={currentViewZenModeEnabled}
+                                onToggle={toggleZenMode}
+                                segment={state}
+                                visible={presentation.visible}
+                              />
                             {/snippet}
                             {#snippet header()}
                               <div
@@ -1508,65 +1497,39 @@
         {/snippet}
       </PrismReviewMargin>
 
-      {#if currentViewZenModeEnabled}
+      {#if currentViewZenModeEnabled && !entity.user.subscription}
         <div
           class={flex({
             position: 'fixed',
-            top: '18px',
+            top: '44px',
             right: '18px',
             zIndex: 'editor',
             alignItems: 'center',
             gap: '8px',
           })}
         >
-          {#if !entity.user.subscription}
-            <button
-              class={flex({
-                alignItems: 'center',
-                gap: '4px',
-                height: '[31.5px]',
-                paddingX: '8px',
-                borderRadius: '6px',
-                borderWidth: '1px',
-                borderColor: 'border.brand',
-                fontSize: '11px',
-                fontWeight: 'semibold',
-                color: 'text.brand',
-                backgroundColor: 'surface.default',
-                cursor: 'pointer',
-                transition: 'common',
-                _hover: { backgroundColor: 'accent.brand.subtle' },
-              })}
-              onclick={() => SubscribeModal.show('document_zen_mode')}
-              type="button"
-            >
-              <Icon icon={CrownIcon} size={12} />
-              <span>업그레이드</span>
-            </button>
-          {/if}
-
           <button
-            class={center({
-              height: '32px',
-              width: '32px',
+            class={flex({
+              alignItems: 'center',
+              gap: '4px',
+              height: '[31.5px]',
+              paddingX: '8px',
               borderWidth: '1px',
-              borderColor: 'border.strong',
-              borderRadius: '8px',
-              color: 'text.subtle',
-              backgroundColor: { base: 'surface.default', _hover: 'surface.subtle' },
+              borderColor: 'border.brand',
+              borderRadius: '6px',
+              fontSize: '11px',
+              fontWeight: 'semibold',
+              color: 'text.brand',
+              backgroundColor: 'surface.default',
+              cursor: 'pointer',
+              transition: 'common',
+              _hover: { backgroundColor: 'accent.brand.subtle' },
             })}
-            onclick={() => {
-              app.preference.current.zenModeEnabled = false;
-              mixpanel.track('zen_mode_disabled', { via: 'close_button' });
-            }}
-            onpointerdown={(e) => e.preventDefault()}
+            onclick={() => SubscribeModal.show('document_zen_mode')}
             type="button"
-            use:tooltip={{
-              message: '집중 모드 끄기',
-              keys: ['Esc'],
-            }}
           >
-            <Icon icon={XIcon} />
+            <Icon icon={CrownIcon} size={12} />
+            <span>업그레이드</span>
           </button>
         </div>
       {/if}


### PR DESCRIPTION
- 집중 모드 토글을 pane 헤더에서 에디터 context bar의 보기 제어 영역으로 옮겼습니다.
- 단축키 등으로 집중 모드 상태가 바뀔 때도 토글이 잠시 노출되도록 했습니다.
- 집중 모드의 별도 종료 버튼을 제거하고, 업그레이드 버튼은 context bar 아래에 배치했습니다.
- 제목 없는 문서의 breadcrumb 표기를 `(제목 없음)`으로 통일했습니다.
- context bar가 사라질 때 fade out 효과가 나타나지 않는 문제를 수정했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>