### PR TITLE
공유 문서의 목표 조회 권한 제한

### DIFF
--- a/apps/api/src/graphql/resolvers/entity.ts
+++ b/apps/api/src/graphql/resolvers/entity.ts
@@ -229,6 +229,40 @@ Entity.implement({
       type: EntityGoal,
       nullable: true,
       resolve: async (self, _, ctx) => {
+        const userId = ctx.session?.userId;
+        if (!userId) {
+          return null;
+        }
+
+        // 공유 문서의 목표는 문서 독자에게 보이지만, 상위 폴더 목표는 사이트 소유자에게만 보인다.
+        if (self.type !== EntityType.DOCUMENT) {
+          const permissionLoader = ctx.loader({
+            name: 'Entity.goal.permission',
+            nullable: true,
+            load: async (siteIds: string[]) => {
+              const allowed: { siteId: string }[] = [];
+
+              for (const siteId of siteIds) {
+                try {
+                  await assertSitePermission({ userId, siteId });
+                  allowed.push({ siteId });
+                } catch (err) {
+                  if (!(err instanceof TypieError)) {
+                    throw err;
+                  }
+                }
+              }
+
+              return allowed;
+            },
+            key: (row) => row?.siteId,
+          });
+
+          if (!(await permissionLoader.load(self.siteId))) {
+            return null;
+          }
+        }
+
         const loader = ctx.loader({
           name: 'Entity.goal',
           nullable: true,

--- a/apps/api/src/graphql/resolvers/user.ts
+++ b/apps/api/src/graphql/resolvers/user.ts
@@ -322,7 +322,12 @@ User.implement({
     goal: t.withAuth({ session: true }).field({
       type: UserGoal,
       nullable: true,
-      resolve: async (self) => {
+      resolve: async (self, _, ctx) => {
+        // User는 문서 소유자 등 다른 경로에서도 노출되므로 개인 목표는 세션 사용자에게만 반환한다.
+        if (ctx.session.userId !== self.id) {
+          return null;
+        }
+
         const row = await currentUserGoal(self.id);
         return row?.id ?? null;
       },
@@ -330,7 +335,11 @@ User.implement({
 
     goalHistory: t.withAuth({ session: true }).field({
       type: [UserGoalHistory],
-      resolve: async (self) => {
+      resolve: async (self, _, ctx) => {
+        if (ctx.session.userId !== self.id) {
+          return [];
+        }
+
         return await dailyGoalHistory(self.id);
       },
     }),


### PR DESCRIPTION
- 공유 문서의 문서 목표는 문서를 읽는 사용자에게 표시합니다.
- 상위 폴더 목표는 사이트 소유자와 관리자에게만 노출합니다.
- 개인 목표와 목표 이력은 해당 사용자 본인에게만 반환합니다.

공유 문서의 비소유자는 문서 자체의 목표와 자신의 개인 목표는 볼 수 있어야 하지만, 문서 소유자의 상위 폴더 목표나 개인 목표에는 접근할 수 없어야 합니다.



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>