### PR TITLE
에디터 줌에서 이미지/임베드 컨트롤 크기를 고정

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ExternalEmbed.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalEmbed.svelte
@@ -19,6 +19,10 @@
     element: ExternalElement;
   };
 
+  const ACTION_SIZE = 28;
+  const ACTION_INSET = 8;
+  const ACTION_GAP = 4;
+
   let { element }: Props = $props();
 
   const ctx = getEditorContext();
@@ -28,9 +32,20 @@
   const asset = $derived(embedId ? ctx.editor?.embedAssets.get(embedId) : undefined);
   const inflight = $derived(ctx.editor?.inflightEmbeds.get(element.node));
   const canEdit = $derived(!ctx.editor?.readOnly);
+  const displayZoom = $derived(ctx.editor?.safeDisplayZoom() ?? 1);
 
   let inflightUrl = $state('');
   let error = $state(false);
+  let componentWidth = $state(0);
+  let componentHeight = $state(0);
+
+  const fixedControlTransform = $derived(displayZoom === 1 ? undefined : `scale(${1 / displayZoom})`);
+  const visibleActionCount = $derived.by(() => {
+    const availableWidth = componentWidth * displayZoom - ACTION_INSET * displayZoom;
+    const availableHeight = componentHeight * displayZoom - ACTION_INSET * displayZoom;
+    if (availableWidth < ACTION_SIZE || availableHeight < ACTION_SIZE) return 0;
+    return availableWidth >= ACTION_SIZE * 2 + ACTION_GAP * displayZoom ? 2 : 1;
+  });
 
   const selectedBlockNodes = $derived(ctx.editor?.blockState?.nodes ?? []);
   const isOnlySelectedElement = $derived(
@@ -122,7 +137,7 @@
 </script>
 
 <ExternalElementWrapper {element} minHeight={asset ? undefined : '48px'}>
-  <div class={css({ position: 'relative', width: 'full' })}>
+  <div class={css({ position: 'relative', width: 'full' })} bind:clientWidth={componentWidth} bind:clientHeight={componentHeight}>
     {#if asset}
       {#if asset.html}
         <div class={css({ display: 'contents' }, canEdit && { pointerEvents: 'none' })}>
@@ -169,30 +184,13 @@
         </div>
       {/if}
 
-      <div class={flex({ position: 'absolute', top: '8px', right: '8px', gap: '4px' })}>
-        <button
-          class={css({
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            borderRadius: '4px',
-            color: 'text.bright',
-            backgroundColor: '[#363839/70]',
-            size: '28px',
-            _hover: { backgroundColor: '[#363839/40]' },
-          })}
-          aria-label="링크 열기"
-          onclick={() => window.open(asset.url, '_blank', 'noopener,noreferrer')}
-          onpointerdown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          type="button"
+      {#if visibleActionCount > 0}
+        <div
+          style:gap={`${ACTION_GAP * displayZoom}px`}
+          style:transform={fixedControlTransform}
+          style:transform-origin="top right"
+          class={flex({ position: 'absolute', top: '8px', right: '8px' })}
         >
-          <Icon icon={ExternalLinkIcon} size={16} />
-        </button>
-
-        {#if canEdit}
           <button
             class={css({
               display: 'flex',
@@ -204,18 +202,42 @@
               size: '28px',
               _hover: { backgroundColor: '[#363839/40]' },
             })}
-            aria-label="임베드 삭제"
-            onclick={deleteNode}
+            aria-label="링크 열기"
+            onclick={() => window.open(asset.url, '_blank', 'noopener,noreferrer')}
             onpointerdown={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
             type="button"
           >
-            <Icon icon={Trash2Icon} size={16} />
+            <Icon icon={ExternalLinkIcon} size={16} />
           </button>
-        {/if}
-      </div>
+
+          {#if canEdit && visibleActionCount > 1}
+            <button
+              class={css({
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: '4px',
+                color: 'text.bright',
+                backgroundColor: '[#363839/70]',
+                size: '28px',
+                _hover: { backgroundColor: '[#363839/40]' },
+              })}
+              aria-label="임베드 삭제"
+              onclick={deleteNode}
+              onpointerdown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              type="button"
+            >
+              <Icon icon={Trash2Icon} size={16} />
+            </button>
+          {/if}
+        </div>
+      {/if}
     {:else}
       <div
         class={flex({

--- a/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImage.svelte
@@ -29,6 +29,14 @@
     boundsWidth: number;
   };
 
+  const ACTION_SIZE = 28;
+  const ACTION_INSET = 10;
+  const ACTION_GAP = 6;
+  const RESIZE_HANDLE_MAX_HEIGHT = 72;
+  const RESIZE_HANDLE_MIN_HEIGHT = 24;
+  const UPLOAD_SPINNER_SIZE = 24;
+  const UPLOAD_SPINNER_MIN_SIZE = 12;
+
   let { element }: Props = $props();
 
   const ctx = getEditorContext();
@@ -59,7 +67,9 @@
   const imageSrc = $derived(asset?.url ?? inflight?.url);
   const originalWidth = $derived(asset?.width ?? inflight?.width ?? 0);
   const originalHeight = $derived(asset?.height ?? inflight?.height ?? 0);
+  const displayZoom = $derived(ctx.editor?.safeDisplayZoom() ?? 1);
   const liveWidth = $derived(calculateImageWidth(element.bounds.width, proportion, originalWidth));
+  const liveHeight = $derived(originalWidth > 0 ? liveWidth * (originalHeight / originalWidth) : 0);
   const containerSize = $derived(
     calculateImageContainerSize({
       boundsWidth: element.bounds.width,
@@ -68,6 +78,20 @@
       originalHeight,
     }),
   );
+  const displayedWidth = $derived(liveWidth * displayZoom);
+  const displayedHeight = $derived(liveHeight * displayZoom);
+  const fixedControlTransform = $derived(displayZoom === 1 ? undefined : `scale(${1 / displayZoom})`);
+  const visibleActionCount = $derived.by(() => {
+    const availableWidth = displayedWidth - ACTION_INSET * displayZoom;
+    const availableHeight = displayedHeight - ACTION_INSET * displayZoom;
+    if (availableWidth < ACTION_SIZE || availableHeight < ACTION_SIZE) return 0;
+    return availableWidth >= ACTION_SIZE * 2 + ACTION_GAP * displayZoom ? 2 : 1;
+  });
+  const resizeHandleVisualHeight = $derived(
+    Math.max(RESIZE_HANDLE_MIN_HEIGHT, Math.min(liveHeight / 3, RESIZE_HANDLE_MAX_HEIGHT, displayedHeight)),
+  );
+  const uploadSpinnerVisualSize = $derived(Math.min(UPLOAD_SPINNER_SIZE, displayedWidth, displayedHeight));
+  const showUploadSpinner = $derived(uploadSpinnerVisualSize >= UPLOAD_SPINNER_MIN_SIZE);
   const canEdit = $derived(!ctx.editor?.readOnly);
   const selectedBlockNodes = $derived(ctx.editor?.blockState?.nodes ?? []);
   const isOnlySelectedElement = $derived(
@@ -328,13 +352,27 @@
       />
 
       {#if stage === 'uploading'}
-        <div class={center({ position: 'absolute', inset: '0', backgroundColor: 'white/50' })}>
-          <RingSpinner style={css.raw({ size: '24px', color: 'text.disabled' })} />
+        <div class={center({ position: 'absolute', inset: '0', backgroundColor: 'white/50' })} aria-label="이미지 업로드 중" role="status">
+          {#if showUploadSpinner}
+            <div
+              style:width={`${uploadSpinnerVisualSize}px`}
+              style:height={`${uploadSpinnerVisualSize}px`}
+              style:transform={fixedControlTransform}
+              style:transform-origin="center"
+            >
+              <RingSpinner style={css.raw({ size: 'full', color: 'text.disabled' })} />
+            </div>
+          {/if}
         </div>
       {/if}
 
-      {#if canEdit && stage === 'ready'}
-        <div class={flex({ position: 'absolute', top: '10px', right: '10px', gap: '6px', zIndex: '10' })}>
+      {#if canEdit && stage === 'ready' && visibleActionCount > 0}
+        <div
+          style:gap={`${ACTION_GAP * displayZoom}px`}
+          style:transform={fixedControlTransform}
+          style:transform-origin="top right"
+          class={flex({ position: 'absolute', top: '10px', right: '10px', zIndex: '10' })}
+        >
           <button
             class={center({
               borderRadius: '4px',
@@ -356,37 +394,42 @@
             <Icon icon={Maximize2Icon} size={16} />
           </button>
 
-          <button
-            class={center({
-              borderRadius: '4px',
-              size: '28px',
-              color: 'text.bright',
-              backgroundColor: '[#363839/70]',
-              opacity: '0',
-              transition: 'opacity',
-              _hover: { backgroundColor: '[#363839/40]' },
-              _groupHover: { opacity: '100' },
-            })}
-            aria-label="이미지 삭제"
-            onclick={deleteNode}
-            onpointerdown={(event) => {
-              event.stopPropagation();
-            }}
-            type="button"
-          >
-            <Icon icon={Trash2Icon} size={16} />
-          </button>
+          {#if visibleActionCount > 1}
+            <button
+              class={center({
+                borderRadius: '4px',
+                size: '28px',
+                color: 'text.bright',
+                backgroundColor: '[#363839/70]',
+                opacity: '0',
+                transition: 'opacity',
+                _hover: { backgroundColor: '[#363839/40]' },
+                _groupHover: { opacity: '100' },
+              })}
+              aria-label="이미지 삭제"
+              onclick={deleteNode}
+              onpointerdown={(event) => {
+                event.stopPropagation();
+              }}
+              type="button"
+            >
+              <Icon icon={Trash2Icon} size={16} />
+            </button>
+          {/if}
         </div>
+      {/if}
 
+      {#if canEdit && stage === 'ready'}
         <div class={flex({ position: 'absolute', top: '0', bottom: '0', left: '10px', alignItems: 'center', pointerEvents: 'none' })}>
           <button
+            style:height={`${resizeHandleVisualHeight}px`}
+            style:transform={fixedControlTransform}
+            style:transform-origin="left center"
             class={css({
               borderRadius: '4px',
               backgroundColor: 'white/50',
               mixBlendMode: 'difference',
               width: '8px',
-              height: '1/3',
-              maxHeight: '72px',
               cursor: 'col-resize',
               opacity: '0',
               transition: 'opacity',
@@ -408,13 +451,14 @@
 
         <div class={flex({ position: 'absolute', top: '0', bottom: '0', right: '10px', alignItems: 'center', pointerEvents: 'none' })}>
           <button
+            style:height={`${resizeHandleVisualHeight}px`}
+            style:transform={fixedControlTransform}
+            style:transform-origin="right center"
             class={css({
               borderRadius: '4px',
               backgroundColor: 'white/50',
               mixBlendMode: 'difference',
               width: '8px',
-              height: '1/3',
-              maxHeight: '72px',
               cursor: 'col-resize',
               opacity: '0',
               transition: 'opacity',

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -12,6 +12,10 @@ import type { PlainDoc, PlainNode, PlainNodeEntry } from '@typie/editor-ffi/brow
 import type { EditorFrameSyncTestHarness } from './editor-frame-sync-test-host.svelte';
 
 vi.mock('$env/dynamic/public', () => ({ env: {} }));
+vi.mock('@mearie/svelte', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@mearie/svelte')>();
+  return { ...original, createMutation: () => [vi.fn()] };
+});
 
 const PAGE_WIDTH = 320;
 const PAGE_HEIGHT = 220;
@@ -146,6 +150,12 @@ function continuousDoc(text = ''): PlainDoc {
       ...document.root,
       node: { type: 'root', layout_mode: { type: 'continuous', max_width: 600 } },
     },
+  };
+}
+
+function externalComponentDoc(node: PlainNode): PlainDoc {
+  return {
+    root: entry({ type: 'root', layout_mode: { type: 'continuous', max_width: PAGE_WIDTH } }, [entry(node)]),
   };
 }
 
@@ -303,6 +313,12 @@ async function mountEditor(
   await tick();
   await vi.waitFor(() => expect(editor?.published?.frames.get(0)).toBeDefined());
   return { editor, ...result };
+}
+
+async function setDisplayZoom(editor: Editor, displayZoom: number): Promise<void> {
+  editor.displayZoom = displayZoom;
+  await tick();
+  await nextAnimationFrame();
 }
 
 async function mountEditorWithPublishedReady(plain: PlainDoc, options: { headerHeight?: number } = {}) {
@@ -1578,6 +1594,160 @@ describe('web editor frame synchronization', () => {
     expect(editor.published?.frames.get(0)?.canvas.height).toBeGreaterThan(0);
     expect(attachSurfaceSpy.mock.calls.filter(([page]) => page === 0)).toHaveLength(1);
     expectActualCanvas(editor, 0, false);
+  });
+
+  it('keeps image component chrome fixed while content, inset, and gaps follow display zoom', async () => {
+    const { editor } = await mountEditor(externalComponentDoc({ type: 'image', id: 'asset', proportion: 100 }));
+    editor.imageAssets.set('asset', {
+      id: 'asset',
+      url: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"/>',
+      originalUrl: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"/>',
+      width: 100,
+      height: 100,
+      placeholder: '',
+    });
+
+    await expect.poll(() => document.querySelectorAll('[aria-label="이미지 크기 조절"]').length).toBe(2);
+    const image = document.querySelector<HTMLElement>('img[alt="본문 이미지"]');
+    expect(image).not.toBeNull();
+    if (!image) throw new Error('Expected a ready image');
+
+    const readChrome = () => {
+      const expand = document.querySelector<HTMLElement>('[aria-label="이미지 확대 보기"]');
+      const remove = document.querySelector<HTMLElement>('[aria-label="이미지 삭제"]');
+      const handles = [...document.querySelectorAll<HTMLElement>('[aria-label="이미지 크기 조절"]')];
+      expect(expand).not.toBeNull();
+      expect(remove).not.toBeNull();
+      expect(handles).toHaveLength(2);
+      if (!expand || !remove || handles.length !== 2) throw new Error('Expected ready image chrome');
+      const imageRect = image.getBoundingClientRect();
+      const expandRect = expand.getBoundingClientRect();
+      const removeRect = remove.getBoundingClientRect();
+      const handleRect = handles[0].getBoundingClientRect();
+      const iconRect = expand.querySelector('svg')?.getBoundingClientRect();
+      if (!iconRect) throw new Error('Expected an image action icon');
+      return {
+        imageRect,
+        expandRect,
+        removeRect,
+        handleRect,
+        iconRect,
+        rightInset: imageRect.right - removeRect.right,
+        gap: removeRect.left - expandRect.right,
+      };
+    };
+
+    const unit = readChrome();
+    expect(unit.imageRect.width).toBeCloseTo(100, 0);
+    expect(unit.expandRect.width).toBeCloseTo(28, 0);
+    expect(unit.iconRect.width).toBeCloseTo(16, 0);
+    expect(unit.handleRect.width).toBeCloseTo(8, 0);
+    expect(unit.handleRect.height).toBeCloseTo(100 / 3, 0);
+    expect(unit.rightInset).toBeCloseTo(10, 0);
+    expect(unit.gap).toBeCloseTo(6, 0);
+
+    await setDisplayZoom(editor, 2);
+    const doubled = readChrome();
+    expect(doubled.imageRect.width).toBeCloseTo(200, 0);
+    expect(doubled.expandRect.width).toBeCloseTo(unit.expandRect.width, 0);
+    expect(doubled.iconRect.width).toBeCloseTo(unit.iconRect.width, 0);
+    expect(doubled.handleRect.width).toBeCloseTo(unit.handleRect.width, 0);
+    expect(doubled.handleRect.height).toBeCloseTo(unit.handleRect.height, 0);
+    expect(doubled.rightInset).toBeCloseTo(unit.rightInset * 2, 0);
+    expect(doubled.gap).toBeCloseTo(unit.gap * 2, 0);
+
+    await setDisplayZoom(editor, 0.5);
+    const compactExpand = document.querySelector<HTMLElement>('[aria-label="이미지 확대 보기"]');
+    expect(compactExpand?.getBoundingClientRect().width).toBeCloseTo(28, 0);
+    expect(document.querySelector('[aria-label="이미지 삭제"]')).toBeNull();
+    expect(document.querySelectorAll('[aria-label="이미지 크기 조절"]')).toHaveLength(2);
+
+    await setDisplayZoom(editor, 0.2);
+    expect(image.getBoundingClientRect().width).toBeCloseTo(20, 0);
+    expect(document.querySelector('[aria-label="이미지 확대 보기"]')).toBeNull();
+    expect(document.querySelector('[aria-label="이미지 삭제"]')).toBeNull();
+    const minimumHandles = [...document.querySelectorAll<HTMLElement>('[aria-label="이미지 크기 조절"]')];
+    expect(minimumHandles).toHaveLength(2);
+    expect(minimumHandles[0]?.getBoundingClientRect().height).toBeCloseTo(24, 0);
+  });
+
+  it('keeps uploading image status accessible while its spinner fits available space', async () => {
+    const { editor } = await mountEditor(externalComponentDoc({ type: 'image', id: 'asset', proportion: 100 }));
+    const image = editor.appliedSnapshot.externalElements[0];
+    if (!image) throw new Error('Expected an image external element');
+    editor.inflightImages.set(image.node, {
+      uploadId: 'uploading-image',
+      url: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"/>',
+      width: 40,
+      height: 40,
+    });
+
+    await expect.poll(() => document.querySelector('[role="status"][aria-label="이미지 업로드 중"]')).not.toBeNull();
+    const status = document.querySelector<HTMLElement>('[role="status"][aria-label="이미지 업로드 중"]');
+    const spinner = status?.querySelector<SVGElement>('svg');
+    expect(spinner?.getBoundingClientRect().width).toBeCloseTo(24, 0);
+
+    await setDisplayZoom(editor, 0.5);
+    const compactSpinner = status?.querySelector<SVGElement>('svg');
+    expect(compactSpinner?.getBoundingClientRect().width).toBeCloseTo(20, 0);
+
+    await setDisplayZoom(editor, 0.2);
+    expect(status?.isConnected).toBe(true);
+    expect(status?.querySelector('svg')).toBeNull();
+  });
+
+  it('keeps embed component chrome fixed and removes it when the embed cannot contain one action', async () => {
+    const { editor } = await mountEditor(externalComponentDoc({ type: 'embed', id: 'embed' }));
+    editor.embedAssets.set('embed', {
+      id: 'embed',
+      url: 'https://example.com',
+      title: 'Example',
+      description: 'Embedded content',
+      thumbnailUrl: null,
+      html: null,
+    });
+
+    await expect.poll(() => document.querySelector('[aria-label="링크 열기"]')).not.toBeNull();
+    const readChrome = () => {
+      const wrapper = document.querySelector<HTMLElement>('[data-external-element]');
+      const open = document.querySelector<HTMLElement>('[aria-label="링크 열기"]');
+      const remove = document.querySelector<HTMLElement>('[aria-label="임베드 삭제"]');
+      expect(wrapper).not.toBeNull();
+      expect(open).not.toBeNull();
+      expect(remove).not.toBeNull();
+      if (!wrapper || !open || !remove) throw new Error('Expected ready embed chrome');
+      const wrapperRect = wrapper.getBoundingClientRect();
+      const openRect = open.getBoundingClientRect();
+      const removeRect = remove.getBoundingClientRect();
+      const iconRect = open.querySelector('svg')?.getBoundingClientRect();
+      if (!iconRect) throw new Error('Expected an embed action icon');
+      return {
+        wrapperRect,
+        openRect,
+        removeRect,
+        iconRect,
+        rightInset: wrapperRect.right - removeRect.right,
+        gap: removeRect.left - openRect.right,
+      };
+    };
+
+    const unit = readChrome();
+    expect(unit.openRect.width).toBeCloseTo(28, 0);
+    expect(unit.iconRect.width).toBeCloseTo(16, 0);
+    expect(unit.rightInset).toBeCloseTo(8, 0);
+    expect(unit.gap).toBeCloseTo(4, 0);
+
+    await setDisplayZoom(editor, 2);
+    const doubled = readChrome();
+    expect(doubled.wrapperRect.width).toBeCloseTo(unit.wrapperRect.width * 2, 0);
+    expect(doubled.openRect.width).toBeCloseTo(unit.openRect.width, 0);
+    expect(doubled.iconRect.width).toBeCloseTo(unit.iconRect.width, 0);
+    expect(doubled.rightInset).toBeCloseTo(unit.rightInset * 2, 0);
+    expect(doubled.gap).toBeCloseTo(unit.gap * 2, 0);
+
+    await setDisplayZoom(editor, 0.2);
+    expect(document.querySelector('[aria-label="링크 열기"]')).toBeNull();
+    expect(document.querySelector('[aria-label="임베드 삭제"]')).toBeNull();
   });
 
   it('commits a large continuous scale gap with coherent layout and surface publication', async () => {


### PR DESCRIPTION
에디터 줌과 무관하게 이미지·임베드 액션 버튼과 이미지 resizer의 시각적 크기를 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>