### PR TITLE
엔티티 트리 조회에 사이트 권한 검사 추가

### DIFF
--- a/apps/api/src/graphql/resolvers/entity.ts
+++ b/apps/api/src/graphql/resolvers/entity.ts
@@ -121,6 +121,8 @@ Entity.implement({
     children: t.field({
       type: [Entity],
       resolve: async (self, _, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.siteId });
+
         const loader = ctx.loader({
           name: 'Entity.children',
           many: true,
@@ -143,6 +145,8 @@ Entity.implement({
       type: Entity,
       nullable: true,
       resolve: async (self, _, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.siteId });
+
         const loader = ctx.loader({
           name: 'Entity.firstChild',
           many: true,
@@ -168,6 +172,8 @@ Entity.implement({
       type: Entity,
       nullable: true,
       resolve: async (self, _, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.siteId });
+
         const loader = ctx.loader({
           name: 'Entity.lastChild',
           many: true,
@@ -192,6 +198,8 @@ Entity.implement({
     deletedChildren: t.field({
       type: [Entity],
       resolve: async (self, _, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.siteId });
+
         const loader = ctx.loader({
           name: 'Entity.deletedChildren',
           many: true,
@@ -318,7 +326,9 @@ Entity.implement({
 
     descendants: t.field({
       type: [Entity],
-      resolve: async (self) => {
+      resolve: async (self, _, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.siteId });
+
         const rows = await db.execute<{ id: string }>(sql`
           WITH RECURSIVE sq AS (
             SELECT ${Entities.id}, ${Entities.depth}

--- a/apps/api/src/graphql/resolvers/site.ts
+++ b/apps/api/src/graphql/resolvers/site.ts
@@ -44,6 +44,8 @@ Site.implement({
     entities: t.field({
       type: [Entity],
       resolve: async (self, _, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.id });
+
         const loader = ctx.loader({
           name: 'Site.entities',
           many: true,
@@ -65,7 +67,9 @@ Site.implement({
       type: Entity,
       nullable: true,
       args: { type: t.arg({ type: EntityType }) },
-      resolve: async (self, args) => {
+      resolve: async (self, args, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.id });
+
         const rows = await db.execute<{ id: string }>(
           sql`
             WITH RECURSIVE sq AS (
@@ -94,6 +98,8 @@ Site.implement({
       type: Entity,
       nullable: true,
       resolve: async (self, _, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.id });
+
         const loader = ctx.loader({
           name: 'Site.lastRootEntity',
           many: true,
@@ -160,7 +166,9 @@ Site.implement({
 
     deletedEntities: t.field({
       type: [Entity],
-      resolve: async (self) => {
+      resolve: async (self, _, ctx) => {
+        await assertSitePermission({ userId: ctx.session?.userId, siteId: self.id });
+
         const parentEntities = alias(Entities, 'parent_entities');
         return await db
           .select(getTableColumns(Entities))


### PR DESCRIPTION
## 배경

공유 문서의 비소유자는 문서 자체와 breadcrumb에 필요한 상위 경로에는 접근할 수 있어야 합니다.

하지만 기존에는 공유 문서나 상위 폴더의 ID를 이용해 `Entity.children`, `Site.entities` 등의 GraphQL 필드를 직접 호출하면 문서 소유자의 다른 폴더와 문서까지 탐색할 수 있었습니다. 프론트엔드에서 breadcrumb 팝업을 소유자에게만 표시하는 것으로는 직접적인 API 요청을 막을 수 없습니다.

## 변경 사항

- 엔티티 트리 탐색 필드에 기존 사이트 권한 검사를 적용했습니다.
  - `Entity.children`
  - `Entity.firstChild`
  - `Entity.lastChild`
  - `Entity.deletedChildren`
  - `Entity.descendants`
- 사이트 루트 트리 탐색 필드에도 같은 권한 검사를 적용했습니다.
  - `Site.entities`
  - `Site.firstEntity`
  - `Site.lastRootEntity`
  - `Site.deletedEntities`
- 공유 문서의 정적 breadcrumb를 표시하는 데 필요한 `Entity.ancestors` 접근은 유지했습니다.
- 새로운 권한 추상화나 GraphQL 스키마 변경 없이 기존 `assertSitePermission`을 각 데이터 경계에서 직접 사용했습니다.

## 동작 변화

- 사이트 소유자와 관리자는 기존처럼 엔티티 트리를 조회할 수 있습니다.
- 비소유자는 공유 문서 자체와 상위 경로를 볼 수 있지만, 소유자의 다른 문서나 폴더를 열거할 수 없습니다.
- 공개 페이지용 `SiteView`와 `EntityView` 동작은 변경하지 않습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>