### PR TITLE
컨텍스트 바 고정 기능 및 뷰어 줌 컨트롤

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -3,7 +3,7 @@
   import { css } from '@typie/styled-system/css';
   import { token } from '@typie/styled-system/tokens';
   import { VerticalDivider } from '@typie/ui/components';
-  import { getThemeContext } from '@typie/ui/context';
+  import { getThemeContext, tryAppContext } from '@typie/ui/context';
   import { Toast } from '@typie/ui/notification';
   import { elementScrollViewport, windowScrollViewport } from '@typie/ui/utils';
   import { onDestroy, untrack } from 'svelte';
@@ -43,6 +43,7 @@
   import EditorContextBar from './ui/EditorContextBar.svelte';
   import EditorZoom from './ui/EditorZoom.svelte';
   import EditorZoomControls from './ui/EditorZoomControls.svelte';
+  import FloatingEditorZoomControls from './ui/FloatingEditorZoomControls.svelte';
   import ViewportOverlay from './ViewportOverlay.svelte';
   import type { SystemStyleObject } from '@typie/styled-system/types';
   import type { Snippet } from 'svelte';
@@ -89,16 +90,30 @@
 
   const ctx = getEditorContext();
   const theme = getThemeContext();
+  const app = tryAppContext();
+  const contextBarPinned = $derived(app?.preference.current.contextBarPinned ?? false);
+
+  function setContextBarPinned(pinned: boolean): void {
+    if (app) app.preference.current.contextBarPinned = pinned;
+  }
 
   // 이 View 인스턴스가 소유한다. 공유 컨텍스트에 두면 {#key ctx.editor}로 View가 교체될 때
   // 새 인스턴스가 옛 인스턴스의 host를 읽어버린다 (새 브랜치 생성이 옛 브랜치 파괴보다 먼저다).
   let surfaceHost = $state<EditorSurfaceHost>();
   let editorViewSurface = $state<HTMLElement>();
+  let contextBarTopOcclusion = $state(0);
 
   setupEditorScroll(ctx);
   setupEditorPublication(ctx, () => surfaceHost);
   onDestroy(() => {
     if (ctx.editor) cancelPointerInteraction(ctx.editor);
+  });
+
+  $effect(() => {
+    const scroll = ctx.scroll;
+    const topInset = contextBarTopOcclusion;
+    if (!scroll) return;
+    untrack(() => scroll.setTopInset(topInset));
   });
 
   $effect(() => {
@@ -357,6 +372,36 @@
     style,
   )}
 >
