### PR TITLE
프리즘 리뷰 카드 컬럼 스크롤 범위 수정

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardColumn.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardColumn.svelte
@@ -6,7 +6,7 @@
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import ChevronUpIcon from '~icons/lucide/chevron-up';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
-  import { layoutCards } from './column-layout.ts';
+  import { CARD_BOTTOM_GAP, layoutBottomWithin, layoutCards } from './column-layout.ts';
   import { getMarginContext } from './context.svelte.ts';
   import { lanePresentation } from './margin-motion.ts';
   import { COLUMN_WIDTH, edgeJumpLabel } from './margin-view.ts';
@@ -124,7 +124,7 @@
     });
   };
 
-  const syncContentBottomOverflow = (cardExtent: number) => {
+  const syncContentBottomOverflow = () => {
     const editor = ctx.editor;
     const scroll = ctx.scroll;
     const area = editor?.extensionAreaEl;
@@ -132,6 +132,12 @@
     if (!scroll || !area || !lastPage) return;
 
     const contentBottom = lastPage.getBoundingClientRect().bottom - area.getBoundingClientRect().top;
+    const cardBottoms = Object.values(cardEls).flatMap((element) => {
+      if (!element) return [];
+      const bottom = layoutBottomWithin(element, area);
+      return bottom === null ? [] : [bottom];
+    });
+    const cardExtent = cardBottoms.length === 0 ? 0 : Math.max(...cardBottoms) + CARD_BOTTOM_GAP;
     scroll.setContentBottomOverflow(Math.max(0, cardExtent - contentBottom));
   };
 
@@ -160,7 +166,7 @@
     const result = layoutCards(entries, margin.activeId);
     tops = result.tops;
     spacer = result.spacer;
-    syncContentBottomOverflow(result.spacer);
+    void tick().then(syncContentBottomOverflow);
     const activation = margin.activation;
     const active = activation.sequence === pendingRevealSequence ? entries.find((entry) => entry.id === activation.id) : undefined;
     const editor = ctx.editor;
@@ -504,6 +510,7 @@
     <div class={flex({ direction: 'column', gap: '10px', marginTop: '12px' })}>
       {#each cards as item (item.id)}
         <div
+          bind:this={cardEls[item.id]}
           style:opacity={presentation.opacity}
           style:transform={`scale(${presentation.scale})`}
           style:will-change={presentationAnimating ? 'opacity, transform' : 'auto'}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/column-layout.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/column-layout.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { CARD_GAP, layoutCards } from './column-layout.ts';
+import { CURSOR_VISIBLE_MARGIN } from '$lib/editor-ffi/constants';
+import { CARD_GAP, layoutBottomWithin, layoutCards } from './column-layout.ts';
 import type { CardEntry } from './column-layout.ts';
 
 const entry = (id: string, desired: number, height = 100): CardEntry => ({ id, desired, height });
+
+const layoutElement = (offsetTop: number, offsetHeight: number, offsetParent: HTMLElement | null): HTMLElement =>
+  ({ offsetTop, offsetHeight, offsetParent }) as HTMLElement;
 
 describe('layoutCards', () => {
   it('겹치지 않으면 각자 앵커 높이에 선다', () => {
@@ -41,6 +45,16 @@ describe('layoutCards', () => {
 
   it('스페이서는 가장 아래 카드의 바닥을 덮는다', () => {
     const { spacer } = layoutCards([entry('a', 0), entry('b', 300)], null);
-    expect(spacer).toBe(300 + 100 + 8);
+    expect(spacer).toBe(300 + 100 + CURSOR_VISIBLE_MARGIN);
+  });
+
+  it('흐름 배치 카드의 하단을 컬럼 조상 좌표로 계산한다', () => {
+    const area = layoutElement(0, 0, null);
+    const column = layoutElement(0, 0, area);
+    const flow = layoutElement(12, 0, column);
+    const card = layoutElement(110, 100, flow);
+
+    expect(layoutBottomWithin).toBeTypeOf('function');
+    expect(layoutBottomWithin(card, area)).toBe(222);
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/column-layout.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/column-layout.ts
@@ -1,6 +1,20 @@
+import { CURSOR_VISIBLE_MARGIN } from '$lib/editor-ffi/constants';
+
 export type CardEntry = { id: string; desired: number; height: number };
 
 export const CARD_GAP = 12;
+export const CARD_BOTTOM_GAP = CURSOR_VISIBLE_MARGIN;
+
+export const layoutBottomWithin = (element: HTMLElement, ancestor: HTMLElement): number | null => {
+  let bottom = element.offsetHeight;
+  let current: HTMLElement | null = element;
+  while (current !== ancestor) {
+    bottom += current.offsetTop;
+    current = current.offsetParent as HTMLElement | null;
+    if (current === null) return null;
+  }
+  return bottom;
+};
 
 export const layoutCards = (entries: readonly CardEntry[], activeId: string | null): { tops: Record<string, number>; spacer: number } => {
   const sorted = entries.toSorted((a, b) => a.desired - b.desired);
@@ -35,5 +49,5 @@ export const layoutCards = (entries: readonly CardEntry[], activeId: string | nu
   }
 
   const bottoms = sorted.map((entry) => tops[entry.id] + entry.height);
-  return { tops, spacer: (bottoms.length > 0 ? Math.max(...bottoms) : 0) + 8 };
+  return { tops, spacer: (bottoms.length > 0 ? Math.max(...bottoms) : 0) + CARD_BOTTOM_GAP };
 };


### PR DESCRIPTION
- 이번 회차, 지난 회차, 자리 잃음 탭 모두 표시된 카드의 실제 하단을 기준으로 에디터 스크롤 범위를 확장합니다.
- 마지막 카드 아래에 cursor guard와 동일한 60px 여백을 둡니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>