### PR TITLE
프리즘 리뷰 버튼이 포인터 포커스를 차단하지 않도록 함

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewButton.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewButton.svelte
@@ -32,7 +32,6 @@
       open = true;
       mixpanel.track('open_prism_review_rounds_modal');
     }}
-    onpointerdown={(event) => event.preventDefault()}
     type="button"
     use:tooltip={{ message: '리뷰' }}
   >


### PR DESCRIPTION
프리즘 리뷰 버튼이 포인터 포커스를 차단하면서, 에디터의 `focus-visible` 상태가 모달 첫 버튼으로 이어지던 문제를 수정

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>