+  {#if ctx.editor}
+    <EditorZoom {active} editor={ctx.editor} {editorViewSurface} layout={zoomLayout} scroll={ctx.scroll} viewportWidth={clientWidth ?? 0}>
+      {#snippet zoomControls({ controls, showViewControlsOnPaneEntry })}
+        {#if viewer}
+          <FloatingEditorZoomControls {controls} />
+        {:else if editorViewSurface}
+          <EditorContextBar
+            {breadcrumb}
+            {editorViewSurface}
+            interactiveViewControlsWhenHidden
+            onPinnedChange={setContextBarPinned}
+            onTopOcclusionChange={(topOcclusion) => (contextBarTopOcclusion = topOcclusion)}
+            pinned={contextBarPinned}
+            {showViewControlsOnPaneEntry}
+          >
+            {#snippet viewControls({ state, presentation }: EditorContextBarSegmentRenderProps)}
+              <div class={css({ display: 'flex', alignItems: 'center' })} aria-label="보기 제어" role="group">
+                <EditorZoomControls {...controls} visibility={state} visible={presentation.visible} />
+                {#if controls.enabled && additionalViewControls}
+                  <VerticalDivider style={css.raw({ height: '12px' })} />
+                {/if}
+                {@render additionalViewControls?.({ state, presentation })}
+              </div>
+            {/snippet}
+          </EditorContextBar>
+        {/if}
+      {/snippet}
+    </EditorZoom>
+  {/if}
+
   <div
     style:--page-gap={isPaginated ? `${pageGap}px` : undefined}
     style:overflow-x={!useWindowScroll && contentAnimation ? 'clip' : undefined}
@@ -551,26 +596,6 @@
       </div>
     {/if}
   </div>
-
-  {#if ctx.editor}
-    <EditorZoom {active} editor={ctx.editor} {editorViewSurface} layout={zoomLayout} scroll={ctx.scroll} viewportWidth={clientWidth ?? 0}>
-      {#snippet zoomControls({ controls, showViewControlsOnPaneEntry })}
-        {#if editorViewSurface}
-          <EditorContextBar {breadcrumb} {editorViewSurface} interactiveViewControlsWhenHidden {showViewControlsOnPaneEntry}>
-            {#snippet viewControls({ state, presentation }: EditorContextBarSegmentRenderProps)}
-              <div class={css({ display: 'flex', alignItems: 'center' })} aria-label="보기 제어" role="group">
-                <EditorZoomControls {...controls} segment={state} visible={presentation.visible} />
-                {#if controls.enabled && additionalViewControls}
-                  <VerticalDivider style={css.raw({ height: '12px' })} />
-                {/if}
-                {@render additionalViewControls?.({ state, presentation })}
-              </div>
-            {/snippet}
-          </EditorContextBar>
-        {/if}
-      {/snippet}
-    </EditorZoom>
-  {/if}
 
   {#if ctx.editor && !useWindowScroll}
     <Scrollbar />

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorBreadcrumb.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorBreadcrumb.svelte
@@ -27,6 +27,7 @@
   let viewport = $state<HTMLElement>();
   let content = $state<HTMLElement>();
   let metrics = $state<Metrics>({ viewportWidth: 0, contentWidth: 0 });
+  let overflowLeading = $state(false);
   let overflowTrailing = $state(false);
   let pendingTrailingAlignment = true;
   let lastPathIdentity: string | undefined;
@@ -35,16 +36,22 @@
   let fogTransitionFrame: number | undefined;
   let trailingAlignmentFrame: number | undefined;
 
+  const leadingMaskStops = Array.from({ length: FOG_SAMPLES + 1 }, (_, index) => {
+    const progress = index / FOG_SAMPLES;
+    const alphaGain = smootherstep(progress);
+    return `rgb(0 0 0 / calc(1 - var(--breadcrumb-leading-fog) * ${1 - alphaGain})) ${(index / FOG_SAMPLES) * FOG_WIDTH}px`;
+  });
   const trailingMaskStops = Array.from({ length: FOG_SAMPLES + 1 }, (_, index) => {
     const offset = (index / FOG_SAMPLES) * FOG_WIDTH;
     const alphaLoss = smootherstep(index / FOG_SAMPLES);
     return `rgb(0 0 0 / calc(1 - var(--breadcrumb-trailing-fog) * ${alphaLoss})) calc(100% - ${FOG_WIDTH - offset}px)`;
   });
-  const maskImage = `linear-gradient(to right, black 0, ${trailingMaskStops.join(', ')})`;
+  const maskImage = `linear-gradient(to right, ${leadingMaskStops.join(', ')}, black ${FOG_WIDTH}px, black calc(100% - ${FOG_WIDTH}px), ${trailingMaskStops.join(', ')})`;
 
   function updateOverflow() {
     if (!viewport) return;
     const maximum = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
+    overflowLeading = viewport.scrollLeft > AT_END_EPSILON;
     overflowTrailing = viewport.scrollLeft < maximum - AT_END_EPSILON;
   }
 
@@ -145,12 +152,14 @@
     bind:this={viewport}
     id={viewportId}
     style:mask-image={maskImage}
+    style:--breadcrumb-leading-fog={overflowLeading ? 1 : 0}
     style:--breadcrumb-trailing-fog={overflowTrailing ? 1 : 0}
     style:transition={fogTransitionReady && !prefersReducedMotion.current
-      ? `--breadcrumb-trailing-fog ${FOG_TRANSITION_MS}ms ease-out`
+      ? `--breadcrumb-leading-fog ${FOG_TRANSITION_MS}ms ease-out, --breadcrumb-trailing-fog ${FOG_TRANSITION_MS}ms ease-out`
       : 'none'}
     class={css({ width: 'full', minWidth: '0', overflowX: 'auto', overflowY: 'hidden', scrollbarWidth: 'none' })}
     data-breadcrumb-fog-curve="smootherstep"
+    data-breadcrumb-fog-leading={overflowLeading}
     data-breadcrumb-fog-trailing={overflowTrailing}
     data-editor-breadcrumb-viewport
     onscroll={updateOverflow}
@@ -164,6 +173,12 @@
 </div>
 
 <style>
+  @property --breadcrumb-leading-fog {
+    syntax: '<number>';
+    inherits: false;
+    initial-value: 0;
+  }
+
   @property --breadcrumb-trailing-fog {
     syntax: '<number>';
     inherits: false;

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorContextBar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorContextBar.svelte
@@ -2,24 +2,27 @@
   import { css } from '@typie/styled-system/css';
   import { token } from '@typie/styled-system/tokens';
   import { hoverIntent } from '@typie/ui/actions';
+  import { VerticalDivider } from '@typie/ui/components';
   import { prefersReducedMotion } from '@typie/ui/state';
+  import { untrack } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
   import {
     CONTEXT_BAR_FADE_IN_MS,
     CONTEXT_BAR_FADE_OUT_MS,
     CONTEXT_BAR_TRANSIENT_VISIBLE_MS,
     ContextBarVisibilityCoordinator,
-    EditorContextBarSegmentState,
     smootherstep,
   } from './editor-context-bar.svelte';
+  import EditorContextBarPinControl from './EditorContextBarPinControl.svelte';
   import EditorContextBarSegment from './EditorContextBarSegment.svelte';
+  import { TransientVisibilityState } from './transient-visibility.svelte';
   import type { HoverIntentParameter } from '@typie/ui/actions';
   import type { Snippet } from 'svelte';
   import type { ActionReturn } from 'svelte/action';
   import type { ContextBarPresentation, ContextBarSegmentPresentation } from './editor-context-bar.svelte';
 
   export type EditorContextBarSegmentRenderProps = {
-    state: EditorContextBarSegmentState;
+    state: TransientVisibilityState;
     presentation: ContextBarSegmentPresentation;
   };
 
@@ -29,6 +32,9 @@
     breadcrumb?: Snippet<[EditorContextBarSegmentRenderProps]>;
     viewControls: Snippet<[EditorContextBarSegmentRenderProps]>;
     interactiveViewControlsWhenHidden?: boolean;
+    pinned?: boolean;
+    onTopOcclusionChange?: (topOcclusion: number) => void;
+    onPinnedChange?: (pinned: boolean) => void;
   };
 
   type SegmentGeometry = {
@@ -42,7 +48,7 @@
   type LanePoint = { x: number; y: number };
 
   type LaneHoverPhase = 'idle' | 'pending' | 'preview' | 'spot' | 'expanding' | 'held';
-  type ContextBarSegmentId = 'breadcrumb' | 'viewControls';
+  type ContextBarSegmentId = 'leading' | 'viewControls';
 
   const FADE_WIDTH = 24;
   const LANE_HOVER_INTENT_DELAY_MS = 400;
@@ -50,18 +56,28 @@
   const LANE_SPOT_DWELL_MS = 500;
   const LANE_SPOT_ENTER_MS = 500;
   const LANE_SPOT_SURFACE_TRANSITION_MS = 600;
-  const LANE_SPOT_EXPAND_MS = 1000;
+  const LANE_BACKGROUND_EXPAND_MS = 900;
+  const LANE_EXPANSION_TOTAL_MS = 1000;
+  const LANE_FOREGROUND_REVEAL_DELAY_MS = 100;
+  const LANE_FOREGROUND_REVEAL_MS = 900;
   const LANE_SPOT_RADIUS = 88;
+  const LANE_ENGAGED_SPOT_RADIUS = 52;
+  const LANE_ENGAGED_SPOT_STRENGTH = 0.85;
+  const LANE_ENGAGED_SPOT_ENTER_DELAY_MS = 500;
   const LANE_SPOT_MASK_INSET = 8;
   const LANE_SPOT_EDGE_WIDTH = 48;
   const LANE_SPOT_SURFACE_STRENGTH = 0.7;
   const LANE_SPOT_EXPANSION_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)';
   const LANE_HOLD_REASON = 'lane-hover';
-  const ACTIVE_SURFACE = token('colors.surface.muted');
-  const TRANSIENT_BASE = token('colors.surface.subtle');
+  const PIN_HOLD_REASON = 'pinned';
+  const MUTED_SURFACE = token('colors.surface.muted');
+  const CONTINUOUS_SURFACE = token('colors.surface.default');
+  const PAGINATED_SURFACE = token('colors.surface.subtle');
+  const TRANSIENT_BASE = `color-mix(in srgb, ${CONTINUOUS_SURFACE} 50%, ${PAGINATED_SURFACE} 50%)`;
+  const ACTIVE_SURFACE = `color-mix(in srgb, ${MUTED_SURFACE} 80%, ${TRANSIENT_BASE} 20%)`;
   const SUBTLE_BORDER = token('colors.border.subtle');
   const DEFAULT_BORDER = token('colors.border.default');
-  const TRANSIENT_SURFACE = `color-mix(in srgb, ${TRANSIENT_BASE} 80%, transparent)`;
+  const TRANSIENT_SURFACE = `color-mix(in srgb, ${TRANSIENT_BASE} 75%, transparent)`;
   const TRANSIENT_EDGE = `color-mix(in srgb, ${TRANSIENT_BASE} 40%, ${SUBTLE_BORDER} 60%)`;
   const ENGAGED_EDGE = `color-mix(in srgb, ${ACTIVE_SURFACE} 36%, ${DEFAULT_BORDER} 64%)`;
 
@@ -71,27 +87,35 @@
     breadcrumb,
     viewControls,
     interactiveViewControlsWhenHidden = false,
+    pinned = false,
+    onTopOcclusionChange,
+    onPinnedChange,
   }: Props = $props();
 
-  const breadcrumbState = new EditorContextBarSegmentState();
-  const viewControlsState = new EditorContextBarSegmentState();
+  const leadingState = new TransientVisibilityState();
+  const viewControlsState = new TransientVisibilityState();
   const visibilityCoordinator = new ContextBarVisibilityCoordinator();
   let lane = $state<HTMLElement>();
-  let breadcrumbElement = $state<HTMLElement>();
+  let leadingElement = $state<HTMLElement>();
   let viewControlsElement = $state<HTMLElement>();
-  let breadcrumbGeometry = $state<SegmentGeometry>();
+  let leadingGeometry = $state<SegmentGeometry>();
   let viewControlsGeometry = $state<SegmentGeometry>();
   let laneWidth = $state(0);
   let laneHeight = $state(0);
   let laneHoverPhase = $state<LaneHoverPhase>('idle');
+  let pointerInLane = $state(false);
   let pointerInLaneGap = $state(false);
   let lanePointerX = $state(0);
   let lanePointerY = $state(0);
+  let laneExpansionOriginX = $state(0);
+  let laneExpansionOriginY = $state(0);
+  let laneForegroundRevealStarted = $state(false);
   let laneExpansionMaskedSegments = $state<ContextBarSegmentId[]>([]);
   let fadingTransientSegments = $state<ContextBarSegmentId[]>([]);
   let transientExitPresentation = $state<ContextBarPresentation>();
   let laneHoverIntent: ActionReturn<HoverIntentParameter> | undefined;
   let laneDwellTimer: ReturnType<typeof setTimeout> | undefined;
+  let laneForegroundRevealTimer: ReturnType<typeof setTimeout> | undefined;
   let laneExpansionTimer: ReturnType<typeof setTimeout> | undefined;
   let hiddenSegmentIntentTimer: ReturnType<typeof setTimeout> | undefined;
   let hiddenSegmentIntentTarget: ContextBarSegmentId | undefined;
@@ -99,10 +123,11 @@
   let transientExitTimer: ReturnType<typeof setTimeout> | undefined;
   const fadingTransientTimers = new SvelteMap<ContextBarSegmentId, ReturnType<typeof setTimeout>>();
   let initialRevealComplete = false;
+  let previousPinned: boolean | undefined;
 
   let presentation = $state<ContextBarPresentation>({
     unified: false,
-    breadcrumb: { visible: false, tone: 'transient' },
+    leading: { visible: false, tone: 'transient' },
     viewControls: { visible: false, tone: 'transient' },
   });
   let previousPresentation = presentation;
@@ -111,10 +136,16 @@
   const unifiedPairVisible = $derived(presentation.unified);
   const unifiedSurfaceVisible = $derived(unifiedPairVisible && laneHoverPhase !== 'expanding');
   const laneSpotVisible = $derived(laneHoverPhase === 'preview' || laneHoverPhase === 'spot' || laneHoverPhase === 'expanding');
+  const hasEngagedSegment = $derived(
+    (presentation.leading.visible && presentation.leading.tone === 'engaged') ||
+      (presentation.viewControls.visible && presentation.viewControls.tone === 'engaged'),
+  );
+  const laneEngagedSpotVisible = $derived(pointerInLane && (laneSpotVisible || laneHoverPhase === 'held' || hasEngagedSegment));
   const laneSpotSurfaceStrength = $derived(
     laneHoverPhase === 'expanding' ? 1 : laneHoverPhase === 'preview' || laneHoverPhase === 'spot' ? LANE_SPOT_SURFACE_STRENGTH : 0,
   );
   const laneSpotOpacityTransitionMs = $derived(unifiedSurfaceVisible ? 0 : LANE_SPOT_ENTER_MS);
+  const laneEngagedSpotEnterDelayMs = $derived(pinned ? 0 : LANE_ENGAGED_SPOT_ENTER_DELAY_MS);
   const laneSpotSurfaceTransitionMs = $derived(
     unifiedSurfaceVisible
       ? 0
@@ -124,29 +155,32 @@
           ? LANE_SPOT_ENTER_MS
           : CONTEXT_BAR_FADE_OUT_MS,
   );
-  const laneSpotRadius = $derived(
-    laneHoverPhase === 'expanding' ? Math.hypot(laneWidth, laneHeight) + FADE_WIDTH + LANE_SPOT_MASK_INSET : LANE_SPOT_RADIUS,
-  );
+  const laneExpansionRadius = $derived(Math.hypot(laneWidth, laneHeight) + FADE_WIDTH + LANE_SPOT_MASK_INSET);
+  const laneSpotRadius = $derived(laneHoverPhase === 'expanding' ? laneExpansionRadius : LANE_SPOT_RADIUS);
+  const laneForegroundRevealRadius = $derived(laneForegroundRevealStarted ? laneExpansionRadius : LANE_SPOT_RADIUS);
+  const laneTransientSpotX = $derived(laneHoverPhase === 'expanding' ? laneExpansionOriginX : lanePointerX);
+  const laneTransientSpotY = $derived(laneHoverPhase === 'expanding' ? laneExpansionOriginY : lanePointerY);
   const laneBlurMask = $derived.by(() => laneBlurMasks().join(', '));
   const laneSurfaceMask = $derived.by(() => laneSurfaceMasks().join(', '));
   const laneSurfaceMaskComposite = $derived(laneHoverPhase === 'preview' && fadingTransientSegments.length === 0 ? 'intersect' : 'add');
   const laneBlurVisible = $derived(
     laneSpotVisible ||
       fadingTransientSegments.length > 0 ||
-      (unifiedSurfaceVisible && (presentation.breadcrumb.tone === 'transient' || presentation.viewControls.tone === 'transient')) ||
+      (unifiedSurfaceVisible && (presentation.leading.tone === 'transient' || presentation.viewControls.tone === 'transient')) ||
       (!unifiedPairVisible &&
-        ((presentation.breadcrumb.visible && presentation.breadcrumb.tone === 'transient') ||
+        ((presentation.leading.visible && presentation.leading.tone === 'transient') ||
           (presentation.viewControls.visible && presentation.viewControls.tone === 'transient'))),
   );
-  const hasVisibleSegment = $derived(presentation.breadcrumb.visible || presentation.viewControls.visible);
+  const hasVisibleSegment = $derived(presentation.leading.visible || presentation.viewControls.visible);
+  const topOcclusion = $derived(hasVisibleSegment || laneSpotVisible || transientExitPresentation ? laneHeight : 0);
   const laneBlurRadius = $derived.by(() => {
     if (!laneBlurVisible) return 0;
     if (!hasVisibleSegment && (laneHoverPhase === 'preview' || laneHoverPhase === 'spot')) return 1.5;
-    return 3;
+    return 2;
   });
   const laneBlurTransitionMs = $derived(
     laneHoverPhase === 'expanding'
-      ? LANE_SPOT_EXPAND_MS
+      ? LANE_BACKGROUND_EXPAND_MS
       : laneHoverPhase === 'preview' || laneHoverPhase === 'spot'
         ? LANE_SPOT_ENTER_MS
         : transientExitPresentation
@@ -174,41 +208,54 @@
     return `linear-gradient(to right, ${samples.join(', ')})`;
   }
 
-  function radialMask(x: number, y: number, opacityVariable = '--context-bar-lane-spot-opacity'): string {
+  function radialMask(
+    x: number,
+    y: number,
+    radiusVariable = '--context-bar-lane-spot-radius',
+    opacityVariable = '--context-bar-lane-spot-opacity',
+  ): string {
     const edgeStops = Array.from({ length: 9 }, (_, index) => {
       const progress = index / 8;
       const alpha = 1 - smootherstep(progress);
-      return `rgb(0 0 0 / calc(${alpha} * var(${opacityVariable}))) calc(var(--context-bar-lane-spot-radius) - ${LANE_SPOT_MASK_INSET + LANE_SPOT_EDGE_WIDTH * (1 - progress)}px)`;
+      return `rgb(0 0 0 / calc(${alpha} * var(${opacityVariable}))) calc(var(${radiusVariable}) - ${LANE_SPOT_MASK_INSET + LANE_SPOT_EDGE_WIDTH * (1 - progress)}px)`;
     });
-    return `radial-gradient(circle at ${x}px ${y}px, rgb(0 0 0 / var(${opacityVariable})) 0, rgb(0 0 0 / var(${opacityVariable})) calc(var(--context-bar-lane-spot-radius) - ${LANE_SPOT_MASK_INSET + LANE_SPOT_EDGE_WIDTH}px), ${edgeStops.join(', ')})`;
+    return `radial-gradient(circle at ${x}px ${y}px, rgb(0 0 0 / var(${opacityVariable})) 0, rgb(0 0 0 / var(${opacityVariable})) calc(var(${radiusVariable}) - ${LANE_SPOT_MASK_INSET + LANE_SPOT_EDGE_WIDTH}px), ${edgeStops.join(', ')})`;
   }
 
   function laneSpotMask(opacityVariable: string): string {
-    return radialMask(lanePointerX, lanePointerY, opacityVariable);
+    return radialMask(laneTransientSpotX, laneTransientSpotY, '--context-bar-lane-spot-radius', opacityVariable);
+  }
+
+  function engagedSpotMask(): string {
+    const stops = Array.from({ length: 9 }, (_, index) => {
+      const progress = index / 8;
+      return `rgb(0 0 0 / ${LANE_ENGAGED_SPOT_STRENGTH * (1 - smootherstep(progress))}) ${LANE_ENGAGED_SPOT_RADIUS * progress}px`;
+    });
+    return `radial-gradient(circle at ${lanePointerX}px ${lanePointerY}px, ${stops.join(', ')})`;
   }
 
   function unifiedTransientMask(): string {
-    if (!breadcrumbGeometry || !viewControlsGeometry) return 'linear-gradient(transparent, transparent)';
+    if (!leadingGeometry || !viewControlsGeometry) return 'linear-gradient(transparent, transparent)';
     const hasTransientSegment =
-      surfaceMaskPresentation.breadcrumb.tone === 'transient' ||
+      surfaceMaskPresentation.leading.tone === 'transient' ||
       surfaceMaskPresentation.viewControls.tone === 'transient' ||
       fadingTransientSegments.length > 0;
     if (hasTransientSegment) return 'linear-gradient(black, black)';
 
-    const breadcrumbEngaged = surfaceMaskPresentation.breadcrumb.tone === 'engaged' && !fadingTransientSegments.includes('breadcrumb');
+    const leadingEngaged = surfaceMaskPresentation.leading.tone === 'engaged' && !fadingTransientSegments.includes('leading');
     const viewControlsEngaged =
       surfaceMaskPresentation.viewControls.tone === 'engaged' && !fadingTransientSegments.includes('viewControls');
-    if (!breadcrumbEngaged && !viewControlsEngaged) return 'linear-gradient(black, black)';
+    if (!leadingEngaged && !viewControlsEngaged) return 'linear-gradient(black, black)';
 
-    const width = viewControlsGeometry.right - breadcrumbGeometry.left;
-    const breadcrumbRight = breadcrumbGeometry.right - breadcrumbGeometry.left;
-    const viewControlsLeft = viewControlsGeometry.left - breadcrumbGeometry.left;
+    const width = viewControlsGeometry.right - leadingGeometry.left;
+    const leadingRight = leadingGeometry.right - leadingGeometry.left;
+    const viewControlsLeft = viewControlsGeometry.left - leadingGeometry.left;
     const positions = [0, width];
     const addPosition = (position: number) => {
       if (!positions.includes(position)) positions.push(position);
     };
-    if (breadcrumbEngaged) {
-      for (let index = 0; index <= 8; index += 1) addPosition(Math.min(width, breadcrumbRight + (FADE_WIDTH * index) / 8));
+    if (leadingEngaged) {
+      for (let index = 0; index <= 8; index += 1) addPosition(Math.min(width, leadingRight + (FADE_WIDTH * index) / 8));
     }
     if (viewControlsEngaged) {
       for (let index = 0; index <= 8; index += 1) addPosition(Math.max(0, viewControlsLeft - FADE_WIDTH + (FADE_WIDTH * index) / 8));
@@ -217,15 +264,15 @@
     const stops = positions
       .toSorted((left, right) => left - right)
       .map((position) => {
-        const breadcrumbAlpha = breadcrumbEngaged ? smootherstep((position - breadcrumbRight) / FADE_WIDTH) : 1;
+        const leadingAlpha = leadingEngaged ? smootherstep((position - leadingRight) / FADE_WIDTH) : 1;
         const viewControlsAlpha = viewControlsEngaged ? 1 - smootherstep((position - (viewControlsLeft - FADE_WIDTH)) / FADE_WIDTH) : 1;
-        return `rgb(0 0 0 / ${Math.min(breadcrumbAlpha, viewControlsAlpha)}) ${position}px`;
+        return `rgb(0 0 0 / ${Math.min(leadingAlpha, viewControlsAlpha)}) ${position}px`;
       });
     return `linear-gradient(to right, ${stops.join(', ')})`;
   }
 
   function segmentLaneMask(segment: ContextBarSegmentId, transientOnly: boolean): string | undefined {
-    const geometry = segment === 'breadcrumb' ? breadcrumbGeometry : viewControlsGeometry;
+    const geometry = segment === 'leading' ? leadingGeometry : viewControlsGeometry;
     const segmentPresentation = surfaceMaskPresentation[segment];
     if (
       !geometry ||
@@ -238,17 +285,17 @@
 
     const samples = Array.from({ length: 9 }, (_, index) => {
       const progress = index / 8;
-      const alpha = segment === 'breadcrumb' ? 1 - smootherstep(progress) : smootherstep(progress);
-      const position = segment === 'breadcrumb' ? geometry.right + FADE_WIDTH * progress : geometry.left - FADE_WIDTH * (1 - progress);
+      const alpha = segment === 'leading' ? 1 - smootherstep(progress) : smootherstep(progress);
+      const position = segment === 'leading' ? geometry.right + FADE_WIDTH * progress : geometry.left - FADE_WIDTH * (1 - progress);
       return `rgb(0 0 0 / ${alpha}) ${position}px`;
     });
-    if (segment === 'breadcrumb') samples.push('transparent 100%');
+    if (segment === 'leading') samples.push('transparent 100%');
     else samples.unshift('transparent 0');
     return `linear-gradient(to right, ${samples.join(', ')})`;
   }
 
   function loneEngagedSegment(): ContextBarSegmentId | undefined {
-    const visibleSegments = (['breadcrumb', 'viewControls'] as const).filter((segment) => presentation[segment].visible);
+    const visibleSegments = (['leading', 'viewControls'] as const).filter((segment) => presentation[segment].visible);
     const segment = visibleSegments.length === 1 ? visibleSegments[0] : undefined;
     if (!segment) return;
     const state = segmentState(segment);
@@ -256,15 +303,15 @@
   }
 
   function outsideEngagedSegmentMask(segment: ContextBarSegmentId): string {
-    const geometry = segment === 'breadcrumb' ? breadcrumbGeometry : viewControlsGeometry;
+    const geometry = segment === 'leading' ? leadingGeometry : viewControlsGeometry;
     if (!geometry) return 'linear-gradient(transparent, transparent)';
     const samples = Array.from({ length: 9 }, (_, index) => {
       const progress = index / 8;
-      const alpha = segment === 'breadcrumb' ? smootherstep(progress) : 1 - smootherstep(progress);
-      const position = segment === 'breadcrumb' ? geometry.right + FADE_WIDTH * progress : geometry.left - FADE_WIDTH * (1 - progress);
+      const alpha = segment === 'leading' ? smootherstep(progress) : 1 - smootherstep(progress);
+      const position = segment === 'leading' ? geometry.right + FADE_WIDTH * progress : geometry.left - FADE_WIDTH * (1 - progress);
       return `rgb(0 0 0 / ${alpha}) ${position}px`;
     });
-    if (segment === 'breadcrumb') samples.push('black 100%');
+    if (segment === 'leading') samples.push('black 100%');
     else samples.unshift('black 0');
     return `linear-gradient(to right, ${samples.join(', ')})`;
   }
@@ -272,7 +319,7 @@
   function laneBlurMasks(): string[] {
     const masks = [laneSpotMask('--context-bar-lane-spot-opacity')];
     const hasTransientSegment =
-      surfaceMaskPresentation.breadcrumb.tone === 'transient' ||
+      surfaceMaskPresentation.leading.tone === 'transient' ||
       surfaceMaskPresentation.viewControls.tone === 'transient' ||
       fadingTransientSegments.length > 0;
     if (unifiedSurfaceVisible || transientExitPresentation?.unified) {
@@ -281,9 +328,9 @@
     }
 
     const includeEngagedSegments = laneSpotVisible;
-    const breadcrumbMask = segmentLaneMask('breadcrumb', !includeEngagedSegments);
+    const leadingMask = segmentLaneMask('leading', !includeEngagedSegments);
     const viewControlsMask = segmentLaneMask('viewControls', !includeEngagedSegments);
-    if (breadcrumbMask) masks.push(breadcrumbMask);
+    if (leadingMask) masks.push(leadingMask);
     if (viewControlsMask) masks.push(viewControlsMask);
     return masks;
   }
@@ -300,16 +347,21 @@
       masks.push(unifiedTransientMask());
       return masks;
     }
-    const breadcrumbMask = segmentLaneMask('breadcrumb', true);
+    const leadingMask = segmentLaneMask('leading', true);
     const viewControlsMask = segmentLaneMask('viewControls', true);
-    if (breadcrumbMask) masks.push(breadcrumbMask);
+    if (leadingMask) masks.push(leadingMask);
     if (viewControlsMask) masks.push(viewControlsMask);
     return masks;
   }
 
   function segmentRevealMask(segment: ContextBarSegmentId, geometry: SegmentGeometry | undefined): string {
     if (!geometry || laneHoverPhase !== 'expanding' || !laneExpansionMaskedSegments.includes(segment)) return 'none';
-    return radialMask(lanePointerX - geometry.left, lanePointerY);
+    return radialMask(
+      laneExpansionOriginX - geometry.left,
+      laneExpansionOriginY,
+      '--context-bar-segment-reveal-radius',
+      '--context-bar-segment-reveal-opacity',
+    );
   }
 
   function syncGeometry(): void {
@@ -327,12 +379,12 @@
         width: rect.width,
       };
     };
-    breadcrumbGeometry = breadcrumbElement ? relativeGeometry(breadcrumbElement) : undefined;
+    leadingGeometry = leadingElement ? relativeGeometry(leadingElement) : undefined;
     viewControlsGeometry = relativeGeometry(viewControlsElement);
   }
 
-  function segmentState(segment: ContextBarSegmentId): EditorContextBarSegmentState {
-    return segment === 'breadcrumb' ? breadcrumbState : viewControlsState;
+  function segmentState(segment: ContextBarSegmentId): TransientVisibilityState {
+    return segment === 'leading' ? leadingState : viewControlsState;
   }
 
   function clearHiddenSegmentIntent(): void {
@@ -406,7 +458,7 @@
   }
 
   function segmentAtPoint(point: LanePoint): ContextBarSegmentId | undefined {
-    if (geometryContainsPoint(breadcrumbGeometry, point)) return 'breadcrumb';
+    if (geometryContainsPoint(leadingGeometry, point)) return 'leading';
     if (geometryContainsPoint(viewControlsGeometry, point)) return 'viewControls';
   }
 
@@ -427,31 +479,50 @@
 
   function clearLaneTimers(): void {
     clearTimeout(laneDwellTimer);
+    clearTimeout(laneForegroundRevealTimer);
     clearTimeout(laneExpansionTimer);
     setLaneHoverIntentEnabled(false);
     laneDwellTimer = undefined;
+    laneForegroundRevealTimer = undefined;
     laneExpansionTimer = undefined;
+    laneForegroundRevealStarted = false;
   }
 
   function holdLane(): void {
     clearLaneTimers();
     laneHoverPhase = 'held';
     laneExpansionMaskedSegments = [];
-    breadcrumbState.hold(LANE_HOLD_REASON);
+    leadingState.hold(LANE_HOLD_REASON);
     viewControlsState.hold(LANE_HOLD_REASON);
   }
 
-  function stopLaneInteraction(linger: boolean): void {
+  function stopLaneInteraction(linger: boolean, pointerStillInLane = false): void {
     const wasHeld = laneHoverPhase === 'held';
+    pointerInLane = pointerStillInLane;
     pointerInLaneGap = false;
     clearLaneTimers();
     laneHoverPhase = 'idle';
     laneExpansionMaskedSegments = [];
-    breadcrumbState.release(LANE_HOLD_REASON);
+    leadingState.release(LANE_HOLD_REASON);
     viewControlsState.release(LANE_HOLD_REASON);
     if (!wasHeld || !linger) return;
-    breadcrumbState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+    leadingState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
     viewControlsState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+  }
+
+  function settlePinnedPresentation(): void {
+    clearHiddenSegmentIntent();
+    releaseHiddenSegmentHover();
+    clearLaneTimers();
+    clearFadingTransientSegments();
+    clearTransientSurfaceExit();
+    laneHoverPhase = 'idle';
+    pointerInLaneGap = false;
+    laneExpansionMaskedSegments = [];
+    leadingState.release(LANE_HOLD_REASON);
+    viewControlsState.release(LANE_HOLD_REASON);
+    leadingState.hold(PIN_HOLD_REASON);
+    viewControlsState.hold(PIN_HOLD_REASON);
   }
 
   function startLaneSpot(): void {
@@ -475,14 +546,25 @@
   }
 
   function startLaneExpansion(): void {
-    laneExpansionMaskedSegments = (['breadcrumb', 'viewControls'] as const).filter((segment) => !presentation[segment].visible);
+    clearLaneTimers();
+    if (prefersReducedMotion.current) {
+      holdLane();
+      return;
+    }
+    laneExpansionOriginX = lanePointerX;
+    laneExpansionOriginY = lanePointerY;
+    laneExpansionMaskedSegments = (['leading', 'viewControls'] as const).filter((segment) => !presentation[segment].visible);
     laneHoverPhase = 'expanding';
-    breadcrumbState.hold(LANE_HOLD_REASON);
+    leadingState.hold(LANE_HOLD_REASON);
     viewControlsState.hold(LANE_HOLD_REASON);
+    laneForegroundRevealTimer = setTimeout(() => {
+      laneForegroundRevealTimer = undefined;
+      laneForegroundRevealStarted = true;
+    }, LANE_FOREGROUND_REVEAL_DELAY_MS);
     laneExpansionTimer = setTimeout(() => {
       laneExpansionTimer = undefined;
       holdLane();
-    }, LANE_SPOT_EXPAND_MS);
+    }, LANE_EXPANSION_TOTAL_MS);
   }
 
   function startLaneIntent(): void {
@@ -501,12 +583,12 @@
   }
 
   function isLaneGap(point: LanePoint): boolean {
-    if (!breadcrumbGeometry || !viewControlsGeometry || viewControlsGeometry.left <= breadcrumbGeometry.right) return false;
-    return point.x > breadcrumbGeometry.right && point.x < viewControlsGeometry.left;
+    if (!leadingGeometry || !viewControlsGeometry || viewControlsGeometry.left <= leadingGeometry.right) return false;
+    return point.x > leadingGeometry.right && point.x < viewControlsGeometry.left;
   }
 
   function handlePanePointerMove(event: PointerEvent): void {
-    if (!breadcrumbElement || event.pointerType === 'touch') {
+    if (!leadingElement || event.pointerType === 'touch') {
       stopLaneInteraction(false);
       clearHiddenSegmentIntent();
       releaseHiddenSegmentHover();
@@ -521,10 +603,12 @@
       return;
     }
 
+    pointerInLane = true;
+    lanePointerX = point.x;
+    lanePointerY = point.y;
+
     if (isLaneGap(point)) {
       pointerInLaneGap = true;
-      lanePointerX = point.x;
-      lanePointerY = point.y;
       clearHiddenSegmentIntent();
       releaseHiddenSegmentHover();
 
@@ -538,7 +622,7 @@
       if (laneHoverPhase === 'held' || presentation.unified) {
         holdLane();
       } else if (laneHoverPhase === 'idle') {
-        if (presentation.breadcrumb.visible || presentation.viewControls.visible) startLaneSpot();
+        if (presentation.leading.visible || presentation.viewControls.visible) startLaneSpot();
         else startLaneIntent();
       }
       return;
@@ -547,13 +631,25 @@
     const segment = segmentAtPoint(point);
     if (segment && loneEngagedSegment() === segment) {
       pointerInLaneGap = false;
-      lanePointerX = point.x;
-      lanePointerY = point.y;
       if (laneHoverPhase !== 'preview') startLanePreview();
       return;
     }
 
-    stopLaneInteraction(true);
+    if (segment && (laneHoverPhase === 'spot' || laneHoverPhase === 'expanding' || laneHoverPhase === 'held')) {
+      pointerInLaneGap = false;
+      if (hiddenSegmentEngaged === segment) return;
+      if (hiddenSegmentEngaged) releaseHiddenSegmentHover();
+      if (presentation[segment].visible) {
+        clearHiddenSegmentIntent();
+        return;
+      }
+
+      const sibling: ContextBarSegmentId = segment === 'leading' ? 'viewControls' : 'leading';
+      if (presentation[sibling].visible) engageHiddenSegment(segment);
+      return;
+    }
+
+    stopLaneInteraction(true, true);
     if (!segment) {
       clearHiddenSegmentIntent();
       releaseHiddenSegmentHover();
@@ -568,7 +664,7 @@
       return;
     }
 
-    const sibling: ContextBarSegmentId = segment === 'breadcrumb' ? 'viewControls' : 'breadcrumb';
+    const sibling: ContextBarSegmentId = segment === 'leading' ? 'viewControls' : 'leading';
     if (presentation[sibling].visible) {
       engageHiddenSegment(segment);
       return;
@@ -591,18 +687,35 @@
   }
 
   $effect(() => {
+    const nextPinned = pinned;
+    untrack(() => {
+      if (nextPinned) {
+        settlePinnedPresentation();
+      } else {
+        leadingState.release(PIN_HOLD_REASON);
+        viewControlsState.release(PIN_HOLD_REASON);
+        if (previousPinned) {
+          leadingState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+          viewControlsState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+        }
+      }
+      previousPinned = nextPinned;
+    });
+  });
+
+  $effect(() => {
     const nextPresentation = visibilityCoordinator.resolve({
-      breadcrumb: breadcrumb ? breadcrumbState.activity : { transient: false, hovered: false, focused: false, holds: [] },
+      leading: leadingState.activity,
       viewControls: viewControlsState.activity,
     });
     const hadTransientSurface =
-      (previousPresentation.breadcrumb.visible && previousPresentation.breadcrumb.tone === 'transient') ||
+      (previousPresentation.leading.visible && previousPresentation.leading.tone === 'transient') ||
       (previousPresentation.viewControls.visible && previousPresentation.viewControls.tone === 'transient');
-    const nextHidden = !nextPresentation.breadcrumb.visible && !nextPresentation.viewControls.visible;
+    const nextHidden = !nextPresentation.leading.visible && !nextPresentation.viewControls.visible;
     if (hadTransientSurface && nextHidden) startTransientSurfaceExit(previousPresentation);
     else if (!nextHidden) clearTransientSurfaceExit();
 
-    for (const segment of ['breadcrumb', 'viewControls'] as const) {
+    for (const segment of ['leading', 'viewControls'] as const) {
       if (
         previousPresentation[segment].visible &&
         previousPresentation[segment].tone === 'transient' &&
@@ -611,6 +724,10 @@
       ) {
         retainTransientDuringEngagement(segment);
       }
+    }
+    if (laneHoverPhase === 'expanding') {
+      const nextMaskedSegments = laneExpansionMaskedSegments.filter((segment) => nextPresentation[segment].tone !== 'engaged');
+      if (nextMaskedSegments.length !== laneExpansionMaskedSegments.length) laneExpansionMaskedSegments = nextMaskedSegments;
     }
     previousPresentation = nextPresentation;
     presentation = nextPresentation;
@@ -621,23 +738,26 @@
   });
 
   $effect(() => {
+    if (laneHoverPhase === 'expanding' && prefersReducedMotion.current) holdLane();
+  });
+
+  $effect(() => {
     const currentLane = lane;
-    const currentBreadcrumb = breadcrumbElement;
+    const currentLeading = leadingElement;
     const currentViewControls = viewControlsElement;
     if (!currentLane || !currentViewControls) return;
     const observer = new ResizeObserver(syncGeometry);
     observer.observe(currentLane);
     observer.observe(currentViewControls);
-    if (currentBreadcrumb) observer.observe(currentBreadcrumb);
+    if (currentLeading) observer.observe(currentLeading);
     syncGeometry();
     return () => observer.disconnect();
   });
 
   $effect(() => {
-    const breadcrumbReady = !breadcrumb || (breadcrumbGeometry?.width ?? 0) > 0;
-    if (initialRevealComplete || !breadcrumbReady || (viewControlsGeometry?.width ?? 0) <= 0) return;
+    if (initialRevealComplete || (leadingGeometry?.width ?? 0) <= 0 || (viewControlsGeometry?.width ?? 0) <= 0) return;
     initialRevealComplete = true;
-    if (breadcrumb) breadcrumbState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+    leadingState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
     viewControlsState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
   });
 
@@ -647,7 +767,7 @@
     laneHoverIntent = currentLaneHoverIntent;
     const handlePointerEnter = (event: PointerEvent) => {
       if (event.pointerType === 'touch') return;
-      if (breadcrumb) breadcrumbState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+      leadingState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
       if (showViewControlsOnPaneEntry) viewControlsState.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
     };
     target.addEventListener('pointerenter', handlePointerEnter);
@@ -663,12 +783,18 @@
   });
 
   $effect(() => {
+    const nextTopOcclusion = topOcclusion;
+    untrack(() => onTopOcclusionChange?.(nextTopOcclusion));
+  });
+
+  $effect(() => {
     return () => {
+      onTopOcclusionChange?.(0);
       clearHiddenSegmentIntent();
       clearFadingTransientSegments();
       clearTransientSurfaceExit();
       stopLaneInteraction(false);
-      breadcrumbState.destroy();
+      leadingState.destroy();
       viewControlsState.destroy();
     };
   });
@@ -681,7 +807,7 @@
   style:--context-bar-lane-spot-radius={`${laneSpotRadius}px`}
   style:transition={prefersReducedMotion.current
     ? 'none'
-    : `--context-bar-lane-spot-opacity ${laneSpotOpacityTransitionMs}ms ease-out, --context-bar-lane-spot-surface-opacity ${laneSpotSurfaceTransitionMs}ms ease-out, --context-bar-lane-spot-radius ${LANE_SPOT_EXPAND_MS}ms ${LANE_SPOT_EXPANSION_EASING}`}
+    : `--context-bar-lane-spot-opacity ${laneSpotOpacityTransitionMs}ms ease-out, --context-bar-lane-spot-surface-opacity ${laneSpotSurfaceTransitionMs}ms ease-out, --context-bar-lane-spot-radius ${LANE_BACKGROUND_EXPAND_MS}ms ${LANE_SPOT_EXPANSION_EASING}`}
   class={css({
     position: 'absolute',
     top: '0',
@@ -723,38 +849,30 @@
     data-context-bar-lane-surface
     data-context-bar-spot-surface-strength={laneSpotSurfaceStrength}
     data-context-bar-spot-visible={laneSpotVisible}
-    data-context-bar-spot-x={lanePointerX}
-    data-context-bar-spot-y={lanePointerY}
+    data-context-bar-spot-x={laneTransientSpotX}
+    data-context-bar-spot-y={laneTransientSpotY}
   >
     <div style:background={TRANSIENT_EDGE} class={css({ position: 'absolute', right: '0', bottom: '0', left: '0', height: '1px' })}></div>
   </div>
 
-  {#if breadcrumb}
-    <div style:mask-image={segmentRevealMask('breadcrumb', breadcrumbGeometry)} class={css({ minWidth: '0', flex: '[0 1 auto]' })}>
-      <EditorContextBarSegment
-        id="breadcrumb"
-        presentation={presentation.breadcrumb}
-        state={breadcrumbState}
-        bind:element={breadcrumbElement}
-      >
-        {@render breadcrumb({ state: breadcrumbState, presentation: presentation.breadcrumb })}
-      </EditorContextBarSegment>
-    </div>
-  {/if}
+  <div
+    style:background={ACTIVE_SURFACE}
+    style:mask-image={engagedSpotMask()}
+    style:opacity={laneEngagedSpotVisible ? '1' : '0'}
+    style:transition={prefersReducedMotion.current
+      ? 'none'
+      : laneEngagedSpotVisible
+        ? `opacity ${LANE_SPOT_ENTER_MS}ms ease-out ${laneEngagedSpotEnterDelayMs}ms`
+        : `opacity ${CONTEXT_BAR_FADE_OUT_MS}ms ease-out`}
+    class={css({ position: 'absolute', inset: '0', zIndex: '[-1]', pointerEvents: 'none' })}
+    aria-hidden="true"
+    data-context-bar-engaged-spot
+    data-context-bar-spot-visible={laneEngagedSpotVisible}
+    data-context-bar-spot-x={lanePointerX}
+    data-context-bar-spot-y={lanePointerY}
+  ></div>
 
-  <div style:mask-image={segmentRevealMask('viewControls', viewControlsGeometry)} class={css({ flex: 'none', marginLeft: 'auto' })}>
-    <EditorContextBarSegment
-      id="view-controls"
-      interactiveWhenHidden={interactiveViewControlsWhenHidden}
-      presentation={presentation.viewControls}
-      state={viewControlsState}
-      bind:element={viewControlsElement}
-    >
-      {@render viewControls({ state: viewControlsState, presentation: presentation.viewControls })}
-    </EditorContextBarSegment>
-  </div>
-
-  {#each [{ id: 'breadcrumb', side: 'leading', geometry: breadcrumbGeometry, presentation: presentation.breadcrumb }, { id: 'view-controls', side: 'trailing', geometry: viewControlsGeometry, presentation: presentation.viewControls }] as surface (surface.id)}
+  {#each [{ id: 'leading', side: 'leading', geometry: leadingGeometry, presentation: presentation.leading }, { id: 'view-controls', side: 'trailing', geometry: viewControlsGeometry, presentation: presentation.viewControls }] as surface (surface.id)}
     {#if surface.geometry}
       {@const leading = surface.side === 'leading'}
       {@const surfaceVisible = surface.presentation.visible && surface.presentation.tone === 'engaged'}
@@ -778,6 +896,50 @@
       </div>
     {/if}
   {/each}
+
+  <div
+    style:--context-bar-segment-reveal-radius={`${laneForegroundRevealRadius}px`}
+    style:--context-bar-segment-reveal-opacity={laneForegroundRevealStarted ? 1 : 0}
+    style:mask-image={segmentRevealMask('leading', leadingGeometry)}
+    style:transition={prefersReducedMotion.current || !laneExpansionMaskedSegments.includes('leading')
+      ? 'none'
+      : `--context-bar-segment-reveal-radius ${LANE_FOREGROUND_REVEAL_MS}ms ${LANE_SPOT_EXPANSION_EASING}`}
+    class={css({ minWidth: '0', flex: '[0 1 auto]' })}
+  >
+    <EditorContextBarSegment id="leading" presentation={presentation.leading} state={leadingState} bind:element={leadingElement}>
+      <div class={css({ display: 'flex', alignItems: 'center', minWidth: '0', height: '32px', paddingLeft: '16px' })}>
+        <EditorContextBarPinControl onToggle={() => onPinnedChange?.(!pinned)} {pinned} />
+        {#if breadcrumb}
+          <span class={css({ display: 'flex', alignItems: 'center', flex: 'none', marginLeft: '8px' })} data-context-bar-pin-divider>
+            <VerticalDivider style={css.raw({ height: '12px' })} />
+          </span>
+          <div class={css({ minWidth: '0', flex: '[0 1 auto]' })}>
+            {@render breadcrumb({ state: leadingState, presentation: presentation.leading })}
+          </div>
+        {/if}
+      </div>
+    </EditorContextBarSegment>
+  </div>
+
+  <div
+    style:--context-bar-segment-reveal-radius={`${laneForegroundRevealRadius}px`}
+    style:--context-bar-segment-reveal-opacity={laneForegroundRevealStarted ? 1 : 0}
+    style:mask-image={segmentRevealMask('viewControls', viewControlsGeometry)}
+    style:transition={prefersReducedMotion.current || !laneExpansionMaskedSegments.includes('viewControls')
+      ? 'none'
+      : `--context-bar-segment-reveal-radius ${LANE_FOREGROUND_REVEAL_MS}ms ${LANE_SPOT_EXPANSION_EASING}`}
+    class={css({ flex: 'none', marginLeft: 'auto' })}
+  >
+    <EditorContextBarSegment
+      id="view-controls"
+      interactiveWhenHidden={interactiveViewControlsWhenHidden}
+      presentation={presentation.viewControls}
+      state={viewControlsState}
+      bind:element={viewControlsElement}
+    >
+      {@render viewControls({ state: viewControlsState, presentation: presentation.viewControls })}
+    </EditorContextBarSegment>
+  </div>
 </div>
 
 <style>
@@ -794,6 +956,18 @@
   }
 
   @property --context-bar-lane-spot-surface-opacity {
+    syntax: '<number>';
+    inherits: true;
+    initial-value: 0;
+  }
+
+  @property --context-bar-segment-reveal-radius {
+    syntax: '<length>';
+    inherits: true;
+    initial-value: 88px;
+  }
+
+  @property --context-bar-segment-reveal-opacity {
     syntax: '<number>';
     inherits: true;
     initial-value: 0;

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorContextBarPinControl.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorContextBarPinControl.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { tooltip } from '@typie/ui/actions';
+  import { Icon } from '@typie/ui/components';
+  import PinIcon from '~icons/lucide/pin';
+
+  type Props = {
+    pinned: boolean;
+    onToggle: () => unknown;
+  };
+
+  let { pinned, onToggle }: Props = $props();
+  const tooltipLabel = $derived(pinned ? '고정 해제하기' : '고정하기');
+  const accessibleLabel = $derived(pinned ? '문서 경로 및 보기 도구 고정 해제' : '문서 경로 및 보기 도구 고정');
+</script>
+
+<button
+  class={css({
+    display: 'grid',
+    placeItems: 'center',
+    flex: 'none',
+    size: '24px',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    _supportHover: { backgroundColor: 'interactive.hover', color: 'text.default' },
+    _focusVisible: { outline: '2px solid token(colors.border.focus)', outlineOffset: '-2px' },
+  })}
+  aria-label={accessibleLabel}
+  aria-pressed={pinned}
+  data-context-bar-pin
+  onclick={onToggle}
+  onpointerdown={(event) => event.preventDefault()}
+  type="button"
+  use:tooltip={{ message: tooltipLabel, placement: 'bottom' }}
+>
+  <span style:transform={pinned ? 'rotate(0deg)' : 'rotate(45deg)'} class={css({ display: 'grid', placeItems: 'center' })}>
+    <Icon icon={PinIcon} size={14} />
+  </span>
+</button>

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorContextBarSegment.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorContextBarSegment.svelte
@@ -5,11 +5,12 @@
   import { prefersReducedMotion } from '@typie/ui/state';
   import { CONTEXT_BAR_FADE_IN_MS, CONTEXT_BAR_FADE_OUT_MS, CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from './editor-context-bar.svelte';
   import type { Snippet } from 'svelte';
-  import type { ContextBarSegmentPresentation, EditorContextBarSegmentState } from './editor-context-bar.svelte';
+  import type { ContextBarSegmentPresentation } from './editor-context-bar.svelte';
+  import type { TransientVisibilityState } from './transient-visibility.svelte';
 
   type Props = {
-    id: 'breadcrumb' | 'view-controls';
-    state: EditorContextBarSegmentState;
+    id: 'leading' | 'view-controls';
+    state: TransientVisibilityState;
     presentation: ContextBarSegmentPresentation;
     interactiveWhenHidden?: boolean;
     element?: HTMLElement;

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorFocusModeControl.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorFocusModeControl.svelte
@@ -5,11 +5,11 @@
   import Maximize2Icon from '~icons/lucide/maximize-2';
   import Minimize2Icon from '~icons/lucide/minimize-2';
   import { CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from './editor-context-bar.svelte';
-  import type { EditorContextBarSegmentState } from './editor-context-bar.svelte';
+  import type { TransientVisibilityState } from './transient-visibility.svelte';
 
   type Props = {
     enabled: boolean;
-    segment: EditorContextBarSegmentState;
+    segment: TransientVisibilityState;
     visible: boolean;
     onToggle: () => unknown;
   };

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorZoomControls.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorZoomControls.svelte
@@ -15,7 +15,7 @@
   import { zoomDiffers } from '$lib/editor-ffi/zoom';
   import { CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from './editor-context-bar.svelte';
   import type { DocumentZoomLandmark } from '$lib/editor-ffi/zoom';
-  import type { EditorContextBarSegmentState } from './editor-context-bar.svelte';
+  import type { TransientVisibilityState } from './transient-visibility.svelte';
 
   export type EditorZoomControlsProps = {
     enabled: boolean;
@@ -27,14 +27,15 @@
     toggleTargetLandmark: DocumentZoomLandmark | null;
     boundaryAttemptRequest?: number;
     boundaryAttemptLandmark?: DocumentZoomLandmark | null;
-    segment: EditorContextBarSegmentState;
+    visibility: TransientVisibilityState;
     visible: boolean;
+    keyboardDiscoverableWhenHidden?: boolean;
     onZoomOut: () => unknown | Promise<unknown>;
     onZoomIn: () => unknown | Promise<unknown>;
     onToggleZoom: () => unknown | Promise<unknown>;
   };
 
-  export type EditorZoomControlsRenderProps = Omit<EditorZoomControlsProps, 'segment' | 'visible'>;
+  export type EditorZoomControlsRenderProps = Omit<EditorZoomControlsProps, 'visibility' | 'visible' | 'keyboardDiscoverableWhenHidden'>;
 
   type ZoomRangeState = 'in-range' | 'below-minimum' | 'above-maximum';
 
@@ -65,8 +66,9 @@
     toggleTargetLandmark,
     boundaryAttemptRequest = 0,
     boundaryAttemptLandmark = null,
-    segment,
+    visibility,
     visible,
+    keyboardDiscoverableWhenHidden = false,
     onZoomOut,
     onZoomIn,
     onToggleZoom,
@@ -84,7 +86,6 @@
   let lastBoundaryAttemptRequest = 0;
   let snapFeedbackRequest = $state(0);
   let snapFeedbackLandmark = $state<DocumentZoomLandmark | null>(null);
-  let wasEnabled = $state(false);
   const prefersReducedMotion = $derived(reducedMotionPreference.current);
 
   const zoomPercent = $derived(Math.round(indicatorZoom * 100));
@@ -136,7 +137,7 @@
   }
 
   function showTemporarily() {
-    segment.showTemporarily(announcedLandmark ? ZOOM_OVERLAY_LANDMARK_VISIBLE_MS : CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+    visibility.showTemporarily(announcedLandmark ? ZOOM_OVERLAY_LANDMARK_VISIBLE_MS : CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
   }
 
   function handleIndicatorPointerDown(event: PointerEvent) {
@@ -179,8 +180,8 @@
   function announceLandmark(next: DocumentZoomLandmark | null, held = false) {
     clearLandmarkTimer();
     announcedLandmark = next;
-    if (next !== null && held) segment.hold('zoom-landmark');
-    else segment.release('zoom-landmark');
+    if (next !== null && held) visibility.hold('zoom-landmark');
+    else visibility.release('zoom-landmark');
     if (!next || held) return;
     landmarkTimer = setTimeout(() => {
       announcedLandmark = null;
@@ -209,13 +210,11 @@
   }
 
   $effect(() => {
-    const entered = enabled && !wasEnabled;
-    wasEnabled = enabled;
     const previousZoom = lastZoom;
     lastZoom = displayZoom;
     const initialObservation = previousZoom === null;
     const zoomChanged = !initialObservation && zoomDiffers(previousZoom, displayZoom);
-    if (enabled && (zoomChanged || entered)) showTemporarily();
+    if (enabled && zoomChanged) showTemporarily();
   });
 
   $effect(() => {
@@ -229,7 +228,7 @@
       lastLandmark = undefined;
       clearLandmarkTimer();
       announcedLandmark = null;
-      segment.release('zoom-landmark');
+      visibility.release('zoom-landmark');
       return;
     }
 
@@ -273,7 +272,7 @@
     return () => {
       clearLandmarkTimer();
       clearTouchClickSuppression();
-      segment.release('zoom-landmark');
+      visibility.release('zoom-landmark');
     };
   });
 </script>
@@ -310,7 +309,7 @@
       aria-label={atMinimum ? '최소 배율입니다' : '페이지 축소'}
       data-at-zoom-boundary={atMinimum}
       onclick={onZoomOut}
-      tabindex={visible ? 0 : -1}
+      tabindex={visible || keyboardDiscoverableWhenHidden ? 0 : -1}
       type="button"
       use:tooltip={{
         message: atMinimum ? '최소 배율입니다' : '페이지 축소',
@@ -340,7 +339,7 @@
       onfocus={handleValueFocus}
       onpointerenter={handleValuePointerEnter}
       onpointerleave={handleValuePointerLeave}
-      tabindex={visible ? 0 : -1}
+      tabindex={visible || keyboardDiscoverableWhenHidden ? 0 : -1}
       type="button"
       use:tooltip={{ message: toggleLabel, keys: toggleKeys, placement: 'bottom' }}
     >
@@ -396,7 +395,7 @@
       aria-label={atMaximum ? '최대 배율입니다' : '페이지 확대'}
       data-at-zoom-boundary={atMaximum}
       onclick={onZoomIn}
-      tabindex={visible ? 0 : -1}
+      tabindex={visible || keyboardDiscoverableWhenHidden ? 0 : -1}
       type="button"
       use:tooltip={{
         message: atMaximum ? '최대 배율입니다' : '페이지 확대',

--- a/apps/website/src/lib/editor-ffi/components/ui/FloatingEditorZoomControls.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/FloatingEditorZoomControls.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { token } from '@typie/styled-system/tokens';
+  import { prefersReducedMotion } from '@typie/ui/state';
+  import { CONTEXT_BAR_FADE_IN_MS, CONTEXT_BAR_FADE_OUT_MS, CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from './editor-context-bar.svelte';
+  import EditorZoomControls from './EditorZoomControls.svelte';
+  import { TransientVisibilityState } from './transient-visibility.svelte';
+  import type { EditorZoomControlsRenderProps } from './EditorZoomControls.svelte';
+
+  type Props = {
+    controls: EditorZoomControlsRenderProps;
+  };
+
+  const FADE_WIDTH = 24;
+  const ACTIVE_SURFACE = token('colors.surface.muted');
+  const CONTINUOUS_SURFACE = token('colors.surface.default');
+  const PAGINATED_SURFACE = token('colors.surface.subtle');
+  const TRANSIENT_BASE = `color-mix(in srgb, ${CONTINUOUS_SURFACE} 50%, ${PAGINATED_SURFACE} 50%)`;
+  const SUBTLE_BORDER = token('colors.border.subtle');
+  const DEFAULT_BORDER = token('colors.border.default');
+  const TRANSIENT_SURFACE = `color-mix(in srgb, ${TRANSIENT_BASE} 85%, transparent)`;
+  const TRANSIENT_EDGE = `color-mix(in srgb, ${TRANSIENT_BASE} 40%, ${SUBTLE_BORDER} 60%)`;
+  const ENGAGED_EDGE = `color-mix(in srgb, ${ACTIVE_SURFACE} 36%, ${DEFAULT_BORDER} 64%)`;
+
+  let { controls }: Props = $props();
+  const visibility = new TransientVisibilityState();
+  const visible = $derived(controls.enabled && visibility.visible);
+  const engaged = $derived(visibility.engaged);
+  const surfaceColor = $derived(engaged ? ACTIVE_SURFACE : TRANSIENT_SURFACE);
+  const edgeColor = $derived(engaged ? ENGAGED_EDGE : TRANSIENT_EDGE);
+
+  const smootherstep = (value: number): number => {
+    const x = Math.min(1, Math.max(0, value));
+    return x * x * x * (x * (x * 6 - 15) + 10);
+  };
+  const fadeStops = Array.from({ length: 9 }, (_, index) => {
+    const progress = index / 8;
+    return `rgb(0 0 0 / ${smootherstep(progress)}) ${FADE_WIDTH * progress}px`;
+  });
+  const fadeMask = `linear-gradient(to right, ${fadeStops.join(', ')}, black ${FADE_WIDTH}px, black 100%)`;
+
+  function handlePointerEnter(): void {
+    if (visible) visibility.setHovered(true);
+  }
+
+  function handlePointerLeave(): void {
+    if (visibility.hovered) visibility.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+    visibility.setHovered(false);
+  }
+
+  function handleFocusIn(): void {
+    visibility.setFocused(true);
+  }
+
+  function handleFocusOut(event: FocusEvent & { currentTarget: HTMLDivElement }): void {
+    const nextInside = event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget);
+    if (!nextInside && visibility.focused) visibility.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
+    visibility.setFocused(nextInside);
+  }
+
+  $effect(() => {
+    if (!controls.enabled) visibility.destroy();
+  });
+
+  $effect(() => () => visibility.destroy());
+</script>
+
+<div
+  class={css({
+    position: 'fixed',
+    top: '[var(--usersite-sticky-header-bottom, 0px)]',
+    right: '0',
+    zIndex: '5',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    height: '0',
+    pointerEvents: 'none',
+  })}
+  data-floating-editor-zoom-anchor
+  role="presentation"
+>
+  <div
+    style:color={token(engaged ? 'colors.text.default' : 'colors.text.subtle')}
+    style:opacity={visible ? '1' : '0'}
+    style:pointer-events={visible ? 'auto' : 'none'}
+    style:transition={prefersReducedMotion.current
+      ? 'none'
+      : `opacity ${visible ? CONTEXT_BAR_FADE_IN_MS : CONTEXT_BAR_FADE_OUT_MS}ms ease-out, color ${CONTEXT_BAR_FADE_IN_MS}ms ease-out`}
+    class={css({ position: 'relative', isolation: 'isolate', width: '[fit-content]' })}
+    data-floating-editor-zoom-controls
+    onfocusin={handleFocusIn}
+    onfocusout={handleFocusOut}
+    onpointerenter={handlePointerEnter}
+    onpointerleave={handlePointerLeave}
+    role="presentation"
+  >
+    <div
+      style:backdrop-filter={`blur(${visible && !engaged ? 2 : 0}px)`}
+      style:mask-image={fadeMask}
+      style:transition={prefersReducedMotion.current ? 'none' : 'backdrop-filter 320ms cubic-bezier(0, 0, 0.2, 1)'}
+      class={css({ position: 'absolute', top: '0', right: '0', bottom: '0', left: '-24px', zIndex: '[-2]', pointerEvents: 'none' })}
+      aria-hidden="true"
+      data-floating-editor-zoom-blur
+    ></div>
+    <div
+      style:background-color={surfaceColor}
+      style:mask-image={fadeMask}
+      style:transition={prefersReducedMotion.current ? 'none' : `background-color ${CONTEXT_BAR_FADE_IN_MS}ms ease-out`}
+      class={css({ position: 'absolute', top: '0', right: '0', bottom: '0', left: '-24px', zIndex: '[-1]', pointerEvents: 'none' })}
+      aria-hidden="true"
+      data-floating-editor-zoom-surface
+    ></div>
+    <div
+      style:background-color={edgeColor}
+      style:mask-image={fadeMask}
+      style:transition={prefersReducedMotion.current ? 'none' : `background-color ${CONTEXT_BAR_FADE_IN_MS}ms ease-out`}
+      class={css({ position: 'absolute', right: '0', bottom: '0', left: '-24px', zIndex: '[-1]', height: '1px', pointerEvents: 'none' })}
+      aria-hidden="true"
+      data-floating-editor-zoom-edge
+    ></div>
+
+    <EditorZoomControls {...controls} keyboardDiscoverableWhenHidden {visibility} {visible} />
+  </div>
+</div>

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar-test-root.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar-test-root.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   import { VerticalDivider } from '@typie/ui/components';
+  import { setupAppContext } from '@typie/ui/context';
   import { CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from './editor-context-bar.svelte';
   import EditorBreadcrumb from './EditorBreadcrumb.svelte';
   import EditorContextBar from './EditorContextBar.svelte';
   import EditorFocusModeControl from './EditorFocusModeControl.svelte';
   import EditorZoomControls from './EditorZoomControls.svelte';
+  import FloatingEditorZoomControls from './FloatingEditorZoomControls.svelte';
   import type { DocumentZoomLandmark } from '$lib/editor-ffi/zoom';
   import type { EditorContextBarSegmentRenderProps } from './EditorContextBar.svelte';
 
   type Props = {
-    mode?: 'zoom' | 'context-bar';
+    mode?: 'zoom' | 'context-bar' | 'floating-zoom';
     initialEnabled?: boolean;
     initialZoom?: number;
     initialIndicatorZoom?: number;
@@ -23,6 +25,9 @@
     viewControlsWidth?: number;
     viewControlsPaneEntry?: boolean;
     withinPane?: boolean;
+    preferenceUserId?: string;
+    twoPanes?: boolean;
+    useAppPinned?: boolean;
   };
 
   let {
@@ -40,7 +45,16 @@
     viewControlsWidth = 124,
     viewControlsPaneEntry = true,
     withinPane = true,
+    preferenceUserId = 'editor-context-bar-test',
+    twoPanes = false,
+    useAppPinned = false,
   }: Props = $props();
+  const app = setupAppContext(preferenceUserId);
+  const contextBarPinned = $derived(
+    useAppPinned
+      ? ((app.preference.current as typeof app.preference.current & { contextBarPinned?: boolean }).contextBarPinned ?? true)
+      : false,
+  );
   let enabled = $state(initialEnabled);
   let displayZoom = $state(initialZoom);
   let indicatorZoom = $state(initialIndicatorZoom);
@@ -49,10 +63,12 @@
   let boundaryAttemptLandmark = $state<DocumentZoomLandmark | null>(null);
   let focusMode = $state(false);
   let editorViewSurface = $state<HTMLElement>();
+  let secondEditorViewSurface = $state<HTMLElement>();
   let scrollContainer = $state<HTMLElement>();
   let currentSurfaceWidth = $state(surfaceWidth);
   let currentBreadcrumbWidth = $state(breadcrumbWidth);
   let breadcrumbPathIdentity = $state('folder/document');
+  let contextBarTopOcclusion = $state(0);
 
   const toggleTargetLandmark = $derived<DocumentZoomLandmark | null>(
     initialToggleTargetLandmark === undefined ? (landmark === 'unit' ? 'fit-width' : 'unit') : initialToggleTargetLandmark,
@@ -85,15 +101,47 @@
   export function setSurfaceWidth(nextWidth: number) {
     currentSurfaceWidth = nextWidth;
   }
+
+  export function setPinned(nextPinned: boolean) {
+    (app.preference.current as typeof app.preference.current & { contextBarPinned?: boolean }).contextBarPinned = nextPinned;
+  }
 </script>
 
-<svelte:element this={withinPane ? 'div' : 'section'} data-pane-id={withinPane ? 'zoom-overlay-test-pane' : undefined}>
+<svelte:element
+  this={withinPane ? 'div' : 'section'}
+  data-context-bar-top-occlusion={contextBarTopOcclusion}
+  data-pane-id={withinPane ? 'zoom-overlay-test-pane' : undefined}
+>
   <div data-testid="editor-toolbar"></div>
   <div bind:this={editorViewSurface} style:width={`${currentSurfaceWidth}px`} style="position: relative; height: 120px">
+    {#if mode === 'floating-zoom'}
+      <FloatingEditorZoomControls
+        controls={{
+          atMaximum: landmark === 'maximum',
+          atMinimum: landmark === 'minimum',
+          boundaryAttemptLandmark,
+          boundaryAttemptRequest,
+          displayZoom,
+          enabled,
+          indicatorZoom,
+          landmark,
+          onToggleZoom,
+          onZoomIn,
+          onZoomOut,
+          toggleTargetLandmark,
+        }}
+      />
+    {/if}
     <button data-testid="context-bar-underlay" type="button">본문</button>
     <div bind:this={scrollContainer} data-testid="editor-pane"></div>
     {#if mode === 'zoom' && editorViewSurface && scrollContainer}
-      <EditorContextBar {editorViewSurface} interactiveViewControlsWhenHidden showViewControlsOnPaneEntry={enabled && landmark !== 'unit'}>
+      <EditorContextBar
+        {editorViewSurface}
+        interactiveViewControlsWhenHidden
+        onPinnedChange={setPinned}
+        pinned={contextBarPinned}
+        showViewControlsOnPaneEntry={enabled && landmark !== 'unit'}
+      >
         {#snippet viewControls({ state, presentation }: EditorContextBarSegmentRenderProps)}
           <div style="display: flex; align-items: center">
             <EditorZoomControls
@@ -108,8 +156,8 @@
               {onToggleZoom}
               {onZoomIn}
               {onZoomOut}
-              segment={state}
               {toggleTargetLandmark}
+              visibility={state}
               visible={presentation.visible}
             />
             {#if enabled}
@@ -125,7 +173,13 @@
         {/snippet}
       </EditorContextBar>
     {:else if mode === 'context-bar' && editorViewSurface}
-      <EditorContextBar {editorViewSurface} showViewControlsOnPaneEntry={viewControlsPaneEntry}>
+      <EditorContextBar
+        {editorViewSurface}
+        onPinnedChange={setPinned}
+        onTopOcclusionChange={(topOcclusion) => (contextBarTopOcclusion = topOcclusion)}
+        pinned={contextBarPinned}
+        showViewControlsOnPaneEntry={viewControlsPaneEntry}
+      >
         {#snippet breadcrumb({ state }: EditorContextBarSegmentRenderProps)}
           <EditorBreadcrumb
             onPathChange={() => state.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS)}
@@ -150,3 +204,20 @@
     {/if}
   </div>
 </svelte:element>
+
+{#if mode === 'context-bar' && twoPanes}
+  <div bind:this={secondEditorViewSurface} style:width={`${currentSurfaceWidth}px`} style="position: relative; height: 120px">
+    {#if secondEditorViewSurface}
+      <EditorContextBar
+        editorViewSurface={secondEditorViewSurface}
+        onPinnedChange={setPinned}
+        pinned={contextBarPinned}
+        showViewControlsOnPaneEntry={false}
+      >
+        {#snippet viewControls({ state }: EditorContextBarSegmentRenderProps)}
+          <button onclick={() => state.showTemporarily(1000)} type="button">두 번째 보기</button>
+        {/snippet}
+      </EditorContextBar>
+    {/if}
+  </div>
+{/if}

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.browser.test.ts
@@ -5,6 +5,45 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import EditorContextBarTestRoot from './editor-context-bar-test-root.svelte';
 import type { DocumentZoomLandmark } from '$lib/editor-ffi/zoom';
 
+const reducedMotionPreference = vi.hoisted(() => {
+  const query = '(prefers-reduced-motion: reduce)';
+  const listeners = new Set<EventListenerOrEventListenerObject>();
+  let matches = false;
+  const mediaQuery = {
+    get matches() {
+      return matches;
+    },
+    media: query,
+    onchange: null,
+    addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => listeners.add(listener),
+    removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => listeners.delete(listener),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: () => true,
+  } satisfies MediaQueryList;
+
+  vi.stubGlobal('matchMedia', (candidate: string) =>
+    candidate === query
+      ? mediaQuery
+      : ({
+          ...mediaQuery,
+          matches: false,
+          media: candidate,
+        } satisfies MediaQueryList),
+  );
+
+  return {
+    set(next: boolean) {
+      matches = next;
+      const event = new Event('change');
+      for (const listener of listeners) {
+        if (typeof listener === 'function') listener(event);
+        else listener.handleEvent(event);
+      }
+    },
+  };
+});
+
 type TestProps = {
   enabled: boolean;
   displayZoom: number;
@@ -21,7 +60,13 @@ type TestProps = {
 const TRANSIENT_VISIBLE_MS = 1500;
 const HOVER_INTENT_SETTLE_MS = 100;
 const LANE_SPOT_DWELL_MS = 500;
-const LANE_SPOT_EXPAND_MS = 1000;
+const LANE_BACKGROUND_EXPAND_MS = 900;
+const LANE_EXPANSION_TOTAL_MS = 1000;
+const LANE_ENGAGED_SPOT_ENTER_DELAY_MS = 500;
+const LANE_ENGAGED_SPOT_STRENGTH = 0.85;
+const LANE_FOREGROUND_REVEAL_DELAY_MS = 100;
+const LANE_FOREGROUND_REVEAL_MS = 900;
+const LANE_SPOT_RADIUS = 88;
 const SURFACE_FADE_IN_MS = 180;
 const SURFACE_FADE_OUT_MS = 400;
 let mounted: Record<string, unknown> | undefined;
@@ -38,13 +83,14 @@ async function mountContextBar(
     viewControlsWidth: number;
     viewControlsPaneEntry: boolean;
     withinPane: boolean;
+    useAppPinned: boolean;
   }> = {},
 ) {
   mounted = mount(EditorContextBarTestRoot, { target: document.body, props: { mode: 'context-bar', ...props } });
   await tick();
   const surface = document.querySelector<HTMLElement>('[data-testid="context-bar-underlay"]')?.parentElement;
   const pane = document.querySelector<HTMLElement>('[data-pane-id="zoom-overlay-test-pane"]');
-  const breadcrumb = document.querySelector<HTMLElement>('[data-context-bar-segment="breadcrumb"]');
+  const breadcrumb = document.querySelector<HTMLElement>('[data-context-bar-segment="leading"]');
   const viewControls = document.querySelector<HTMLElement>('[data-context-bar-segment="view-controls"]');
   const bar = document.querySelector<HTMLElement>('[data-editor-context-bar]');
   const breadcrumbViewport = document.querySelector<HTMLElement>('[data-editor-breadcrumb-viewport]');
@@ -88,16 +134,59 @@ async function mountOverlay(
   return { overlay, paneContainer: paneContainer ?? editorViewSurface, scrollContainer, editorViewSurface, toolbar, host: mounted };
 }
 
+async function mountFloatingOverlay({
+  displayZoom = 1,
+  indicatorZoom = displayZoom,
+  landmark = null,
+}: Partial<Pick<TestProps, 'displayZoom' | 'indicatorZoom' | 'landmark'>> = {}) {
+  mounted = mount(EditorContextBarTestRoot, {
+    target: document.body,
+    props: {
+      mode: 'floating-zoom',
+      initialEnabled: true,
+      initialZoom: displayZoom,
+      initialIndicatorZoom: indicatorZoom,
+      initialLandmark: landmark,
+    },
+  });
+  await tick();
+  return {
+    anchor: document.querySelector<HTMLElement>('[data-floating-editor-zoom-anchor]'),
+    overlay: document.querySelector<HTMLElement>('[data-floating-editor-zoom-controls]'),
+    contextBar: document.querySelector<HTMLElement>('[data-editor-context-bar]'),
+    host: mounted,
+  };
+}
+
 async function expireTransientVisibility() {
   await vi.advanceTimersByTimeAsync(TRANSIENT_VISIBLE_MS);
   await tick();
 }
 
+async function startHiddenLaneGapHover(props: { useAppPinned?: boolean } = {}) {
+  const contextBar = await mountContextBar({ surfaceWidth: 640, ...props });
+  const { pane, breadcrumb, viewControls, bar } = contextBar;
+  if (!pane) throw new Error('Missing pane fixture');
+  enter(pane);
+  await expireTransientVisibility();
+
+  const breadcrumbRect = breadcrumb.getBoundingClientRect();
+  const viewControlsRect = viewControls.getBoundingClientRect();
+  const barRect = bar.getBoundingClientRect();
+  const gapX = (breadcrumbRect.right + viewControlsRect.left) / 2;
+  const gapY = barRect.top + barRect.height / 2;
+  move(pane, gapX, gapY);
+  return { ...contextBar, pane, breadcrumbRect, viewControlsRect, barRect, gapX, gapY };
+}
+
 afterEach(async () => {
   if (mounted) await unmount(mounted);
   mounted = undefined;
+  reducedMotionPreference.set(false);
   vi.useRealTimers();
   vi.restoreAllMocks();
+  localStorage.clear();
+  document.body.style.removeProperty('--usersite-sticky-header-bottom');
   document.body.replaceChildren();
 });
 
@@ -116,9 +205,12 @@ describe('editor context bar', () => {
 
   it('keeps the transient surface mask while the context bar fades out', async () => {
     vi.useFakeTimers();
-    const { breadcrumb, viewControls } = await mountContextBar({ viewControlsPaneEntry: false });
+    const { breadcrumb, viewControls, bar } = await mountContextBar({ viewControlsPaneEntry: false });
     const surface = document.querySelector<HTMLElement>('[data-context-bar-lane-surface]');
     const blur = document.querySelector<HTMLElement>('[data-context-bar-blur-layer]');
+    const fixture = document.querySelector<HTMLElement>('[data-context-bar-top-occlusion]');
+
+    expect(fixture?.dataset.contextBarTopOcclusion).toBe(`${bar.getBoundingClientRect().height}`);
 
     await expireTransientVisibility();
 
@@ -127,10 +219,12 @@ describe('editor context bar', () => {
     expect(surface?.style.opacity).toBe('0');
     expect(surface?.style.maskImage).toContain('linear-gradient(black, black)');
     expect(blur?.style.maskImage).toContain('linear-gradient(black, black)');
+    expect(fixture?.dataset.contextBarTopOcclusion).toBe(`${bar.getBoundingClientRect().height}`);
 
     await vi.advanceTimersByTimeAsync(SURFACE_FADE_OUT_MS);
     expect(surface?.style.maskImage).not.toContain('linear-gradient(black, black)');
     expect(blur?.style.maskImage).not.toContain('linear-gradient(black, black)');
+    expect(fixture?.dataset.contextBarTopOcclusion).toBe('0');
   });
 
   it('preserves view controls and lets a long breadcrumb consume only the remaining width', async () => {
@@ -204,7 +298,7 @@ describe('editor context bar', () => {
     const laneSurface = document.querySelector<HTMLElement>('[data-context-bar-lane-surface]');
     const blurLayer = document.querySelector<HTMLElement>('[data-context-bar-blur-layer]');
     expect(laneSurface?.dataset.contextBarFullLane).toBe('true');
-    expect(document.querySelector<HTMLElement>('[data-context-bar-surface="breadcrumb"]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-context-bar-surface="leading"]')?.style.opacity).toBe('0');
     expect(document.querySelector<HTMLElement>('[data-context-bar-surface="view-controls"]')?.style.opacity).toBe('0');
 
     enter(viewControls);
@@ -260,13 +354,13 @@ describe('editor context bar', () => {
     await vi.advanceTimersByTimeAsync(LANE_SPOT_DWELL_MS);
     expect(bar.dataset.contextBarLanePhase).toBe('expanding');
     expect(spot?.dataset.contextBarSpotSurfaceStrength).toBe('1');
-    expect(document.querySelector<HTMLElement>('[data-context-bar-blur-layer]')?.dataset.contextBarBlurRadius).toBe('3');
+    expect(document.querySelector<HTMLElement>('[data-context-bar-blur-layer]')?.dataset.contextBarBlurRadius).toBe('2');
     expect(breadcrumb.style.opacity).toBe('1');
     expect(viewControls.style.opacity).toBe('1');
     expect(breadcrumb.parentElement?.style.maskImage).toContain('radial-gradient');
     expect(viewControls.parentElement?.style.maskImage).toContain('radial-gradient');
 
-    await vi.advanceTimersByTimeAsync(LANE_SPOT_EXPAND_MS);
+    await vi.advanceTimersByTimeAsync(LANE_EXPANSION_TOTAL_MS);
     expect(bar.dataset.contextBarLanePhase).toBe('held');
     expect(breadcrumb.style.opacity).toBe('1');
     expect(viewControls.style.opacity).toBe('1');
@@ -287,6 +381,202 @@ describe('editor context bar', () => {
     expect(viewControls.style.opacity).toBe('0');
   });
 
+  it('finishes a 900ms background wave as the 100ms-delayed foreground reaches the shared 1000ms endpoint', async () => {
+    vi.useFakeTimers();
+    const { breadcrumb, viewControls, bar } = await startHiddenLaneGapHover();
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS + LANE_SPOT_DWELL_MS);
+
+    const breadcrumbReveal = breadcrumb.parentElement as HTMLElement;
+    const viewControlsReveal = viewControls.parentElement as HTMLElement;
+    const revealRadius = '--context-bar-segment-reveal-radius';
+    const revealOpacity = '--context-bar-segment-reveal-opacity';
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+    expect(bar.style.transition).toContain(`${LANE_BACKGROUND_EXPAND_MS}ms`);
+    expect(breadcrumbReveal.style.transition).toContain(`${LANE_FOREGROUND_REVEAL_MS}ms`);
+    expect(viewControlsReveal.style.transition).toContain(`${LANE_FOREGROUND_REVEAL_MS}ms`);
+    expect(breadcrumbReveal.style.getPropertyValue(revealRadius)).toBe(`${LANE_SPOT_RADIUS}px`);
+    expect(viewControlsReveal.style.getPropertyValue(revealRadius)).toBe(`${LANE_SPOT_RADIUS}px`);
+    expect(breadcrumbReveal.style.getPropertyValue(revealOpacity)).toBe('0');
+    expect(viewControlsReveal.style.getPropertyValue(revealOpacity)).toBe('0');
+
+    await vi.advanceTimersByTimeAsync(LANE_FOREGROUND_REVEAL_DELAY_MS - 1);
+    expect(breadcrumbReveal.style.getPropertyValue(revealRadius)).toBe(`${LANE_SPOT_RADIUS}px`);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(breadcrumbReveal.style.getPropertyValue(revealRadius)).not.toBe(`${LANE_SPOT_RADIUS}px`);
+    expect(viewControlsReveal.style.getPropertyValue(revealRadius)).not.toBe(`${LANE_SPOT_RADIUS}px`);
+    expect(breadcrumbReveal.style.getPropertyValue(revealOpacity)).toBe('1');
+    expect(viewControlsReveal.style.getPropertyValue(revealOpacity)).toBe('1');
+
+    await vi.advanceTimersByTimeAsync(LANE_BACKGROUND_EXPAND_MS - LANE_FOREGROUND_REVEAL_DELAY_MS);
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+    expect(breadcrumbReveal.style.maskImage).toContain('radial-gradient');
+
+    await vi.advanceTimersByTimeAsync(LANE_EXPANSION_TOTAL_MS - LANE_BACKGROUND_EXPAND_MS - 1);
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+    expect(breadcrumbReveal.style.maskImage).toContain('radial-gradient');
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(bar.dataset.contextBarLanePhase).toBe('held');
+    expect(breadcrumbReveal.style.maskImage).toBe('none');
+    expect(viewControlsReveal.style.maskImage).toBe('none');
+  });
+
+  it('latches the transient wave while the engaged spot follows the pointer across segments and survives expansion', async () => {
+    vi.useFakeTimers();
+    const { pane, breadcrumb, bar, breadcrumbRect, viewControlsRect, barRect, gapX, gapY } = await startHiddenLaneGapHover();
+    const origin = {
+      x: gapX - barRect.left,
+      y: gapY - barRect.top,
+    };
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS);
+
+    const transientSurface = document.querySelector<HTMLElement>('[data-context-bar-lane-surface]');
+    const engagedSpot = document.querySelector<HTMLElement>('[data-context-bar-engaged-spot]');
+    const blur = document.querySelector<HTMLElement>('[data-context-bar-blur-layer]');
+    if (!transientSurface || !engagedSpot || !blur) throw new Error('Missing context bar surface layers');
+    expect(bar.dataset.contextBarLanePhase).toBe('spot');
+    expect(bar.style.transition).toContain(`--context-bar-lane-spot-opacity 500ms ease-out`);
+    expect(engagedSpot.style.transition).toContain(`opacity 500ms ease-out ${LANE_ENGAGED_SPOT_ENTER_DELAY_MS}ms`);
+    expect(engagedSpot.style.maskImage).toContain(`rgba(0, 0, 0, ${LANE_ENGAGED_SPOT_STRENGTH}) 0px`);
+    expect(engagedSpot.dataset.contextBarSpotVisible).toBe('true');
+    expect(engagedSpot.style.backdropFilter).toBe('');
+    expect(transientSurface.style.maskImage).toContain(`circle at ${origin.x}px ${origin.y}px`);
+    expect(blur.nextElementSibling).toBe(transientSurface);
+    expect(transientSurface.nextElementSibling).toBe(engagedSpot);
+    const layers = [...bar.children];
+    expect(layers.indexOf(engagedSpot)).toBeLessThan(layers.indexOf(breadcrumb.parentElement as HTMLElement));
+
+    await vi.advanceTimersByTimeAsync(LANE_SPOT_DWELL_MS);
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+
+    const viewControlsPoint = {
+      x: viewControlsRect.left + viewControlsRect.width / 2,
+      y: viewControlsRect.top + viewControlsRect.height / 2,
+    };
+    move(pane, viewControlsPoint.x, viewControlsPoint.y);
+    await tick();
+
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+    expect(transientSurface?.style.maskImage).toContain(`circle at ${origin.x}px ${origin.y}px`);
+    expect(engagedSpot?.dataset.contextBarSpotX).toBe(String(viewControlsPoint.x - barRect.left));
+    expect(engagedSpot?.dataset.contextBarSpotY).toBe(String(viewControlsPoint.y - barRect.top));
+
+    await vi.advanceTimersByTimeAsync(LANE_EXPANSION_TOTAL_MS);
+    expect(bar.dataset.contextBarLanePhase).toBe('held');
+    expect(engagedSpot?.dataset.contextBarSpotVisible).toBe('true');
+
+    const breadcrumbPoint = {
+      x: breadcrumbRect.left + breadcrumbRect.width / 2,
+      y: breadcrumbRect.top + breadcrumbRect.height / 2,
+    };
+    move(pane, breadcrumbPoint.x, breadcrumbPoint.y);
+    await tick();
+    expect(bar.dataset.contextBarLanePhase).toBe('held');
+    expect(engagedSpot?.dataset.contextBarSpotX).toBe(String(breadcrumbPoint.x - barRect.left));
+
+    move(pane, breadcrumbPoint.x, barRect.bottom + 20);
+    await tick();
+    expect(engagedSpot?.dataset.contextBarSpotVisible).toBe('false');
+    expect(engagedSpot?.style.transition).toContain(`${SURFACE_FADE_OUT_MS}ms`);
+  });
+
+  it('removes only the expansion masks whose segments become focused or pointer-engaged', async () => {
+    vi.useFakeTimers();
+    const { breadcrumb, viewControls, bar } = await startHiddenLaneGapHover();
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS + LANE_SPOT_DWELL_MS);
+
+    const breadcrumbReveal = breadcrumb.parentElement as HTMLElement;
+    const viewControlsReveal = viewControls.parentElement as HTMLElement;
+    expect(breadcrumbReveal.style.maskImage).toContain('radial-gradient');
+    expect(viewControlsReveal.style.maskImage).toContain('radial-gradient');
+
+    document.querySelector<HTMLButtonElement>('[data-testid="show-breadcrumb"]')?.focus();
+    await tick();
+    expect(breadcrumb.dataset.contextBarTone).toBe('engaged');
+    expect(breadcrumbReveal.style.maskImage).toBe('none');
+    expect(viewControlsReveal.style.maskImage).toContain('radial-gradient');
+
+    enter(viewControls);
+    await tick();
+    expect(viewControls.dataset.contextBarTone).toBe('engaged');
+    expect(viewControlsReveal.style.maskImage).toBe('none');
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+  });
+
+  it('keeps the engaged spot absent for pointerless transient reveals', async () => {
+    vi.useFakeTimers();
+    const { breadcrumb } = await mountContextBar({ surfaceWidth: 640 });
+    const engagedSpot = document.querySelector<HTMLElement>('[data-context-bar-engaged-spot]');
+
+    expect(breadcrumb.style.opacity).toBe('1');
+    expect(engagedSpot).not.toBeNull();
+    expect(engagedSpot?.dataset.contextBarSpotVisible).toBe('false');
+
+    await expireTransientVisibility();
+    document.querySelector<HTMLButtonElement>('[data-testid="show-breadcrumb"]')?.click();
+    await tick();
+    expect(breadcrumb.style.opacity).toBe('1');
+    expect(engagedSpot?.dataset.contextBarSpotVisible).toBe('false');
+  });
+
+  it('clears a staggered reveal when expansion is interrupted and restarts from the next pointer origin', async () => {
+    vi.useFakeTimers();
+    const { pane, breadcrumb, viewControls, bar, barRect, gapX: firstX, gapY } = await startHiddenLaneGapHover();
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS + LANE_SPOT_DWELL_MS + LANE_FOREGROUND_REVEAL_DELAY_MS / 2);
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+
+    move(pane, firstX, barRect.bottom + 20);
+    await tick();
+    expect(bar.dataset.contextBarLanePhase).toBe('idle');
+    expect(breadcrumb.parentElement?.style.maskImage).toBe('none');
+    expect(viewControls.parentElement?.style.maskImage).toBe('none');
+
+    const secondX = firstX + 48;
+    move(pane, secondX, gapY);
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS + LANE_SPOT_DWELL_MS);
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+    expect(document.querySelector<HTMLElement>('[data-context-bar-lane-surface]')?.style.maskImage).toContain(
+      `circle at ${secondX - barRect.left}px`,
+    );
+    expect(breadcrumb.parentElement?.style.getPropertyValue('--context-bar-segment-reveal-radius')).toBe(`${LANE_SPOT_RADIUS}px`);
+  });
+
+  it('skips the expansion waves under initial reduced motion while retaining the static engaged spot', async () => {
+    vi.useFakeTimers();
+    reducedMotionPreference.set(true);
+    const { breadcrumb, viewControls, bar } = await startHiddenLaneGapHover();
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS + LANE_SPOT_DWELL_MS);
+
+    expect(bar.dataset.contextBarLanePhase).toBe('held');
+    expect(bar.style.transition).toBe('none');
+    expect(breadcrumb.parentElement?.style.maskImage).toBe('none');
+    expect(viewControls.parentElement?.style.maskImage).toBe('none');
+    expect(document.querySelector<HTMLElement>('[data-context-bar-engaged-spot]')?.dataset.contextBarSpotVisible).toBe('true');
+  });
+
+  it('finishes an active expansion immediately when reduced motion turns on and does not replay when it turns off', async () => {
+    vi.useFakeTimers();
+    const { breadcrumb, viewControls, bar } = await startHiddenLaneGapHover();
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS + LANE_SPOT_DWELL_MS + LANE_FOREGROUND_REVEAL_DELAY_MS / 2);
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+    expect(breadcrumb.parentElement?.style.maskImage).toContain('radial-gradient');
+
+    reducedMotionPreference.set(true);
+    await tick();
+    expect(bar.dataset.contextBarLanePhase).toBe('held');
+    expect(breadcrumb.parentElement?.style.maskImage).toBe('none');
+    expect(viewControls.parentElement?.style.maskImage).toBe('none');
+    expect(document.querySelector<HTMLElement>('[data-context-bar-engaged-spot]')?.dataset.contextBarSpotVisible).toBe('true');
+
+    reducedMotionPreference.set(false);
+    await tick();
+    await vi.advanceTimersByTimeAsync(LANE_EXPANSION_TOTAL_MS * 2);
+    expect(bar.dataset.contextBarLanePhase).toBe('held');
+    expect(breadcrumb.parentElement?.style.maskImage).toBe('none');
+    expect(viewControls.parentElement?.style.maskImage).toBe('none');
+  });
+
   it('shows the lane spot immediately when one segment is already visible', async () => {
     vi.useFakeTimers();
     const { pane, breadcrumb, viewControls, bar } = await mountContextBar({ surfaceWidth: 640 });
@@ -303,7 +593,7 @@ describe('editor context bar', () => {
 
     expect(bar.dataset.contextBarLanePhase).toBe('spot');
     expect(document.querySelector<HTMLElement>('[data-context-bar-lane-spot]')?.dataset.contextBarSpotVisible).toBe('true');
-    expect(document.querySelector<HTMLElement>('[data-context-bar-blur-layer]')?.dataset.contextBarBlurRadius).toBe('3');
+    expect(document.querySelector<HTMLElement>('[data-context-bar-blur-layer]')?.dataset.contextBarBlurRadius).toBe('2');
     const activeBlurLayers = [...document.querySelectorAll<HTMLElement>('[data-context-bar-blur-layer]')].filter(
       (element) => element.style.opacity !== '0' && element.style.backdropFilter !== 'blur(0px)',
     );
@@ -345,7 +635,7 @@ describe('editor context bar', () => {
     const transientSurface = document.querySelector<HTMLElement>('[data-context-bar-lane-spot]');
     expect(bar.dataset.contextBarLanePhase).toBe('preview');
     expect(blur?.style.maskComposite).toBe('add');
-    expect(blur?.dataset.contextBarBlurRadius).toBe('3');
+    expect(blur?.dataset.contextBarBlurRadius).toBe('2');
     expect(transientSurface?.style.maskComposite).toBe('add');
     expect(blur?.style.maskImage).not.toBe(transientSurface?.style.maskImage);
     expect(viewControls.style.opacity).toBe('0');
@@ -353,7 +643,7 @@ describe('editor context bar', () => {
     await vi.advanceTimersByTimeAsync(SURFACE_FADE_IN_MS);
     expect(transientSurface?.style.maskComposite).toBe('intersect');
 
-    await vi.advanceTimersByTimeAsync(LANE_SPOT_DWELL_MS + LANE_SPOT_EXPAND_MS);
+    await vi.advanceTimersByTimeAsync(LANE_SPOT_DWELL_MS + LANE_EXPANSION_TOTAL_MS);
     expect(bar.dataset.contextBarLanePhase).toBe('preview');
     expect(viewControls.style.opacity).toBe('0');
 
@@ -380,7 +670,7 @@ describe('editor context bar', () => {
     await tick();
 
     expect(breadcrumb.dataset.contextBarTone).toBe('engaged');
-    expect(document.querySelector<HTMLElement>('[data-context-bar-blur-layer]')?.dataset.contextBarBlurRadius).toBe('3');
+    expect(document.querySelector<HTMLElement>('[data-context-bar-blur-layer]')?.dataset.contextBarBlurRadius).toBe('2');
 
     await vi.advanceTimersByTimeAsync(SURFACE_FADE_IN_MS);
     expect(document.querySelector<HTMLElement>('[data-context-bar-blur-layer]')?.dataset.contextBarBlurRadius).toBe('0');
@@ -459,19 +749,167 @@ describe('editor context bar', () => {
     expect(breadcrumbViewport.scrollLeft).toBe(0);
   });
 
-  it('derives only the trailing scroll fog from the native scroll position using the smootherstep curve', async () => {
+  it('derives both scroll fogs from native position without masking the fixed pin and divider', async () => {
     const { breadcrumbViewport } = await mountContextBar({ surfaceWidth: 320, breadcrumbWidth: 600 });
     await vi.waitFor(() => expect(breadcrumbViewport.scrollLeft).toBeGreaterThan(0));
+    const pin = document.querySelector<HTMLElement>('[data-context-bar-pin]');
+    const divider = document.querySelector<HTMLElement>('[data-context-bar-pin-divider]');
 
-    expect(breadcrumbViewport.dataset.breadcrumbFogLeading).toBeUndefined();
-    expect(breadcrumbViewport.style.getPropertyValue('--breadcrumb-leading-fog')).toBe('');
+    expect(breadcrumbViewport.dataset.breadcrumbFogLeading).toBe('true');
+    expect(breadcrumbViewport.style.getPropertyValue('--breadcrumb-leading-fog')).toBe('1');
     expect(breadcrumbViewport.dataset.breadcrumbFogTrailing).toBe('false');
     expect(breadcrumbViewport.dataset.breadcrumbFogCurve).toBe('smootherstep');
+    expect(breadcrumbViewport.contains(pin)).toBe(false);
+    expect(breadcrumbViewport.contains(divider)).toBe(false);
 
     breadcrumbViewport.scrollLeft = 0;
     breadcrumbViewport.dispatchEvent(new Event('scroll'));
     await tick();
+    expect(breadcrumbViewport.dataset.breadcrumbFogLeading).toBe('false');
     expect(breadcrumbViewport.dataset.breadcrumbFogTrailing).toBe('true');
+
+    breadcrumbViewport.scrollLeft = 40;
+    breadcrumbViewport.dispatchEvent(new Event('scroll'));
+    await tick();
+    expect(breadcrumbViewport.dataset.breadcrumbFogLeading).toBe('true');
+    expect(breadcrumbViewport.dataset.breadcrumbFogTrailing).toBe('true');
+
+    reducedMotionPreference.set(true);
+    breadcrumbViewport.scrollLeft = 0;
+    breadcrumbViewport.dispatchEvent(new Event('scroll'));
+    await tick();
+    expect(breadcrumbViewport.dataset.breadcrumbFogLeading).toBe('false');
+    expect(breadcrumbViewport.style.transition).toBe('none');
+  });
+});
+
+describe('public viewer floating zoom controls', () => {
+  it('stays hidden on initial enable and reveals only after zoom activity', async () => {
+    vi.useFakeTimers();
+    const { overlay, contextBar, host } = await mountFloatingOverlay({ displayZoom: 1, landmark: 'unit' });
+
+    expect(contextBar).toBeNull();
+    expect(overlay).not.toBeNull();
+    expect(overlay?.style.opacity).toBe('0');
+
+    (
+      host as typeof mounted & { setZoom: (displayZoom: number, indicatorZoom: number, landmark: DocumentZoomLandmark | null) => void }
+    ).setZoom(1.1, 1.1, null);
+    await tick();
+
+    expect(overlay?.style.opacity).toBe('1');
+    await vi.advanceTimersByTimeAsync(TRANSIENT_VISIBLE_MS);
+    expect(overlay?.style.opacity).toBe('0');
+  });
+
+  it('uses a fixed viewport anchor and never exposes a hidden pointer hit area', async () => {
+    document.body.style.setProperty('--usersite-sticky-header-bottom', '52px');
+    const { anchor, overlay } = await mountFloatingOverlay();
+
+    expect(anchor).not.toBeNull();
+    expect(getComputedStyle(anchor as HTMLElement).position).toBe('fixed');
+    expect(getComputedStyle(anchor as HTMLElement).top).toBe('52px');
+    expect(overlay?.style.pointerEvents).toBe('none');
+  });
+
+  it('remains keyboard discoverable and reveals before a hidden control receives interaction', async () => {
+    const { overlay } = await mountFloatingOverlay();
+    const zoomOut = overlay?.querySelector<HTMLButtonElement>('button');
+
+    expect(zoomOut?.tabIndex).toBe(0);
+    zoomOut?.focus();
+    await tick();
+
+    expect(overlay?.style.opacity).toBe('1');
+    expect(overlay?.style.pointerEvents).toBe('auto');
+  });
+});
+
+describe('context bar pin', () => {
+  it('shows the pointer engaged spot without a reveal delay while pinned', async () => {
+    const { pane, breadcrumb, viewControls, bar } = await mountContextBar({ surfaceWidth: 640, useAppPinned: true });
+    if (!pane) throw new Error('Missing pane fixture');
+    const breadcrumbRect = breadcrumb.getBoundingClientRect();
+    const viewControlsRect = viewControls.getBoundingClientRect();
+    const barRect = bar.getBoundingClientRect();
+
+    move(pane, (breadcrumbRect.right + viewControlsRect.left) / 2, barRect.top + barRect.height / 2);
+    await tick();
+
+    const engagedSpot = document.querySelector<HTMLElement>('[data-context-bar-engaged-spot]');
+    expect(bar.dataset.contextBarUnified).toBe('true');
+    expect(bar.dataset.contextBarLanePhase).toBe('held');
+    expect(engagedSpot?.dataset.contextBarSpotVisible).toBe('true');
+    expect(engagedSpot?.style.transition).toBe('opacity 500ms ease-out');
+  });
+
+  it('defaults to pinned and restores an explicitly persisted unpinned preference', async () => {
+    mounted = mount(EditorContextBarTestRoot, {
+      target: document.body,
+      props: { mode: 'context-bar', preferenceUserId: 'pin-default', useAppPinned: true },
+    });
+    await tick();
+
+    expect(document.querySelector<HTMLButtonElement>('[data-context-bar-pin]')?.getAttribute('aria-pressed')).toBe('true');
+
+    await unmount(mounted);
+    mounted = undefined;
+    document.body.replaceChildren();
+    localStorage.setItem('typie:pref:pin-persisted', JSON.stringify({ contextBarPinned: false }));
+    mounted = mount(EditorContextBarTestRoot, {
+      target: document.body,
+      props: { mode: 'context-bar', preferenceUserId: 'pin-persisted', useAppPinned: true },
+    });
+    await tick();
+
+    expect(document.querySelector<HTMLButtonElement>('[data-context-bar-pin]')?.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('updates every pane through one app preference', async () => {
+    mounted = mount(EditorContextBarTestRoot, {
+      target: document.body,
+      props: { mode: 'context-bar', preferenceUserId: 'pin-shared', twoPanes: true, useAppPinned: true },
+    });
+    await tick();
+    const pins = () => [...document.querySelectorAll<HTMLButtonElement>('[data-context-bar-pin]')];
+
+    expect(pins()).toHaveLength(2);
+    pins()[0]?.click();
+    await tick();
+
+    expect(pins().map((pin) => pin.getAttribute('aria-pressed'))).toEqual(['false', 'false']);
+  });
+
+  it('keeps the hidden pin keyboard reachable without exposing a pointer hit area', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem('typie:pref:editor-context-bar-test', JSON.stringify({ contextBarPinned: false }));
+    const { breadcrumb } = await mountContextBar({ useAppPinned: true });
+    const pin = document.querySelector<HTMLButtonElement>('[data-context-bar-pin]');
+
+    await expireTransientVisibility();
+    expect(breadcrumb.style.opacity).toBe('0');
+    expect(breadcrumb.style.pointerEvents).toBe('none');
+    expect(pin?.tabIndex).toBe(0);
+
+    pin?.focus();
+    await tick();
+    expect(breadcrumb.style.opacity).toBe('1');
+  });
+
+  it('settles an active lane expansion immediately when pinned', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem('typie:pref:editor-context-bar-test', JSON.stringify({ contextBarPinned: false }));
+    const { pane, bar, gapX, gapY } = await startHiddenLaneGapHover({ useAppPinned: true });
+
+    move(pane, gapX, gapY);
+    await vi.advanceTimersByTimeAsync(HOVER_INTENT_SETTLE_MS + LANE_SPOT_DWELL_MS);
+    expect(bar.dataset.contextBarLanePhase).toBe('expanding');
+
+    (mounted as typeof mounted & { setPinned: (pinned: boolean) => void }).setPinned(true);
+    await tick();
+
+    expect(bar.dataset.contextBarLanePhase).toBe('idle');
+    expect(bar.dataset.contextBarUnified).toBe('true');
   });
 });
 

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.svelte.ts
@@ -1,84 +1,28 @@
+import type { TransientVisibilityActivity, TransientVisibilityState } from './transient-visibility.svelte';
+
 export const CONTEXT_BAR_TRANSIENT_VISIBLE_MS = 1500;
 export const CONTEXT_BAR_FADE_IN_MS = 180;
 export const CONTEXT_BAR_FADE_OUT_MS = 400;
 
 export type ContextBarTone = 'transient' | 'engaged';
 
-export type ContextBarSegmentActivity = {
-  transient: boolean;
-  hovered: boolean;
-  focused: boolean;
-  holds: readonly string[];
-};
+export type ContextBarSegmentActivity = TransientVisibilityActivity;
 
 export type ContextBarSegmentPresentation = {
   visible: boolean;
   tone: ContextBarTone;
 };
 
-export class EditorContextBarSegmentState {
-  #hideTimer: ReturnType<typeof setTimeout> | undefined;
-  transient = $state(false);
-  hovered = $state(false);
-  focused = $state(false);
-  holds = $state<string[]>([]);
-
-  get activity(): ContextBarSegmentActivity {
-    return {
-      transient: this.transient,
-      hovered: this.hovered,
-      focused: this.focused,
-      holds: this.holds,
-    };
-  }
-
-  showTemporarily(durationMs: number): void {
-    this.transient = true;
-    clearTimeout(this.#hideTimer);
-    this.#hideTimer = setTimeout(() => {
-      this.transient = false;
-      this.#hideTimer = undefined;
-    }, durationMs);
-  }
-
-  hideTransient(): void {
-    clearTimeout(this.#hideTimer);
-    this.#hideTimer = undefined;
-    this.transient = false;
-  }
-
-  setHovered(hovered: boolean): void {
-    this.hovered = hovered;
-  }
-
-  setFocused(focused: boolean): void {
-    this.focused = focused;
-  }
-
-  hold(reason: string): void {
-    if (!this.holds.includes(reason)) this.holds = [...this.holds, reason];
-  }
-
-  release(reason: string): void {
-    if (this.holds.includes(reason)) this.holds = this.holds.filter((hold) => hold !== reason);
-  }
-
-  destroy(): void {
-    this.hideTransient();
-    this.hovered = false;
-    this.focused = false;
-    this.holds = [];
-  }
-}
+export type EditorContextBarSegmentState = TransientVisibilityState;
 
 type ContextBarPresentationInput = {
-  breadcrumb: ContextBarSegmentActivity;
+  leading: ContextBarSegmentActivity;
   viewControls: ContextBarSegmentActivity;
 };
 
 export type ContextBarPresentation = {
   unified: boolean;
-  breadcrumb: ContextBarSegmentPresentation;
+  leading: ContextBarSegmentPresentation;
   viewControls: ContextBarSegmentPresentation;
 };
 
@@ -102,13 +46,13 @@ export class ContextBarVisibilityCoordinator {
 
   resolve(input: ContextBarPresentationInput): ContextBarPresentation {
     const requested = {
-      breadcrumb: resolveContextBarSegmentRequest(input.breadcrumb),
+      leading: resolveContextBarSegmentRequest(input.leading),
       viewControls: resolveContextBarSegmentRequest(input.viewControls),
     };
 
-    if (!this.#unified && requested.breadcrumb.visible && requested.viewControls.visible) this.#unified = true;
+    if (!this.#unified && requested.leading.visible && requested.viewControls.visible) this.#unified = true;
 
-    if (!requested.breadcrumb.visible && !requested.viewControls.visible) {
+    if (!requested.leading.visible && !requested.viewControls.visible) {
       this.#unified = false;
       return { unified: false, ...requested };
     }
@@ -117,7 +61,7 @@ export class ContextBarVisibilityCoordinator {
 
     return {
       unified: true,
-      breadcrumb: requested.breadcrumb.visible ? requested.breadcrumb : { visible: true, tone: 'transient' },
+      leading: requested.leading.visible ? requested.leading : { visible: true, tone: 'transient' },
       viewControls: requested.viewControls.visible ? requested.viewControls : { visible: true, tone: 'transient' },
     };
   }

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.test.ts
@@ -32,9 +32,9 @@ describe('editor context bar visibility', () => {
   it('unifies two visible segments regardless of whether their fade wings meet', () => {
     const coordinator = new ContextBarVisibilityCoordinator();
 
-    expect(coordinator.resolve({ breadcrumb: transient(), viewControls: engaged() })).toEqual({
+    expect(coordinator.resolve({ leading: transient(), viewControls: engaged() })).toEqual({
       unified: true,
-      breadcrumb: { visible: true, tone: 'transient' },
+      leading: { visible: true, tone: 'transient' },
       viewControls: { visible: true, tone: 'engaged' },
     });
   });
@@ -42,10 +42,10 @@ describe('editor context bar visibility', () => {
   it('retains both segments while either unified segment still has a visibility reason', () => {
     const coordinator = new ContextBarVisibilityCoordinator();
 
-    coordinator.resolve({ breadcrumb: transient(), viewControls: engaged() });
-    expect(coordinator.resolve({ breadcrumb: idle(), viewControls: engaged() })).toEqual({
+    coordinator.resolve({ leading: transient(), viewControls: engaged() });
+    expect(coordinator.resolve({ leading: idle(), viewControls: engaged() })).toEqual({
       unified: true,
-      breadcrumb: { visible: true, tone: 'transient' },
+      leading: { visible: true, tone: 'transient' },
       viewControls: { visible: true, tone: 'engaged' },
     });
   });
@@ -53,9 +53,9 @@ describe('editor context bar visibility', () => {
   it('does not reveal a sibling until both segments have appeared together', () => {
     const coordinator = new ContextBarVisibilityCoordinator();
 
-    expect(coordinator.resolve({ breadcrumb: transient(), viewControls: idle() })).toEqual({
+    expect(coordinator.resolve({ leading: transient(), viewControls: idle() })).toEqual({
       unified: false,
-      breadcrumb: { visible: true, tone: 'transient' },
+      leading: { visible: true, tone: 'transient' },
       viewControls: { visible: false, tone: 'transient' },
     });
   });
@@ -63,21 +63,21 @@ describe('editor context bar visibility', () => {
   it('dismisses a unified pair only after both segments have no visibility reason', () => {
     const coordinator = new ContextBarVisibilityCoordinator();
 
-    coordinator.resolve({ breadcrumb: transient(), viewControls: engaged() });
+    coordinator.resolve({ leading: transient(), viewControls: engaged() });
     expect(
       coordinator.resolve({
-        breadcrumb: idle(),
+        leading: idle(),
         viewControls: { ...idle(), holds: ['landmark'] },
       }),
     ).toEqual({
       unified: true,
-      breadcrumb: { visible: true, tone: 'transient' },
+      leading: { visible: true, tone: 'transient' },
       viewControls: { visible: true, tone: 'transient' },
     });
 
-    expect(coordinator.resolve({ breadcrumb: idle(), viewControls: idle() })).toEqual({
+    expect(coordinator.resolve({ leading: idle(), viewControls: idle() })).toEqual({
       unified: false,
-      breadcrumb: { visible: false, tone: 'transient' },
+      leading: { visible: false, tone: 'transient' },
       viewControls: { visible: false, tone: 'transient' },
     });
   });

--- a/apps/website/src/lib/editor-ffi/components/ui/transient-visibility.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/transient-visibility.svelte.ts
@@ -1,0 +1,69 @@
+export type TransientVisibilityActivity = {
+  transient: boolean;
+  hovered: boolean;
+  focused: boolean;
+  holds: readonly string[];
+};
+
+export class TransientVisibilityState {
+  #hideTimer: ReturnType<typeof setTimeout> | undefined;
+  transient = $state(false);
+  hovered = $state(false);
+  focused = $state(false);
+  holds = $state<string[]>([]);
+
+  get activity(): TransientVisibilityActivity {
+    return {
+      transient: this.transient,
+      hovered: this.hovered,
+      focused: this.focused,
+      holds: this.holds,
+    };
+  }
+
+  get visible(): boolean {
+    return this.transient || this.hovered || this.focused || this.holds.length > 0;
+  }
+
+  get engaged(): boolean {
+    return this.hovered || this.focused;
+  }
+
+  showTemporarily(durationMs: number): void {
+    this.transient = true;
+    clearTimeout(this.#hideTimer);
+    this.#hideTimer = setTimeout(() => {
+      this.transient = false;
+      this.#hideTimer = undefined;
+    }, durationMs);
+  }
+
+  hideTransient(): void {
+    clearTimeout(this.#hideTimer);
+    this.#hideTimer = undefined;
+    this.transient = false;
+  }
+
+  setHovered(hovered: boolean): void {
+    this.hovered = hovered;
+  }
+
+  setFocused(focused: boolean): void {
+    this.focused = focused;
+  }
+
+  hold(reason: string): void {
+    if (!this.holds.includes(reason)) this.holds = [...this.holds, reason];
+  }
+
+  release(reason: string): void {
+    if (this.holds.includes(reason)) this.holds = this.holds.filter((hold) => hold !== reason);
+  }
+
+  destroy(): void {
+    this.hideTransient();
+    this.hovered = false;
+    this.focused = false;
+    this.holds = [];
+  }
+}

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync-test-host.svelte
@@ -229,7 +229,7 @@
           <EditorContextBar {editorViewSurface} interactiveViewControlsWhenHidden {showViewControlsOnPaneEntry}>
             {#snippet viewControls({ state, presentation }: EditorContextBarSegmentRenderProps)}
               <div style="display: flex; align-items: center" aria-label="보기 제어" role="group">
-                <EditorZoomControls {...controls} segment={state} visible={presentation.visible} />
+                <EditorZoomControls {...controls} visibility={state} visible={presentation.visible} />
               </div>
             {/snippet}
           </EditorContextBar>

--- a/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
+++ b/apps/website/src/lib/editor-ffi/scroll-scope.test.ts
@@ -160,6 +160,22 @@ describe('EditorScrollScope', () => {
     targetBottom: 520,
   };
 
+  it('updates top and bottom occlusions independently', () => {
+    const { scope } = setup(
+      trackedSnapshot('unused', {
+        page_idx: 0,
+        rect: { x: 0, y: 0, width: 1, height: 20 },
+      }),
+    );
+
+    scope.setBottomInset(40);
+    scope.setTopInset(32);
+    expect(scope.visibleArea).toEqual({ topInset: 32, bottomInset: 40 });
+
+    scope.setTopInset(0);
+    expect(scope.visibleArea).toEqual({ topInset: 0, bottomInset: 40 });
+  });
+
   it('lets external content extend the bottom padding without changing the visible area', () => {
     const snapshot = trackedSnapshot('unused', {
       page_idx: 0,

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -620,6 +620,15 @@ export class EditorScrollScope {
     });
   }
 
+  setTopInset(topInset: number): void {
+    untrack(() => {
+      this.setVisibleArea({
+        topInset,
+        bottomInset: this.visibleArea.bottomInset,
+      });
+    });
+  }
+
   setContentBottomOverflow(bottomOverflow: number): void {
     const next = sanitizeInset(bottomOverflow);
     if (this.#contentBottomOverflow === next) return;

--- a/apps/website/src/lib/hover-intent.test.ts
+++ b/apps/website/src/lib/hover-intent.test.ts
@@ -210,4 +210,23 @@ describe('hoverIntent', () => {
 
     action?.destroy?.();
   });
+
+  it('recovers a hover session from pointer movement after attaching inside the target', async () => {
+    const onEnter = vi.fn();
+    const onIntent = vi.fn();
+    const action = hoverIntent(element, { delay: 400, intentEnabled: false, samples: 1, onEnter, onIntent });
+
+    pointer(element, 'pointermove', 10, 10);
+    expect(onEnter).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(400);
+    expect(onIntent).not.toHaveBeenCalled();
+
+    action?.update?.({ delay: 400, intentEnabled: true, samples: 1, onEnter, onIntent });
+    await vi.advanceTimersByTimeAsync(99);
+    expect(onIntent).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onIntent).toHaveBeenCalledOnce();
+
+    action?.destroy?.();
+  });
 });

--- a/apps/website/src/routes/usersite/wildcard/+layout.svelte
+++ b/apps/website/src/routes/usersite/wildcard/+layout.svelte
@@ -38,6 +38,21 @@
   const theme = getThemeContext();
 
   let themeMenuOpen = $state(false);
+  let environmentBannerHeight = $state(0);
+  let stickyHeader = $state<HTMLElement>();
+  let stickyHeaderHeight = $state(52);
+  let stickyHeaderBottom = $state(52);
+
+  function syncStickyHeaderBottom(): void {
+    stickyHeaderBottom = stickyHeader?.getBoundingClientRect().bottom ?? stickyHeaderHeight;
+  }
+
+  $effect(() => {
+    void environmentBannerHeight;
+    void stickyHeaderHeight;
+    syncStickyHeaderBottom();
+  });
+
   onMount(() => {
     if (!query.data.me && !document.cookie.includes('typie-af')) {
       location.assign(
@@ -82,9 +97,14 @@
   );
 </script>
 
-<div class={flex({ flexDirection: 'column', minHeight: '[100dvh]' })}>
-  <EnvironmentBanner />
+<svelte:window onresize={syncStickyHeaderBottom} onscroll={syncStickyHeaderBottom} />
+
+<div style:--usersite-sticky-header-bottom={`${stickyHeaderBottom}px`} class={flex({ flexDirection: 'column', minHeight: '[100dvh]' })}>
+  <div bind:clientHeight={environmentBannerHeight}>
+    <EnvironmentBanner />
+  </div>
   <header
+    bind:this={stickyHeader}
     class={flex({
       flexDirection: 'column',
       position: 'sticky',
@@ -92,6 +112,7 @@
       zIndex: '50',
       backgroundColor: 'surface.default',
     })}
+    bind:clientHeight={stickyHeaderHeight}
   >
     <AdminImpersonateBanner query$key={query.data} />
 

--- a/packages/ui/src/actions/hover-intent.svelte.ts
+++ b/packages/ui/src/actions/hover-intent.svelte.ts
@@ -98,7 +98,11 @@ export const hoverIntent: Action<HTMLElement, HoverIntentParameter> = (element, 
   };
 
   const handlePointerMove = (event: PointerEvent) => {
-    if (!hovered || intended || event.pointerType === 'touch') return;
+    if (intended || event.pointerType === 'touch') return;
+    if (!hovered) {
+      handlePointerEnter(event);
+      return;
+    }
     pointerEvent = event;
     pointerX = event.clientX;
     pointerY = event.clientY;

--- a/packages/ui/src/context/app.svelte.ts
+++ b/packages/ui/src/context/app.svelte.ts
@@ -28,6 +28,8 @@ export type AppPreference = {
 
   zenModeEnabled: boolean;
 
+  contextBarPinned: boolean;
+
   searchMatchWholeWord: boolean;
 
   exportFormat: 'DOCX' | 'EPUB' | 'HWP' | 'PDF';
@@ -161,6 +163,8 @@ export const setupAppContext = (userId: string) => {
       autoSurroundEnabled: true,
 
       zenModeEnabled: false,
+
+      contextBarPinned: true,
 
       searchMatchWholeWord: false,
 


### PR DESCRIPTION
- 컨텍스트 바에 고정 토글을 추가합니다.
  - 기본값은 고정 상태입니다.
  - 사용자 preference에 저장하고 모든 pane에 함께 적용합니다.
  - 키보드 접근과 `aria-pressed`, 상태별 접근성 라벨을 제공합니다.
- 고정 및 일시 노출 상태가 동일한 visibility 흐름을 사용하도록 정리합니다.
  - transient, hover, focus, landmark 유지 상태를 공통으로 처리합니다.
  - 배경과 foreground가 시차를 두고 확장되며 퇴장 transition도 유지합니다.
- 컨텍스트 바가 표시되는 동안 에디터 visible area의 top occlusion을 반영합니다.
  - cursor guard 여백을 컨텍스트 바 아래에서 유지합니다.
  - 타임라인 슬라이더의 bottom occlusion과 독립적으로 동작합니다.
- 공개 뷰어에서는 컨텍스트 바를 노출하지 않습니다.
  - 줌 동작이 발생할 때만 줌 컨트롤을 sticky header 아래 우상단에 플로팅합니다.
  - 숨겨진 상태에서는 포인터 입력을 가로채지 않습니다.
- breadcrumb의 양쪽 scroll fog와 lane hover 진입 처리를 보완합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>