### PR TITLE
모달 초기 포커스 링을 열기 방식에 맞게 표시

### DIFF
--- a/packages/ui/src/components/Modal.svelte
+++ b/packages/ui/src/components/Modal.svelte
@@ -43,6 +43,7 @@
 
   let trapEl = $state<HTMLElement>();
   let previouslyFocused: HTMLElement | null = null;
+  let initialFocusVisible = $state(false);
 
   // 자식 컴포넌트가 focus-trap 활성화 전에 포커스를 가져가면(예: Notes의 textarea autofocus),
   // focus-trap이 잘못된 엘리먼트를 캡처한다. $effect.pre는 DOM 렌더 전에 실행되므로
@@ -51,6 +52,7 @@
     if (open) {
       if (!previouslyFocused) {
         previouslyFocused = document.activeElement as HTMLElement | null;
+        initialFocusVisible = previouslyFocused?.matches(':focus-visible') ?? false;
       }
     } else {
       if (trapEl) {
@@ -58,6 +60,7 @@
         previouslyFocused?.focus();
       }
       previouslyFocused = null;
+      initialFocusVisible = false;
     }
   });
 
@@ -85,6 +88,7 @@
       returnFocusOnDeactivate: true,
       allowOutsideClick: true, // NOTE: downloadFromBase64 등 외부 클릭 허용
       ...focusTrapOptions,
+      initialFocusOptions: { focusVisible: initialFocusVisible },
     }}
     use:portal
   >

--- a/patches/focus-trap@8.2.2.patch
+++ b/patches/focus-trap@8.2.2.patch
@@ -1,0 +1,59 @@
+# cspell:ignore focusin
+diff --git a/index.d.ts b/index.d.ts
+index 1900adce8b72ee79236da73456cbc67dd155fda4..20ec07820310463505d1100eed0b86f0888eaa56 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -139,6 +139,8 @@ declare module 'focus-trap' {
+      * will result in the default behavior.
+      */
+     initialFocus?: FocusTargetOrFalse | undefined | (() => void);
++    /** Options applied only when focus is initially moved into the trap. */
++    initialFocusOptions?: Pick<FocusOptions, 'focusVisible'>;
+     /**
+      * By default, an error will be thrown if the focus trap contains no
+      * elements in its tab order. With this option you can specify a
+diff --git a/index.js b/index.js
+index d8d893663591d47dfad164324807033bf0ae4220..9599bb20006ad12d681f746c628ef35988e49cbb 100644
+--- a/index.js
++++ b/index.js
+@@ -484,7 +484,7 @@ const createFocusTrap = function (elements, userOptions) {
+     }
+   };
+ 
+-  const tryFocus = function (node) {
++  const tryFocus = function (node, focusOptions) {
+     if (node === false) {
+       return;
+     }
+@@ -494,11 +494,14 @@ const createFocusTrap = function (elements, userOptions) {
+     }
+ 
+     if (!node || !node.focus) {
+-      tryFocus(getInitialFocusNode());
++      tryFocus(getInitialFocusNode(), focusOptions);
+       return;
+     }
+ 
+-    node.focus({ preventScroll: !!config.preventScroll });
++    node.focus({
++      preventScroll: !!config.preventScroll,
++      ...focusOptions,
++    });
+     // NOTE: focus() API does not trigger focusIn event so set MRU node manually
+     state.mostRecentlyFocusedNode = node;
+ 
+@@ -874,12 +877,12 @@ const createFocusTrap = function (elements, userOptions) {
+       //  since we need to capture the timer ID immediately
+       promise = new Promise((resolve) => {
+         state.delayInitialFocusTimer = delay(function () {
+-          tryFocus(getInitialFocusNode());
++          tryFocus(getInitialFocusNode(), config.initialFocusOptions);
+           resolve();
+         });
+       });
+     } else {
+-      tryFocus(getInitialFocusNode());
++      tryFocus(getInitialFocusNode(), config.initialFocusOptions);
+     }
+ 
+     doc.addEventListener('focusin', checkFocusIn, true);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
 
 patchedDependencies:
   '@mearie/core@0.8.1': cfb699f35b5b8753d3ccd535222bba55de7f71f523611369eac36a4b88c7c416
+  focus-trap@8.2.2: ecc77b92122077c63918928f1c2072e5ba00ff557984112bdfa06f79b39ca326
 
 importers:
 
@@ -968,7 +969,7 @@ importers:
         version: 2.4.0
       focus-trap:
         specifier: ^8.2.2
-        version: 8.2.2
+        version: 8.2.2(patch_hash=ecc77b92122077c63918928f1c2072e5ba00ff557984112bdfa06f79b39ca326)
       query-string:
         specifier: ^9.5.0
         version: 9.5.0
@@ -15432,7 +15433,7 @@ snapshots:
       async: 0.2.10
       which: 1.3.1
 
-  focus-trap@8.2.2:
+  focus-trap@8.2.2(patch_hash=ecc77b92122077c63918928f1c2072e5ba00ff557984112bdfa06f79b39ca326):
     dependencies:
       tabbable: 6.5.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,3 +37,4 @@ minimumReleaseAgeExclude:
   - mearie@0.1.8
 patchedDependencies:
   '@mearie/core@0.8.1': patches/@mearie__core@0.8.1.patch
+  focus-trap@8.2.2: patches/focus-trap@8.2.2.patch


### PR DESCRIPTION
자동으로 열리거나 포인터로 연 모달에서도 초기 버튼에 포커스 링이 표시되는 문제를 수정했습니다.
모달을 열기 직전 요소의 :focus-visible 상태를 초기 포커스에 전달합니다.
- 키보드로 연 모달: 포커스 링 표시
- 포인터로 열거나 자동으로 열린 모달: 포커스 링 숨김
- 이후 Tab 이동과 포커스 트랩 동작: 기존과 동일
focus-trap이 focusVisible 옵션을 지원하지 않아, 최초 포커스 호출에만 해당 옵션을 전달하도록 dependency patch를 추가했습니다. 이를 통해 모달별 예외 처리 없이 기존 focus-trap의 대상 선택과 내부 상태 관리를 그대로 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>