### PR TITLE
에디터 breadcrumb에서 트리 탐색과 pane DnD 지원

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/BreadcrumbEntityNode.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/BreadcrumbEntityNode.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  import { createFragment, createQuery } from '@mearie/svelte';
+  import { css, cx } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import { Icon, RingSpinner } from '@typie/ui/components';
+  import ChevronDownIcon from '~icons/lucide/chevron-down';
+  import ChevronRightIcon from '~icons/lucide/chevron-right';
+  import FileIcon from '~icons/lucide/file';
+  import FolderIcon from '~icons/lucide/folder';
+  import { graphql } from '$mearie';
+  import EntityIcon from '../../../@context-menu/EntityIcon.svelte';
+  import EntityName from '../../../@tree/EntityName.svelte';
+  import BreadcrumbEntityNode from './BreadcrumbEntityNode.svelte';
+  import type { EditorBreadcrumbNavigation_Entity_entity$key } from '$mearie';
+  import type { BreadcrumbDocumentDragController } from './breadcrumb-document-drag.svelte';
+
+  const entityTreeRowStyle = css.raw({
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    paddingX: '8px',
+    borderRadius: '6px',
+    transition: 'common',
+    _supportHover: { backgroundColor: 'surface.muted' },
+  });
+
+  const nestedEntityTreeRowStyle = css.raw({
+    borderLeftWidth: '1px',
+    borderLeftRadius: '0',
+    marginLeft: '-1px',
+    paddingLeft: '14px',
+    _supportHover: { borderColor: 'border.strong' },
+  });
+
+  type Props = {
+    currentDocumentEntityId: string;
+    entity$key: EditorBreadcrumbNavigation_Entity_entity$key;
+    expandedFolderIds: ReadonlySet<string>;
+    highlightedEntityId: string;
+    level: number;
+    nested?: boolean;
+    parentEntityId?: string;
+    onActivateDocument: (slug: string) => void;
+    documentDrag: BreadcrumbDocumentDragController;
+    onToggleFolder: (entityId: string) => void;
+  };
+
+  let {
+    currentDocumentEntityId,
+    entity$key,
+    expandedFolderIds,
+    highlightedEntityId,
+    level,
+    nested = false,
+    parentEntityId,
+    onActivateDocument,
+    documentDrag,
+    onToggleFolder,
+  }: Props = $props();
+
+  const entity = createFragment(
+    graphql(`
+      fragment EditorBreadcrumbNavigation_Entity_entity on Entity {
+        id
+        slug
+        icon
+        iconColor
+        ...EntityIcon_entity
+
+        node {
+          __typename
+
+          ... on Folder {
+            id
+            name
+          }
+
+          ... on Document {
+            id
+            title
+          }
+
+          ... on Divider {
+            id
+          }
+        }
+      }
+    `),
+    () => entity$key,
+  );
+
+  const folder = $derived(entity.data.node.__typename === 'Folder');
+  const document = $derived(entity.data.node.__typename === 'Document');
+  const currentDocument = $derived(document && entity.data.id === currentDocumentEntityId);
+  const highlighted = $derived(entity.data.id === highlightedEntityId);
+  const expanded = $derived(folder && expandedFolderIds.has(entity.data.id));
+  const dragDocument = documentDrag.drag;
+  const dragItem = $derived(
+    entity.data.node.__typename === 'Document'
+      ? {
+          slug: entity.data.slug,
+          name: entity.data.node.title,
+          icon: entity.data.icon ?? undefined,
+        }
+      : null,
+  );
+
+  const children = createQuery(
+    graphql(`
+      query EditorBreadcrumbNavigation_FolderChildren_Query($entityId: ID!) {
+        entity(entityId: $entityId) {
+          id
+
+          children {
+            id
+            ...EditorBreadcrumbNavigation_Entity_entity
+          }
+        }
+      }
+    `),
+    () => ({ entityId: entity.data.id }),
+    () => ({ skip: !expanded }),
+  );
+
+  let row = $state<HTMLElement>();
+
+  function targetsCurrentTreeItem(event: MouseEvent | KeyboardEvent) {
+    return (
+      event.composedPath().find((target) => target instanceof HTMLElement && target.getAttribute('role') === 'treeitem') ===
+      event.currentTarget
+    );
+  }
+
+  function activate() {
+    row?.focus();
+    if (folder) onToggleFolder(entity.data.id);
+    else if (document) onActivateDocument(entity.data.slug);
+  }
+
+  function handleClick(event: MouseEvent) {
+    if (!targetsCurrentTreeItem(event)) return;
+    if (documentDrag.consumeClick(event)) return;
+    activate();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (!targetsCurrentTreeItem(event)) return;
+
+    if ((folder && (event.key === 'Enter' || event.key === ' ')) || (document && event.key === 'Enter')) {
+      event.preventDefault();
+      event.stopPropagation();
+      activate();
+    } else if (document && event.key === ' ') {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+</script>
+
+{#if entity.data.node.__typename === 'Divider'}
+  <div
+    class={css(
+      entityTreeRowStyle,
+      {
+        minHeight: '32px',
+        paddingY: '6px',
+      },
+      nested && nestedEntityTreeRowStyle,
+    )}
+    aria-hidden="true"
+    data-breadcrumb-entity-id={entity.data.id}
+    role="presentation"
+  >
+    <div class={css({ width: 'full', height: '1px', backgroundColor: 'interactive.hover' })}></div>
+  </div>
+{:else}
+  <div
+    bind:this={row}
+    class={css(
+      {
+        '&:focus > [data-breadcrumb-tree-row]': { backgroundColor: 'surface.muted' },
+      },
+      document && { touchAction: 'none' },
+    )}
+    aria-current={currentDocument ? 'page' : undefined}
+    aria-expanded={folder ? expanded : undefined}
+    aria-level={level}
+    aria-selected={entity.data.id === highlightedEntityId}
+    data-breadcrumb-entity-id={entity.data.id}
+    data-breadcrumb-entity-kind={folder ? 'folder' : 'document'}
+    data-parent-entity-id={parentEntityId}
+    onclick={handleClick}
+    onkeydown={handleKeydown}
+    role="treeitem"
+    tabindex={highlighted ? 0 : -1}
+    use:dragDocument={dragItem}
+  >
+    <div
+      class={cx(
+        'group',
+        css(
+          entityTreeRowStyle,
+          {
+            width: 'full',
+            minWidth: '0',
+            paddingY: '6px',
+            color: 'text.muted',
+            cursor: 'pointer',
+          },
+          nested && nestedEntityTreeRowStyle,
+        ),
+        (highlighted || currentDocument) && css({ backgroundColor: 'surface.muted' }),
+      )}
+      data-breadcrumb-tree-row
+    >
+      {#if folder}
+        <Icon style={css.raw({ flexShrink: '0', color: 'text.faint' })} icon={expanded ? ChevronDownIcon : ChevronRightIcon} size={14} />
+        <EntityIcon entity$key={entity.data} fallback={FolderIcon} size={14} />
+        <EntityName name={entity.data.node.__typename === 'Folder' ? entity.data.node.name : ''} active={currentDocument} />
+      {:else}
+        <EntityIcon entity$key={entity.data} fallback={FileIcon} size={14} />
+        <EntityName name={entity.data.node.__typename === 'Document' ? entity.data.node.title : ''} active={currentDocument} />
+      {/if}
+    </div>
+
+    {#if folder && expanded}
+      <div class={flex({ flexDirection: 'column', borderLeftWidth: '1px', marginLeft: '24px' })} role="group">
+        {#if children.error}
+          <div
+            class={css({
+              paddingLeft: '14px',
+              paddingRight: '8px',
+              paddingY: '6px',
+              fontSize: '14px',
+              fontWeight: 'medium',
+              color: 'text.disabled',
+            })}
+          >
+            폴더 내용을 불러오지 못했어요
+          </div>
+        {:else if !children.data}
+          <div class={css({ paddingLeft: '14px', paddingRight: '8px', paddingY: '6px', color: 'text.disabled' })}>
+            <RingSpinner style={css.raw({ size: '14px' })} />
+          </div>
+        {:else}
+          {#each children.data.entity.children as child (child.id)}
+            <BreadcrumbEntityNode
+              {currentDocumentEntityId}
+              {documentDrag}
+              entity$key={child}
+              {expandedFolderIds}
+              {highlightedEntityId}
+              level={level + 1}
+              nested
+              {onActivateDocument}
+              {onToggleFolder}
+              parentEntityId={entity.data.id}
+            />
+          {:else}
+            <div
+              class={css({
+                paddingLeft: '14px',
+                paddingRight: '8px',
+                paddingY: '6px',
+                fontSize: '14px',
+                fontWeight: 'medium',
+                color: 'text.disabled',
+              })}
+            >
+              폴더가 비어있어요
+            </div>
+          {/each}
+        {/if}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/BreadcrumbEntityTree.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/BreadcrumbEntityTree.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  import { createQuery } from '@mearie/svelte';
+  import { css } from '@typie/styled-system/css';
+  import { RingSpinner, Scrollbar } from '@typie/ui/components';
+  import { tick } from 'svelte';
+  import { graphql } from '$mearie';
+  import BreadcrumbEntityNode from './BreadcrumbEntityNode.svelte';
+  import type { BreadcrumbDocumentDragController } from './breadcrumb-document-drag.svelte';
+
+  export type BreadcrumbContainer = { kind: 'site'; siteId: string } | { kind: 'entity'; entityId: string };
+
+  type Props = {
+    container: BreadcrumbContainer;
+    currentDocumentEntityId: string;
+    expandedFolderIds: ReadonlySet<string>;
+    highlightedEntityId: string;
+    labelledBy: string;
+    onActivateDocument: (slug: string) => void;
+    documentDrag: BreadcrumbDocumentDragController;
+    onDismiss: () => void;
+    onToggleFolder: (entityId: string) => void;
+    treeId: string;
+  };
+
+  let {
+    container,
+    currentDocumentEntityId,
+    documentDrag,
+    expandedFolderIds,
+    highlightedEntityId,
+    labelledBy,
+    onActivateDocument,
+    onDismiss,
+    onToggleFolder,
+    treeId,
+  }: Props = $props();
+
+  const siteEntities = createQuery(
+    graphql(`
+      query EditorBreadcrumbNavigation_SiteEntities_Query($siteId: ID!) {
+        site(siteId: $siteId) {
+          id
+
+          entities {
+            id
+            ...EditorBreadcrumbNavigation_Entity_entity
+          }
+        }
+      }
+    `),
+    () => ({ siteId: container.kind === 'site' ? container.siteId : '' }),
+    () => ({ skip: container.kind !== 'site' }),
+  );
+
+  const entityChildren = createQuery(
+    graphql(`
+      query EditorBreadcrumbNavigation_EntityChildren_Query($entityId: ID!) {
+        entity(entityId: $entityId) {
+          id
+
+          children {
+            id
+            ...EditorBreadcrumbNavigation_Entity_entity
+          }
+        }
+      }
+    `),
+    () => ({ entityId: container.kind === 'entity' ? container.entityId : '' }),
+    () => ({ skip: container.kind !== 'entity' }),
+  );
+
+  const activeQuery = $derived(container.kind === 'site' ? siteEntities : entityChildren);
+  const entities = $derived(container.kind === 'site' ? siteEntities.data?.site.entities : entityChildren.data?.entity.children);
+  let tree = $state<HTMLElement>();
+
+  function visibleItems(): HTMLElement[] {
+    return tree ? [...tree.querySelectorAll<HTMLElement>('[role="treeitem"]')] : [];
+  }
+
+  function setTabStop(item: HTMLElement) {
+    const previous = tree?.querySelector<HTMLElement>('[role="treeitem"][tabindex="0"]');
+    if (previous !== item) previous?.setAttribute('tabindex', '-1');
+    item.tabIndex = 0;
+  }
+
+  function focusItem(item: HTMLElement | undefined) {
+    if (!item) return;
+    setTabStop(item);
+    item.focus({ focusVisible: false });
+  }
+
+  function handleFocusIn(event: FocusEvent) {
+    const item = event.target instanceof HTMLElement ? event.target.closest<HTMLElement>('[role="treeitem"]') : null;
+    if (item && tree?.contains(item)) setTabStop(item);
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!documentDrag.cancel({ suppressClick: true })) onDismiss();
+      return;
+    }
+
+    const current = event.target instanceof HTMLElement ? event.target.closest<HTMLElement>('[role="treeitem"]') : null;
+    if (!current) return;
+    const items = visibleItems();
+    const index = items.indexOf(current);
+    const kind = current.dataset.breadcrumbEntityKind;
+    const entityId = current.dataset.breadcrumbEntityId;
+    if (!entityId) return;
+
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault();
+      focusItem(event.key === 'Home' ? items[0] : items.at(-1));
+      return;
+    }
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      focusItem(items[index + (event.key === 'ArrowDown' ? 1 : -1)]);
+      return;
+    }
+
+    if (kind === 'folder' && event.key === 'ArrowRight') {
+      event.preventDefault();
+      if (current.getAttribute('aria-expanded') === 'false') {
+        onToggleFolder(entityId);
+      } else {
+        focusItem(items.find((item) => item.dataset.parentEntityId === entityId));
+      }
+      return;
+    }
+
+    if (event.key === 'ArrowLeft') {
+      if (kind === 'folder' && current.getAttribute('aria-expanded') === 'true') {
+        event.preventDefault();
+        onToggleFolder(entityId);
+      } else if (current.dataset.parentEntityId) {
+        event.preventDefault();
+        focusItem(items.find((item) => item.dataset.breadcrumbEntityId === current.dataset.parentEntityId));
+      }
+      return;
+    }
+  }
+
+  $effect(() => {
+    void container;
+    const treeElement = tree;
+    const entityId = highlightedEntityId;
+    void entities;
+    if (!treeElement) return;
+
+    void tick().then(() => {
+      if (!treeElement.isConnected) return;
+      const target = visibleItems().find((item) => item.dataset.breadcrumbEntityId === entityId) ?? visibleItems()[0];
+      if (target) focusItem(target);
+      else treeElement.focus();
+    });
+  });
+</script>
+
+<div class={css({ position: 'relative' })}>
+  <div
+    bind:this={tree}
+    id={treeId}
+    class={css({
+      maxHeight: '[min(392px, var(--floating-available-height, 392px))]',
+      padding: '4px',
+      overflowY: 'auto',
+      overscrollBehavior: 'contain',
+      scrollbarWidth: 'none',
+      touchAction: 'pan-y',
+      userSelect: 'none',
+    })}
+    aria-labelledby={labelledBy}
+    onfocusin={handleFocusIn}
+    onkeydown={handleKeydown}
+    role="tree"
+    tabindex="-1"
+  >
+    {#if activeQuery.error}
+      <div class={css({ paddingX: '8px', paddingY: '6px', fontSize: '14px', fontWeight: 'medium', color: 'text.disabled' })}>
+        폴더 내용을 불러오지 못했어요
+      </div>
+    {:else if !entities}
+      <div class={css({ paddingX: '8px', paddingY: '6px', color: 'text.disabled' })}>
+        <RingSpinner style={css.raw({ size: '14px' })} />
+      </div>
+    {:else}
+      {#each entities as entity (entity.id)}
+        <BreadcrumbEntityNode
+          {currentDocumentEntityId}
+          {documentDrag}
+          entity$key={entity}
+          {expandedFolderIds}
+          {highlightedEntityId}
+          level={1}
+          {onActivateDocument}
+          {onToggleFolder}
+        />
+      {:else}
+        <div class={css({ paddingX: '8px', paddingY: '6px', fontSize: '14px', fontWeight: 'medium', color: 'text.disabled' })}>
+          폴더가 비어있어요
+        </div>
+      {/each}
+    {/if}
+  </div>
+
+  <Scrollbar controls={treeId} label="문서 경로 트리 세로 스크롤" orientation="vertical" scrollContainer={tree} size="md" />
+</div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import { createFloatingActions, portal } from '@typie/ui/actions';
+  import { Icon } from '@typie/ui/components';
+  import { entityIconMap } from '@typie/ui/constants';
+  import { prefersReducedMotion } from '@typie/ui/state';
+  import { onDestroy, tick } from 'svelte';
+  import { SvelteSet } from 'svelte/reactivity';
+  import { scale } from 'svelte/transition';
+  import ChevronRightIcon from '~icons/lucide/chevron-right';
+  import FileIcon from '~icons/lucide/file';
+  import FolderIcon from '~icons/lucide/folder';
+  import EntityIcon from '../../../@context-menu/EntityIcon.svelte';
+  import { getPaneGroup } from '../../@pane/context.svelte';
+  import { BreadcrumbDocumentDragController } from './breadcrumb-document-drag.svelte';
+  import BreadcrumbEntityTree from './BreadcrumbEntityTree.svelte';
+  import type { EditorContextBarSegmentState } from '$lib/editor-ffi/components/ui/editor-context-bar.svelte';
+  import type { EntityIcon_entity$key } from '$mearie';
+  import type { BreadcrumbContainer } from './BreadcrumbEntityTree.svelte';
+
+  export type EditorBreadcrumbPathEntity = {
+    id: string;
+    name: string;
+    entity$key: EntityIcon_entity$key;
+  };
+
+  type BreadcrumbNavigationSegment = {
+    id: string;
+    container: BreadcrumbContainer;
+  };
+
+  type Props = {
+    ancestors: readonly EditorBreadcrumbPathEntity[];
+    current: EditorBreadcrumbPathEntity & { slug: string };
+    isOwner: boolean;
+    onNavigate: (slug: string) => void;
+    popupId: string;
+    segment: EditorContextBarSegmentState;
+    siteId: string;
+  };
+
+  let { ancestors, current, isOwner, onNavigate, popupId, segment, siteId }: Props = $props();
+
+  const POPUP_HOLD_REASON = 'breadcrumb-popup';
+  const pathEntities = $derived([...ancestors, current]);
+  const segments = $derived(
+    pathEntities.map((pathEntity, index): BreadcrumbNavigationSegment => ({
+      id: pathEntity.id,
+      container: index === 0 ? { kind: 'site', siteId } : { kind: 'entity', entityId: pathEntities[index - 1].id },
+    })),
+  );
+  let activeSegmentId = $state<string | null>(null);
+  const expandedFolderIds = new SvelteSet<string>();
+  const activeSegment = $derived(segments.find((candidate) => candidate.id === activeSegmentId));
+  const activeTriggerId = $derived(activeSegment ? triggerId(activeSegment.id) : '');
+  let activeTrigger = $state<HTMLButtonElement>();
+  const paneGroup = getPaneGroup();
+  const documentDrag = new BreadcrumbDocumentDragController({ paneGroup, onDropSuccess: () => dismiss(false) });
+
+  const { floating, setReference } = createFloatingActions({
+    placement: 'bottom-start',
+    offset: 6,
+    onClickOutside: () => {
+      if (!documentDrag.hasPointerSession) dismiss(false);
+    },
+  });
+
+  function triggerId(entityId: string) {
+    return `${popupId}-trigger-${entityId}`;
+  }
+
+  function dismiss(restoreFocus: boolean) {
+    documentDrag.cancel();
+    if (activeSegmentId === null) return;
+    const trigger = activeTrigger;
+    activeSegmentId = null;
+    expandedFolderIds.clear();
+    activeTrigger = undefined;
+    setReference(null);
+    segment.release(POPUP_HOLD_REASON);
+    if (restoreFocus) void tick().then(() => trigger?.isConnected && trigger.focus());
+  }
+
+  function activate(event: MouseEvent, segmentId: string) {
+    const trigger = event.currentTarget as HTMLButtonElement;
+    if (activeSegmentId === segmentId) {
+      dismiss(false);
+      return;
+    }
+
+    const wasClosed = activeSegmentId === null;
+    activeSegmentId = segmentId;
+    expandedFolderIds.clear();
+    activeTrigger = trigger;
+    setReference(trigger);
+    if (wasClosed) segment.hold(POPUP_HOLD_REASON);
+  }
+
+  function toggleFolder(entityId: string) {
+    if (expandedFolderIds.has(entityId)) expandedFolderIds.delete(entityId);
+    else expandedFolderIds.add(entityId);
+  }
+
+  function activateDocument(slug: string) {
+    const currentDocument = slug === current.slug;
+    dismiss(false);
+    if (!currentDocument) onNavigate(slug);
+  }
+
+  function handlePopupFocusOut(event: FocusEvent) {
+    const popup = event.currentTarget as HTMLElement;
+    if (event.relatedTarget instanceof Node && popup.contains(event.relatedTarget)) return;
+    dismiss(false);
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (activeSegmentId === null || event.defaultPrevented) return;
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    if (!documentDrag.cancel({ suppressClick: true })) dismiss(true);
+  }
+
+  $effect(() => {
+    if (!isOwner) dismiss(false);
+  });
+
+  onDestroy(() => {
+    dismiss(false);
+    documentDrag.destroy();
+  });
+</script>
+
+<svelte:window oncontextmenu={(event) => documentDrag.contextMenu(event)} onkeydown={handleWindowKeydown} />
+
+<nav
+  class={css({
+    display: 'flex',
+    alignItems: 'center',
+    height: '32px',
+    paddingLeft: '8px',
+    paddingRight: '16px',
+    fontSize: '12px',
+    fontWeight: 'medium',
+    color: 'text.subtle',
+  })}
+  aria-label="문서 경로"
+>
+  <ol class={flex({ alignItems: 'center', gap: '2px', listStyle: 'none', whiteSpace: 'nowrap' })}>
+    {#each pathEntities as pathEntity, index (pathEntity.id)}
+      {@const currentEntity = index === pathEntities.length - 1}
+      <li aria-current={currentEntity ? 'page' : undefined}>
+        {#if isOwner}
+          <button
+            id={triggerId(pathEntity.id)}
+            class={flex({
+              alignItems: 'center',
+              gap: '4px',
+              height: '24px',
+              paddingX: '4px',
+              borderRadius: '5px',
+              cursor: 'pointer',
+              transition: 'common',
+              _hover: { backgroundColor: 'interactive.hover', color: 'text.default' },
+              _expanded: { backgroundColor: 'interactive.hover', color: 'text.default' },
+            })}
+            aria-controls={popupId}
+            aria-expanded={activeSegmentId === pathEntity.id}
+            aria-haspopup="tree"
+            onclick={(event) => activate(event, pathEntity.id)}
+            type="button"
+          >
+            <EntityIcon entity$key={pathEntity.entity$key} fallback={currentEntity ? undefined : FolderIcon} size={14} />
+            <span>{pathEntity.name}</span>
+            {#if !currentEntity}
+              <span class={css({ display: 'grid', placeItems: 'center', color: 'text.faint' })} aria-hidden="true">
+                <Icon icon={ChevronRightIcon} size={14} />
+              </span>
+            {/if}
+          </button>
+        {:else}
+          <span class={flex({ alignItems: 'center', gap: '4px' })}>
+            <EntityIcon entity$key={pathEntity.entity$key} fallback={currentEntity ? undefined : FolderIcon} size={14} />
+            <span>{pathEntity.name}</span>
+          </span>
+        {/if}
+      </li>
+      {#if !isOwner && !currentEntity}
+        <li class={css({ display: 'grid', placeItems: 'center', color: 'text.faint' })} aria-hidden="true">
+          <Icon icon={ChevronRightIcon} size={14} />
+        </li>
+      {/if}
+    {/each}
+  </ol>
+</nav>
+
+{#if isOwner && activeSegment}
+  <div
+    class={css({
+      zIndex: 'menu',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '2px',
+      borderRadius: '8px',
+      width: '240px',
+      paddingX: '0',
+      paddingY: '0',
+      overflow: 'hidden',
+      backgroundColor: 'surface.subtle',
+      boxShadow: 'menu',
+    })}
+    onfocusout={handlePopupFocusOut}
+    use:floating
+    transition:scale={{ start: 0.95, duration: prefersReducedMotion.current ? 0 : 150 }}
+  >
+    <BreadcrumbEntityTree
+      container={activeSegment.container}
+      currentDocumentEntityId={current.id}
+      {documentDrag}
+      {expandedFolderIds}
+      highlightedEntityId={activeSegment.id}
+      labelledBy={activeTriggerId}
+      onActivateDocument={activateDocument}
+      onDismiss={() => dismiss(true)}
+      onToggleFolder={toggleFolder}
+      treeId={popupId}
+    />
+  </div>
+{/if}
+
+{#if documentDrag.ghost}
+  <div
+    style:left={`${documentDrag.ghost.x + 8}px`}
+    style:top={`${documentDrag.ghost.y}px`}
+    style:max-width={`${documentDrag.ghost.width}px`}
+    class={flex({
+      position: 'fixed',
+      alignItems: 'center',
+      gap: '2px',
+      minWidth: '0',
+      paddingX: '8px',
+      paddingY: '4px',
+      borderRadius: 'full',
+      backgroundColor: 'accent.info.default',
+      color: 'text.bright',
+      fontSize: '14px',
+      fontWeight: 'bold',
+      pointerEvents: 'none',
+      userSelect: 'none',
+      zIndex: 'ghost',
+    })}
+    aria-hidden="true"
+    role="presentation"
+    use:portal
+  >
+    <Icon
+      style={css.raw({ flexShrink: '0', color: 'text.bright' })}
+      icon={entityIconMap.get(documentDrag.ghost.icon ?? '') ?? FileIcon}
+      size={14}
+    />
+    <span class={css({ minWidth: '0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })}>
+      {documentDrag.ghost.name}
+    </span>
+  </div>
+{/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag-test-root.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag-test-root.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  import { cacheExchange, createClient } from '@mearie/core';
+  import { filter, map, pipe } from '@mearie/core/stream';
+  import { setClient } from '@mearie/svelte';
+  import { onDestroy, setContext } from 'svelte';
+  import { schema } from '$mearie';
+  import EditorBreadcrumbNavigation from './EditorBreadcrumbNavigation.svelte';
+  import type { Exchange, OperationResult } from '@mearie/core';
+  import type { EditorContextBarSegmentState } from '$lib/editor-ffi/components/ui/editor-context-bar.svelte';
+  import type { EntityIcon_entity$key } from '$mearie';
+  import type { DragItem, DragPane, DropZone, PaneGroup } from '../../@pane/context.svelte';
+  import type { EditorBreadcrumbPathEntity } from './EditorBreadcrumbNavigation.svelte';
+
+  const currentDocument = {
+    __typename: 'Entity',
+    id: 'document-current',
+    slug: 'document-current',
+    icon: null,
+    iconColor: 'gray',
+    node: { __typename: 'Document', id: 'document-node-current', title: 'Current document' },
+  };
+
+  const siblingDocument = {
+    __typename: 'Entity',
+    id: 'document-sibling',
+    slug: 'document-sibling',
+    icon: null,
+    iconColor: 'gray',
+    node: { __typename: 'Document', id: 'document-node-sibling', title: 'Sibling document' },
+  };
+
+  const rootEntities = [
+    {
+      __typename: 'Entity',
+      id: 'folder-1',
+      slug: 'folder-1',
+      icon: null,
+      iconColor: 'gray',
+      node: { __typename: 'Folder', id: 'folder-node-1', name: 'Folder' },
+    },
+    {
+      __typename: 'Entity',
+      id: 'document-first',
+      slug: 'document-first',
+      icon: null,
+      iconColor: 'gray',
+      node: { __typename: 'Document', id: 'document-node-first', title: 'First document' },
+    },
+    ...Array.from({ length: 16 }, (_, index) => ({
+      __typename: 'Entity',
+      id: `document-extra-${index}`,
+      slug: `document-extra-${index}`,
+      icon: null,
+      iconColor: 'gray',
+      node: { __typename: 'Document', id: `document-node-extra-${index}`, title: `Extra document ${index}` },
+    })),
+  ];
+
+  const childEntities = [siblingDocument, currentDocument];
+  const fixtureExchange: Exchange = () => ({
+    name: 'breadcrumb-document-drag-fixture',
+    io: (operations) =>
+      pipe(
+        operations,
+        filter((operation) => operation.variant === 'request'),
+        map((operation): OperationResult => {
+          return {
+            operation,
+            data:
+              operation.variant === 'request' && operation.artifact.name === 'EditorBreadcrumbNavigation_SiteEntities_Query'
+                ? { site: { __typename: 'Site', id: 'site-1', entities: rootEntities } }
+                : { entity: { __typename: 'Entity', id: 'folder-1', children: childEntities } },
+          };
+        }),
+      ),
+  });
+
+  const client = createClient({
+    schema,
+    exchanges: [cacheExchange(), fixtureExchange],
+    scalars: {
+      JSON: { parse: (value: unknown) => value, serialize: (value: unknown) => value },
+      Binary: { parse: String, serialize: (value: string) => value },
+      DateTime: { parse: String, serialize: (value: string) => value },
+      BigInt: { parse: String, serialize: (value: string) => value },
+    },
+  });
+
+  setClient(client);
+  onDestroy(() => client.dispose());
+
+  let nextDropZone = $state<DropZone | 'none'>('center');
+  let paneActiveZone = $state<PaneGroup['activeZone']>(null);
+  let updates = $state<{ x: number; y: number; zone: DropZone | null }[]>([]);
+  let executions = $state<{ item: DragItem | DragPane; zone: DropZone | null }[]>([]);
+  let cancelCount = $state(0);
+  let holds = $state<string[]>([]);
+  let navigatedSlug = $state('');
+  const ancestors: EditorBreadcrumbPathEntity[] = [
+    {
+      id: 'folder-1',
+      name: 'Folder',
+      entity$key: rootEntities[0] as unknown as EntityIcon_entity$key,
+    },
+  ];
+
+  const paneGroup = {
+    get activeZone() {
+      return paneActiveZone;
+    },
+    set activeZone(value: PaneGroup['activeZone']) {
+      paneActiveZone = value;
+    },
+    updateActiveZone(x: number, y: number) {
+      paneActiveZone = nextDropZone === 'none' ? null : { paneId: 'pane-1', dropZone: nextDropZone };
+      updates = [...updates, { x, y, zone: paneActiveZone?.dropZone ?? null }];
+    },
+    executeDrop(item: DragItem | DragPane) {
+      executions = [...executions, { item, zone: paneActiveZone?.dropZone ?? null }];
+      paneActiveZone = null;
+      return true;
+    },
+    cancelDrag() {
+      cancelCount++;
+      paneActiveZone = null;
+    },
+  } as PaneGroup;
+
+  setContext(Symbol.for('typie.svelte-context.pane.PaneGroup'), paneGroup);
+
+  const segment = {
+    hold(reason: string) {
+      if (!holds.includes(reason)) holds = [...holds, reason];
+    },
+    release(reason: string) {
+      holds = holds.filter((hold) => hold !== reason);
+    },
+  } as EditorContextBarSegmentState;
+</script>
+
+<label>
+  zone
+  <select data-next-drop-zone bind:value={nextDropZone}>
+    <option value="center">center</option>
+    <option value="left">left</option>
+    <option value="right">right</option>
+    <option value="top">top</option>
+    <option value="bottom">bottom</option>
+    <option value="none">none</option>
+  </select>
+</label>
+<EditorBreadcrumbNavigation
+  {ancestors}
+  current={{
+    id: 'document-current',
+    slug: 'document-current',
+    name: 'Current document',
+    entity$key: currentDocument as unknown as EntityIcon_entity$key,
+  }}
+  isOwner
+  onNavigate={(slug) => (navigatedSlug = slug)}
+  popupId="breadcrumb-document-drag-test"
+  {segment}
+  siteId="site-1"
+/>
+
+<output data-pane-updates>{JSON.stringify(updates)}</output>
+<output data-pane-executions>{JSON.stringify(executions)}</output>
+<output data-pane-cancel-count>{cancelCount}</output>
+<output data-holds>{JSON.stringify(holds)}</output>
+<output data-navigated-slug>{navigatedSlug}</output>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag.browser.test.ts
@@ -1,0 +1,242 @@
+import '../../../../../../app.css';
+
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import BreadcrumbDocumentDragTestRoot from './breadcrumb-document-drag-test-root.svelte';
+
+let component: Record<string, unknown> | undefined;
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  document.body.replaceChildren();
+});
+
+const output = (name: string) => document.querySelector(`[data-${name}]`)?.textContent ?? '';
+const popup = () => {
+  const expandedTrigger = document.querySelector<HTMLElement>('[aria-haspopup="tree"][aria-expanded="true"]');
+  const treeId = expandedTrigger?.getAttribute('aria-controls');
+  const tree = treeId ? document.querySelector<HTMLElement>(`[id="${CSS.escape(treeId)}"]`) : null;
+  return tree?.getAttribute('role') === 'tree' ? tree.parentElement?.parentElement : null;
+};
+const ghost = () =>
+  [...document.body.children].find(
+    (element): element is HTMLElement =>
+      element instanceof HTMLElement &&
+      element.dataset.portal !== undefined &&
+      element.getAttribute('aria-hidden') === 'true' &&
+      element.getAttribute('role') === 'presentation' &&
+      element.textContent?.includes('First document') === true,
+  ) ?? null;
+const treeItem = (entityId: string) => document.querySelector<HTMLElement>(`[role="treeitem"][data-breadcrumb-entity-id="${entityId}"]`);
+
+const installPointerCapture = (element: HTMLElement) => {
+  let capturedPointerId: number | undefined;
+  element.setPointerCapture = (pointerId) => (capturedPointerId = pointerId);
+  element.hasPointerCapture = (pointerId) => capturedPointerId === pointerId;
+  element.releasePointerCapture = (pointerId) => {
+    if (capturedPointerId === pointerId) capturedPointerId = undefined;
+  };
+};
+
+const pointer = (
+  target: EventTarget,
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel' | 'lostpointercapture',
+  { pointerType = 'mouse', x = 20, y = 20, pointerId = 1 }: { pointerType?: string; x?: number; y?: number; pointerId?: number } = {},
+) => {
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    isPrimary: true,
+    button: type === 'pointermove' ? -1 : 0,
+    buttons: type === 'pointerup' || type === 'pointercancel' ? 0 : 1,
+    clientX: x,
+    clientY: y,
+    pointerId,
+    pointerType,
+  });
+  target.dispatchEvent(event);
+  return event;
+};
+
+const openPopup = async () => {
+  document.querySelector<HTMLButtonElement>('[aria-haspopup="tree"]')?.click();
+  await expect.poll(popup).not.toBeNull();
+  await expect.poll(() => treeItem('document-first')).not.toBeNull();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+};
+
+const mountFixture = async () => {
+  component = mount(BreadcrumbDocumentDragTestRoot, { target: document.body });
+  await tick();
+  await openPopup();
+};
+
+const beginActiveDrag = async () => {
+  const item = treeItem('document-first');
+  if (!item) throw new Error('Missing document treeitem');
+  installPointerCapture(item);
+  pointer(item, 'pointerdown', { x: 20, y: 20 });
+  pointer(item, 'pointermove', { x: 31, y: 20 });
+  await tick();
+  return item;
+};
+
+describe('breadcrumb document drag', () => {
+  it('keeps a below-threshold mouse gesture as document activation', async () => {
+    await mountFixture();
+    const item = treeItem('document-first');
+    if (!item) throw new Error('Missing document treeitem');
+
+    pointer(item, 'pointerdown', { x: 20, y: 20 });
+    pointer(item, 'pointermove', { x: 25, y: 25 });
+    pointer(item, 'pointerup', { x: 25, y: 25 });
+    item.click();
+
+    await expect.poll(() => output('navigated-slug')).toBe('document-first');
+    expect(output('pane-executions')).toBe('[]');
+  });
+
+  it('delegates a successful drop to PaneGroup without activating the source pane', async () => {
+    await mountFixture();
+    const item = await beginActiveDrag();
+    expect(ghost()).not.toBeNull();
+
+    pointer(item, 'pointerup', { x: 31, y: 20 });
+    item.click();
+
+    await expect.poll(popup).toBeNull();
+    expect(output('pane-executions')).toContain('"zone":"center"');
+    expect(output('pane-executions')).toContain('"slug":"document-first"');
+    expect(output('holds')).toBe('[]');
+    expect(output('navigated-slug')).toBe('');
+  });
+
+  it('starts touch drag after the shared hold and suppresses contextmenu while pending', async () => {
+    await mountFixture();
+    const item = treeItem('document-first');
+    if (!item) throw new Error('Missing document treeitem');
+    installPointerCapture(item);
+
+    pointer(item, 'pointerdown', { pointerType: 'touch' });
+    const pendingMenu = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    item.dispatchEvent(pendingMenu);
+    expect(pendingMenu.defaultPrevented).toBe(true);
+    expect(ghost()).toBeNull();
+
+    await new Promise((resolve) => setTimeout(resolve, 370));
+    await expect.poll(ghost).not.toBeNull();
+    pointer(item, 'pointermove', { pointerType: 'touch', x: 45, y: 55 });
+    const activeGhost = ghost();
+    if (!activeGhost) throw new Error('Missing active document ghost');
+    expect(getComputedStyle(activeGhost).userSelect).toBe('none');
+    await expect.poll(() => output('pane-updates')).toContain('"x":45,"y":55');
+
+    pointer(item, 'pointerup', { pointerType: 'touch' });
+    document.body.click();
+    await expect.poll(popup).toBeNull();
+  });
+
+  it('cancels touch hold on movement without suppressing later contextmenu', async () => {
+    await mountFixture();
+    const item = treeItem('document-first');
+    if (!item) throw new Error('Missing document treeitem');
+
+    const tree = item.closest<HTMLElement>('[role="tree"]');
+    if (!tree) throw new Error('Missing tree scroll surface');
+    expect(tree.scrollHeight).toBeGreaterThan(tree.clientHeight);
+    tree.scrollTop = 100;
+
+    pointer(item, 'pointerdown', { pointerType: 'touch', x: 20, y: 20 });
+    pointer(item, 'pointermove', { pointerType: 'touch', x: 20, y: 5 });
+    expect(tree.scrollTop).toBe(115);
+    pointer(item, 'pointermove', { pointerType: 'touch', x: 20, y: -5 });
+    expect(tree.scrollTop).toBe(125);
+    await new Promise((resolve) => setTimeout(resolve, 370));
+
+    expect(ghost()).toBeNull();
+    expect(output('pane-updates')).toBe('[]');
+    expect(output('pane-cancel-count')).toBe('0');
+    const menu = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    item.dispatchEvent(menu);
+    expect(menu.defaultPrevented).toBe(false);
+
+    pointer(item, 'pointerup', { pointerType: 'touch', x: 20, y: -5 });
+    item.click();
+    await tick();
+    expect(output('navigated-slug')).toBe('');
+    expect(popup()).not.toBeNull();
+
+    treeItem('document-extra-0')?.click();
+    await expect.poll(() => output('navigated-slug')).toBe('document-extra-0');
+  });
+
+  it('keeps the popup open when there is no pane drop zone', async () => {
+    await mountFixture();
+    const select = document.querySelector<HTMLSelectElement>('[data-next-drop-zone]');
+    if (!select) throw new Error('Missing zone control');
+    select.value = 'none';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await tick();
+    const item = await beginActiveDrag();
+
+    pointer(item, 'pointerup', { x: 31, y: 20 });
+    item.click();
+
+    await expect.poll(ghost).toBeNull();
+    expect(popup()).not.toBeNull();
+    expect(output('holds')).toContain('breadcrumb-popup');
+    expect(output('pane-cancel-count')).toBe('1');
+    expect(output('navigated-slug')).toBe('');
+  });
+
+  it('suppresses a delayed click after unexpected lost pointer capture', async () => {
+    await mountFixture();
+    const item = await beginActiveDrag();
+
+    pointer(item, 'lostpointercapture', { x: 31, y: 20 });
+    await expect.poll(ghost).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    pointer(item, 'pointerup', { x: 31, y: 20 });
+    item.click();
+    await tick();
+
+    expect(output('navigated-slug')).toBe('');
+    expect(popup()).not.toBeNull();
+    treeItem('document-extra-0')?.click();
+    await expect.poll(() => output('navigated-slug')).toBe('document-extra-0');
+  });
+
+  it('uses the first Escape to cancel drag and a later Escape to close and restore the trigger', async () => {
+    await mountFixture();
+    const item = await beginActiveDrag();
+    const trigger = document.querySelector<HTMLButtonElement>('[aria-haspopup="tree"]');
+    item.focus();
+    expect(document.activeElement).toBe(item);
+
+    item.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'Escape' }));
+    await expect.poll(ghost).toBeNull();
+    expect(popup()).not.toBeNull();
+    expect(output('holds')).toContain('breadcrumb-popup');
+    expect(output('pane-cancel-count')).toBe('1');
+
+    item.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'Escape' }));
+    await expect.poll(popup).toBeNull();
+    await expect.poll(() => document.activeElement).toBe(trigger);
+    expect(output('holds')).toBe('[]');
+    expect(output('pane-cancel-count')).toBe('1');
+  });
+
+  it('suspends outside-click dismissal while pointer drag is pending', async () => {
+    await mountFixture();
+    const item = treeItem('document-first');
+    if (!item) throw new Error('Missing document treeitem');
+    installPointerCapture(item);
+
+    pointer(item, 'pointerdown');
+    document.body.click();
+    expect(popup()).not.toBeNull();
+
+    pointer(item, 'pointercancel', { x: 31, y: 20 });
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag.svelte.ts
@@ -1,0 +1,255 @@
+import { pointerCapture } from '@typie/ui/actions';
+import type { PointerCaptureCancelReason } from '@typie/ui/actions';
+import type { Action } from 'svelte/action';
+import type { PaneGroup } from '../../@pane/context.svelte';
+
+const TOUCH_DRAG_HOLD_MS = 350;
+const DRAG_MOVE_THRESHOLD_PX = 10;
+
+type DocumentDragItem = {
+  slug: string;
+  name: string;
+  icon?: string;
+};
+
+type PointerSession = {
+  pointerId: number;
+  pointerType: 'mouse' | 'pen' | 'touch';
+  startX: number;
+  startY: number;
+  lastY: number;
+  element: HTMLElement;
+  scrollSurface: HTMLElement;
+  item: DocumentDragItem;
+  active: boolean;
+  touchHoldCanceled: boolean;
+  holdTimeout?: ReturnType<typeof setTimeout>;
+};
+
+type ClickSuppression = {
+  pointerId: number;
+  element: HTMLElement;
+  expiryTimeout?: ReturnType<typeof setTimeout>;
+};
+
+type FinishActiveOptions = {
+  cancelPane: boolean;
+  suppressClick: boolean;
+};
+
+type CancelOptions = {
+  suppressClick?: boolean;
+};
+
+export type BreadcrumbDocumentDragGhost = DocumentDragItem & {
+  x: number;
+  y: number;
+  width: number;
+};
+
+type BreadcrumbDocumentDragOptions = {
+  paneGroup: PaneGroup;
+  onDropSuccess: () => void;
+};
+
+export class BreadcrumbDocumentDragController {
+  #paneGroup: PaneGroup;
+  #onDropSuccess: () => void;
+  #session = $state.raw<PointerSession | null>(null);
+  #clickSuppression: ClickSuppression | null = null;
+  #cancelCapture: (() => void) | null = null;
+  #suppressProgrammaticCancelClick = false;
+
+  ghost = $state<BreadcrumbDocumentDragGhost | null>(null);
+
+  drag: Action<HTMLElement, DocumentDragItem | null> = (element, initialItem) => {
+    let item = initialItem;
+    const capture = pointerCapture<PointerSession>(element, {
+      start: (event) => {
+        if (!item) return null;
+        const session = this.#start(event, element, item);
+        if (session) this.#cancelCapture = capture.cancel;
+        return session;
+      },
+      move: (session, event) => this.#move(session, event),
+      end: (session, event) => this.#end(session, event),
+      cancel: (session, reason) => this.#cancelSession(session, reason),
+    });
+
+    return {
+      update(nextItem) {
+        item = nextItem;
+      },
+      destroy: capture.destroy,
+    };
+  };
+
+  constructor({ paneGroup, onDropSuccess }: BreadcrumbDocumentDragOptions) {
+    this.#paneGroup = paneGroup;
+    this.#onDropSuccess = onDropSuccess;
+  }
+
+  #clearClickSuppression(pointerId?: number): void {
+    const suppression = this.#clickSuppression;
+    if (!suppression || (pointerId !== undefined && suppression.pointerId !== pointerId)) return;
+    if (suppression.expiryTimeout) clearTimeout(suppression.expiryTimeout);
+    this.#clickSuppression = null;
+  }
+
+  #armClickSuppression(session: PointerSession): void {
+    this.#clearClickSuppression();
+    this.#clickSuppression = { pointerId: session.pointerId, element: session.element };
+  }
+
+  #expireClickSuppressionAfterPointerUp(pointerId: number): void {
+    const suppression = this.#clickSuppression;
+    if (!suppression || suppression.pointerId !== pointerId) return;
+    suppression.expiryTimeout = setTimeout(() => {
+      if (this.#clickSuppression === suppression) this.#clickSuppression = null;
+    }, 0);
+  }
+
+  #activate(session: PointerSession, x: number, y: number): void {
+    if (this.#session !== session || session.active || session.touchHoldCanceled) return;
+    if (session.holdTimeout) clearTimeout(session.holdTimeout);
+    session.holdTimeout = undefined;
+    session.active = true;
+
+    this.ghost = { ...session.item, x, y, width: session.element.offsetWidth };
+    this.#paneGroup.updateActiveZone(x, y);
+  }
+
+  #finish(session: PointerSession, { cancelPane, suppressClick }: FinishActiveOptions): void {
+    if (this.#session !== session) return;
+    this.#session = null;
+    this.#cancelCapture = null;
+    this.ghost = null;
+
+    if (session.holdTimeout) clearTimeout(session.holdTimeout);
+    if (cancelPane) this.#paneGroup.cancelDrag();
+    if (suppressClick) this.#armClickSuppression(session);
+  }
+
+  #start(event: PointerEvent, element: HTMLElement, item: DocumentDragItem): PointerSession | null {
+    if (this.#session || !event.isPrimary || event.button !== 0) return null;
+    if (event.pointerType !== 'mouse' && event.pointerType !== 'pen' && event.pointerType !== 'touch') return null;
+
+    const scrollSurface = element.closest<HTMLElement>('[role="tree"]');
+    if (!scrollSurface) return null;
+    this.#clearClickSuppression();
+
+    const session: PointerSession = {
+      pointerId: event.pointerId,
+      pointerType: event.pointerType,
+      startX: event.clientX,
+      startY: event.clientY,
+      lastY: event.clientY,
+      element,
+      scrollSurface,
+      item,
+      active: false,
+      touchHoldCanceled: false,
+    };
+    this.#session = session;
+
+    if (session.pointerType === 'touch') {
+      session.holdTimeout = setTimeout(() => {
+        if (this.#session !== session) return;
+        this.#activate(session, session.startX, session.startY);
+      }, TOUCH_DRAG_HOLD_MS);
+    }
+
+    return session;
+  }
+
+  #move(session: PointerSession, event: PointerEvent): void {
+    if (!session.active) {
+      const distance = Math.abs(event.clientX - session.startX) + Math.abs(event.clientY - session.startY);
+
+      if (session.pointerType === 'touch') {
+        const deltaY = event.clientY - session.lastY;
+        session.lastY = event.clientY;
+
+        if (!session.touchHoldCanceled && distance > DRAG_MOVE_THRESHOLD_PX) {
+          session.touchHoldCanceled = true;
+          if (session.holdTimeout) clearTimeout(session.holdTimeout);
+          session.holdTimeout = undefined;
+        }
+
+        if (session.touchHoldCanceled) {
+          if (event.cancelable) event.preventDefault();
+          session.scrollSurface.scrollTop -= deltaY;
+        }
+        return;
+      }
+
+      if (distance <= DRAG_MOVE_THRESHOLD_PX) return;
+
+      this.#activate(session, event.clientX, event.clientY);
+      return;
+    }
+
+    if (event.cancelable) event.preventDefault();
+    this.ghost = { ...session.item, x: event.clientX, y: event.clientY, width: session.element.offsetWidth };
+    this.#paneGroup.updateActiveZone(event.clientX, event.clientY);
+  }
+
+  #end(session: PointerSession, event: PointerEvent): void {
+    if (!session.active) {
+      if (session.touchHoldCanceled) this.#armClickSuppression(session);
+      this.#finish(session, { cancelPane: false, suppressClick: false });
+      this.#expireClickSuppressionAfterPointerUp(event.pointerId);
+      return;
+    }
+
+    this.#paneGroup.updateActiveZone(event.clientX, event.clientY);
+    const hasDropZone = this.#paneGroup.activeZone !== null;
+    const succeeded = hasDropZone && this.#paneGroup.executeDrop({ slug: session.item.slug, type: 'document' });
+    this.#finish(session, { cancelPane: !succeeded, suppressClick: true });
+    this.#expireClickSuppressionAfterPointerUp(event.pointerId);
+    if (succeeded) this.#onDropSuccess();
+  }
+
+  #cancelSession(session: PointerSession, reason: PointerCaptureCancelReason): void {
+    const suppressClick =
+      reason === 'lostpointercapture' ? session.active : reason === 'programmatic' ? this.#suppressProgrammaticCancelClick : false;
+    this.#suppressProgrammaticCancelClick = false;
+    this.#finish(session, { cancelPane: session.active, suppressClick });
+    if (!suppressClick) this.#clearClickSuppression(session.pointerId);
+  }
+
+  get hasPointerSession(): boolean {
+    return this.#session !== null;
+  }
+
+  contextMenu(event: MouseEvent): void {
+    const session = this.#session;
+    if (!session || session.pointerType !== 'touch' || session.touchHoldCanceled) return;
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  consumeClick(event: MouseEvent): boolean {
+    const suppression = this.#clickSuppression;
+    if (!suppression) return false;
+    this.#clearClickSuppression();
+    if (event.currentTarget !== suppression.element) return false;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    return true;
+  }
+
+  cancel({ suppressClick = false }: CancelOptions = {}): boolean {
+    const session = this.#session;
+    if (!session) return false;
+    this.#suppressProgrammaticCancelClick = suppressClick;
+    this.#cancelCapture?.();
+    if (!suppressClick) this.#clearClickSuppression();
+    return true;
+  }
+
+  destroy(): void {
+    this.cancel();
+    this.#clearClickSuppression();
+  }
+}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-navigation.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-navigation.browser.test.ts
@@ -1,0 +1,138 @@
+import '../../../../../../app.css';
+
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import BreadcrumbDocumentDragTestRoot from './breadcrumb-document-drag-test-root.svelte';
+
+let component: Record<string, unknown> | undefined;
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  document.body.replaceChildren();
+});
+
+const popup = () => {
+  const expandedTrigger = document.querySelector<HTMLElement>('[aria-haspopup="tree"][aria-expanded="true"]');
+  const treeId = expandedTrigger?.getAttribute('aria-controls');
+  const tree = treeId ? document.querySelector<HTMLElement>(`[id="${CSS.escape(treeId)}"]`) : null;
+  return tree?.getAttribute('role') === 'tree' ? tree.parentElement?.parentElement : null;
+};
+const treeItem = (entityId: string) => document.querySelector<HTMLElement>(`[role="treeitem"][data-breadcrumb-entity-id="${entityId}"]`);
+const trigger = (name: string) =>
+  [...document.querySelectorAll<HTMLButtonElement>('[aria-haspopup="tree"]')].find((button) => button.textContent?.includes(name));
+
+const mountFixture = async () => {
+  component = mount(BreadcrumbDocumentDragTestRoot, { target: document.body });
+  await tick();
+};
+
+describe('breadcrumb navigation keyboard interaction', () => {
+  it('marks the current document after expanding it from an ancestor segment', async () => {
+    await mountFixture();
+    const folderTrigger = trigger('Folder');
+    if (!folderTrigger) throw new Error('Missing folder breadcrumb trigger');
+
+    folderTrigger.focus();
+    await userEvent.keyboard('{Enter}');
+    await expect.poll(() => document.activeElement).toBe(treeItem('folder-1'));
+
+    await userEvent.keyboard('{ArrowRight}');
+    await expect.poll(() => treeItem('document-current')).not.toBeNull();
+    await userEvent.keyboard('{ArrowRight}');
+    await expect.poll(() => document.activeElement).toBe(treeItem('document-sibling'));
+    await userEvent.keyboard('{ArrowDown}');
+    await expect.poll(() => document.activeElement).toBe(treeItem('document-current'));
+
+    expect(treeItem('folder-1')?.getAttribute('aria-current')).toBeNull();
+    expect(treeItem('folder-1')?.getAttribute('aria-selected')).toBe('true');
+    expect(treeItem('document-current')?.getAttribute('aria-current')).toBe('page');
+    expect(treeItem('document-current')?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('opens with Space and supports tree navigation and document activation from actual focus', async () => {
+    await mountFixture();
+    const folderTrigger = trigger('Folder');
+    if (!folderTrigger) throw new Error('Missing folder breadcrumb trigger');
+
+    folderTrigger.focus();
+    await userEvent.keyboard(' ');
+    await expect.poll(popup).not.toBeNull();
+    await expect.poll(() => document.activeElement).toBe(treeItem('folder-1'));
+
+    await userEvent.keyboard('{End}');
+    await expect.poll(() => document.activeElement).toBe(treeItem('document-extra-15'));
+    await userEvent.keyboard('{Home}');
+    await expect.poll(() => document.activeElement).toBe(treeItem('folder-1'));
+
+    await userEvent.keyboard('{ArrowRight}');
+    await expect.poll(() => treeItem('document-current')).not.toBeNull();
+    await userEvent.keyboard('{ArrowRight}');
+    await expect.poll(() => document.activeElement).toBe(treeItem('document-sibling'));
+    await userEvent.keyboard('{ArrowLeft}');
+    await expect.poll(() => document.activeElement).toBe(treeItem('folder-1'));
+    await userEvent.keyboard('{ArrowLeft}');
+    await expect.poll(() => treeItem('folder-1')?.getAttribute('aria-expanded')).toBe('false');
+
+    await userEvent.keyboard('{ArrowDown}');
+    await expect.poll(() => document.activeElement).toBe(treeItem('document-first'));
+    await userEvent.keyboard('{Enter}');
+    await expect.poll(popup).toBeNull();
+    await expect.poll(() => document.querySelector('[data-navigated-slug]')?.textContent).toBe('document-first');
+  });
+
+  it('moves from automatic tree focus with row highlighting instead of a focus ring', async () => {
+    await mountFixture();
+    const folderTrigger = trigger('Folder');
+    if (!folderTrigger) throw new Error('Missing folder breadcrumb trigger');
+
+    await userEvent.click(folderTrigger);
+    await expect.poll(() => document.activeElement).toBe(treeItem('folder-1'));
+
+    await userEvent.keyboard('{ArrowDown}');
+    const nextItem = treeItem('document-first');
+    await expect.poll(() => document.activeElement).toBe(nextItem);
+    expect(nextItem?.matches(':focus-visible')).toBe(false);
+
+    const row = nextItem?.querySelector<HTMLElement>('[data-breadcrumb-tree-row]');
+    const ordinaryRow = treeItem('document-extra-0')?.querySelector<HTMLElement>('[data-breadcrumb-tree-row]');
+    if (!nextItem || !row || !ordinaryRow) throw new Error('Missing breadcrumb rows');
+    expect(getComputedStyle(row).backgroundColor).not.toBe(getComputedStyle(ordinaryRow).backgroundColor);
+  });
+
+  it('closes on Tab without restoring focus to the segment trigger', async () => {
+    await mountFixture();
+    const folderTrigger = trigger('Folder');
+    if (!folderTrigger) throw new Error('Missing breadcrumb trigger');
+
+    await userEvent.click(folderTrigger);
+    await expect.poll(() => document.activeElement).toBe(treeItem('folder-1'));
+
+    await userEvent.keyboard('{Tab}');
+    await expect.poll(popup).toBeNull();
+    expect(document.activeElement).not.toBe(folderTrigger);
+    expect(document.querySelector('[data-holds]')?.textContent).toBe('[]');
+  });
+
+  it('keeps the open segment trigger styled like hover', async () => {
+    await mountFixture();
+    const folderTrigger = trigger('Folder');
+    const currentTrigger = trigger('Current document');
+    if (!folderTrigger || !currentTrigger) throw new Error('Missing breadcrumb triggers');
+
+    await userEvent.click(folderTrigger);
+    const mountedPopup = popup();
+    if (!mountedPopup) throw new Error('Missing breadcrumb popup');
+
+    const closedBackground = getComputedStyle(currentTrigger).backgroundColor;
+    const closedColor = getComputedStyle(currentTrigger).color;
+    await userEvent.click(currentTrigger);
+    await userEvent.unhover(currentTrigger);
+    expect(currentTrigger.getAttribute('aria-expanded')).toBe('true');
+    expect(popup()).toBe(mountedPopup);
+    await expect.poll(() => mountedPopup.getBoundingClientRect().left).toBeCloseTo(currentTrigger.getBoundingClientRect().left, 0);
+    expect(getComputedStyle(currentTrigger).backgroundColor).not.toBe(closedBackground);
+    expect(getComputedStyle(currentTrigger).color).not.toBe(closedColor);
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -11,11 +11,9 @@
   import mixpanel from 'mixpanel-browser';
   import { onDestroy, tick, untrack } from 'svelte';
   import { fly } from 'svelte/transition';
-  import ChevronRightIcon from '~icons/lucide/chevron-right';
   import ClockFadingIcon from '~icons/lucide/clock-fading';
   import CrownIcon from '~icons/lucide/crown';
   import EllipsisIcon from '~icons/lucide/ellipsis';
-  import FolderIcon from '~icons/lucide/folder';
   import InfoIcon from '~icons/lucide/info';
   import LightbulbIcon from '~icons/lucide/lightbulb';
   import LockIcon from '~icons/lucide/lock';
@@ -46,6 +44,7 @@
   import { dragPane } from '../@pane/dnd';
   import { getEditorRegistry } from '../@pane/editor-registry.svelte';
   import TabIcon from '../@pane/TabIcon.svelte';
+  import EditorBreadcrumbNavigation from './@breadcrumb/EditorBreadcrumbNavigation.svelte';
   import CommentPopover from './@document-comments/CommentPopover.svelte';
   import DocumentComments from './@document-comments/DocumentComments.svelte';
   import DocumentPanel from './@document-panel/DocumentPanel.svelte';
@@ -67,6 +66,7 @@
   import type { StableSelection } from '@typie/editor-ffi/browser';
   import type { EditorContextBarSegmentRenderProps } from '$lib/editor-ffi/components/ui/EditorContextBar.svelte';
   import type { DocumentEditorV2_query$key } from '$mearie';
+  import type { EditorBreadcrumbPathEntity } from './@breadcrumb/EditorBreadcrumbNavigation.svelte';
   import type { RemoteChangesetEvent } from './sync/remote-changeset-pipeline';
 
   type Props = {
@@ -112,6 +112,10 @@
           icon
           iconColor
           ...EntityIcon_entity
+
+          site {
+            id
+          }
 
           ancestors {
             id
@@ -289,6 +293,15 @@
   const documentId = $derived(document?.id ?? null);
   const breadcrumbPathIdentity = $derived(entity ? [...entity.ancestors.map((ancestor) => ancestor.id), entity.id].join('/') : '');
   const breadcrumbViewportId = `editor-breadcrumb-${pane.id}`;
+  const breadcrumbAncestors = $derived.by(() => {
+    const path: EditorBreadcrumbPathEntity[] = [];
+    for (const ancestor of entity?.ancestors ?? []) {
+      if (ancestor.node.__typename === 'Folder') {
+        path.push({ id: ancestor.id, name: ancestor.node.name, entity$key: ancestor });
+      }
+    }
+    return path;
+  });
   const isOwner = $derived(query.data.me.id === entity?.user.id || query.data.me.role === 'ADMIN');
 
   let editorAreaWidth = $state(0);
@@ -1302,37 +1315,19 @@
                                 pathIdentity={breadcrumbPathIdentity}
                                 viewportId={breadcrumbViewportId}
                               >
-                                <nav
-                                  class={css({
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    height: '32px',
-                                    paddingLeft: '24px',
-                                    paddingRight: '16px',
-                                    fontSize: '12px',
-                                    fontWeight: 'medium',
-                                    color: 'text.subtle',
-                                  })}
-                                  aria-label="문서 경로"
-                                >
-                                  <ol class={flex({ alignItems: 'center', gap: '2px', listStyle: 'none', whiteSpace: 'nowrap' })}>
-                                    {#each entity.ancestors as ancestor (ancestor.id)}
-                                      {#if ancestor.node.__typename === 'Folder'}
-                                        <li class={flex({ alignItems: 'center', gap: '4px' })}>
-                                          <EntityIcon entity$key={ancestor} fallback={FolderIcon} size={14} />
-                                          <span>{ancestor.node.name}</span>
-                                        </li>
-                                        <li class={css({ display: 'grid', placeItems: 'center', color: 'text.faint' })} aria-hidden="true">
-                                          <Icon icon={ChevronRightIcon} size={14} />
-                                        </li>
-                                      {/if}
-                                    {/each}
-                                    <li class={flex({ alignItems: 'center', gap: '4px' })} aria-current="page">
-                                      <EntityIcon entity$key={entity} size={14} />
-                                      <span>{localTitle || '(제목 없음)'}</span>
-                                    </li>
-                                  </ol>
-                                </nav>
+                                {#key breadcrumbPathIdentity}
+                                  <EditorBreadcrumbNavigation
+                                    ancestors={breadcrumbAncestors}
+                                    current={{ id: entity.id, slug: entity.slug, name: localTitle || '(제목 없음)', entity$key: entity }}
+                                    {isOwner}
+                                    onNavigate={(slug) => {
+                                      paneGroup.replacePane(pane.id, { kind: 'entity', slug });
+                                    }}
+                                    popupId={`${breadcrumbViewportId}-tree`}
+                                    segment={state}
+                                    siteId={entity.site.id}
+                                  />
+                                {/key}
                               </EditorBreadcrumb>
                             {/snippet}
                             {#snippet viewControls({ state, presentation }: EditorContextBarSegmentRenderProps)}

--- a/packages/ui/src/actions/floating.svelte.ts
+++ b/packages/ui/src/actions/floating.svelte.ts
@@ -19,6 +19,7 @@ export type ReferenceAction = Action<ReferenceElement>;
 export type FloatingAction = Action<FloatingElement, { appendTo?: Element | null } | undefined>;
 export type ArrowAction = Action<HTMLElement>;
 export type UpdatePosition = () => Promise<void>;
+export type SetFloatingReference = (element: ReferenceElement | null) => void;
 
 type PlacementRect = Pick<Rect, 'x' | 'y' | 'width' | 'height'>;
 type PlacementSize = Pick<Rect, 'width' | 'height'>;
@@ -128,6 +129,7 @@ type CreateFloatingActionsReturn = {
   anchor: ReferenceAction;
   floating: FloatingAction;
   arrow: ArrowAction;
+  setReference: SetFloatingReference;
   update: UpdatePosition;
 };
 
@@ -271,6 +273,13 @@ export function createFloatingActions(options?: CreateFloatingActionsOptions): C
     cleanupClickHandler = undefined;
   };
 
+  const setReference: SetFloatingReference = (element) => {
+    if (referenceElement === element) return;
+    unmount();
+    referenceElement = element ?? undefined;
+    mount();
+  };
+
   const referenceAction: ReferenceAction = (element) => {
     $effect(() => {
       referenceElement = element;
@@ -334,6 +343,7 @@ export function createFloatingActions(options?: CreateFloatingActionsOptions): C
     anchor: referenceAction,
     floating: floatingAction,
     arrow: arrowAction,
+    setReference,
     update: updatePosition,
   };
 }


### PR DESCRIPTION
## 배경

에디터 breadcrumb는 현재 문서의 경로만 표시하고 있어, 같은 폴더의 다른 문서를 확인하거나 이동하려면 사이드바를 사용해야 했습니다.

breadcrumb에서 현재 위치의 엔티티 트리를 바로 탐색하고, 문서를 기존 pane DnD 흐름으로 열 수 있도록 개선합니다.

## 변경 사항

- breadcrumb segment와 오른쪽 chevron을 하나의 클릭 영역으로 구성
- segment를 클릭하면 해당 엔티티가 속한 폴더 또는 루트의 엔티티 트리를 표시
- 폴더를 펼칠 때 하위 엔티티를 지연 조회
- 현재 segment와 현재 문서를 각각 선택·활성 상태로 표시
- 방향키, Home/End, Enter/Space, Escape를 이용한 키보드 탐색 지원
- 문서 클릭 시 현재 pane에서 해당 문서로 이동
- 문서를 pane drop zone으로 드래그할 수 있도록 지원
  - mouse/pen 이동 임계값
  - touch long press 및 스크롤 취소 처리
  - drag 종료 후 원본 문서가 클릭으로 활성화되지 않도록 차단
- 하나의 팝오버를 열린 segment에 다시 배치할 수 있도록 Floating UI reference 갱신 지원
- 팝오버 최대 높이를 약 12개 엔티티로 제한하고, 사용 가능한 viewport 높이가 더 작으면 그에 맞춰 축소
- 로딩, 빈 폴더, 조회 실패 상태를 트리 내부에 표시
- 비소유자에게는 기존처럼 정적 breadcrumb만 표시

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>