### PR TITLE
프리즘 badge dot 개선

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -1506,6 +1506,7 @@ type PrismSession {
   title: String
   toolPolicy: PrismToolPolicy!
   transcript: PrismTranscript!
+  unseenResponseCount: Int!
   unseenReviewCount: Int!
   updatedAt: DateTime!
 }

--- a/apps/api/src/graphql/resolvers/prism.ts
+++ b/apps/api/src/graphql/resolvers/prism.ts
@@ -16,7 +16,7 @@ import { NotFoundError, TypieError } from '@typie/lib/errors';
 import { prismSchema } from '@typie/lib/validation';
 import { ApproveInputSchema, DECLINED_MESSAGE, effectiveResolver, serveVerdict, toGraphQL, TOOL_META, toolFailure } from '@typie/prism';
 import dayjs from 'dayjs';
-import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, gt, inArray, isNotNull, isNull, ne, or, sql } from 'drizzle-orm';
 import { Repeater } from 'graphql-yoga';
 import { nanoid } from 'nanoid';
 import { redis } from '#/cache.ts';
@@ -375,6 +375,34 @@ PrismSession.implement({
         });
 
         return (await loader.load(self.id)) !== null;
+      },
+    }),
+
+    unseenResponseCount: t.int({
+      resolve: async (self, _, ctx) => {
+        const loader = ctx.loader({
+          name: 'PrismSession.unseenResponses',
+          nullable: true,
+          load: async (sessionIds: string[]) => {
+            return await db
+              .select({ sessionId: PrismRuns.sessionId, count: count(PrismRuns.id) })
+              .from(PrismRuns)
+              .innerJoin(PrismSessions, eq(PrismSessions.id, PrismRuns.sessionId))
+              .where(
+                and(
+                  inArray(PrismRuns.sessionId, sessionIds),
+                  inArray(PrismRuns.state, [PrismRunState.COMPLETED, PrismRunState.FAILED]),
+                  isNotNull(PrismRuns.finishedAt),
+                  or(isNull(PrismSessions.seenAt), gt(PrismRuns.finishedAt, PrismSessions.seenAt)),
+                ),
+              )
+              .groupBy(PrismRuns.sessionId);
+          },
+          key: (row) => row?.sessionId,
+        });
+
+        const row = await loader.load(self.id);
+        return row?.count ?? 0;
       },
     }),
 

--- a/apps/api/src/mq/tasks/prism-ingest.ts
+++ b/apps/api/src/mq/tasks/prism-ingest.ts
@@ -176,6 +176,9 @@ const applyAgentOp = async (tx: Transaction, session: SessionRef, op: DomainOp):
             finishedAt: run.finishedAt.valueOf(),
           });
           if (notification) pubsub.publish('prism:notification', session.userId, notification);
+          if (run.state === 'COMPLETED' || run.state === 'FAILED') {
+            pubsub.publish('prism:badge', session.userId, { sessionId: session.id });
+          }
         }
         pubsub.publish('prism:credit', session.userId, {});
       };

--- a/apps/website/src/routes/website/(dashboard)/+layout.svelte
+++ b/apps/website/src/routes/website/(dashboard)/+layout.svelte
@@ -184,6 +184,7 @@
         prismBadgeStream {
           id
           awaitingUser
+          unseenResponseCount
           unseenReviewCount
         }
       }

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismBadgeDot.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismBadgeDot.svelte
@@ -13,4 +13,4 @@
   })}
   aria-hidden="true"
 ></span>
-<span class={css({ srOnly: true })}>새 상태 변화 있음</span>
+<span class={css({ srOnly: true })}>확인할 항목 있음</span>

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
@@ -95,6 +95,7 @@
           updatedAt
           toolPolicy
           awaitingUser
+          unseenResponseCount
           unseenReviewCount
         }
       }
@@ -174,6 +175,7 @@
       mutation DashboardLayout_PrismPanel_MarkSeen_Mutation($input: MarkPrismSessionSeenInput!) {
         markPrismSessionSeen(input: $input) {
           id
+          unseenResponseCount
           unseenReviewCount
         }
       }
@@ -595,7 +597,10 @@
   const panelVisible = $derived(app.state.prismAccess || panelOpen);
   const panelInteractive = $derived(panelOpen && !app.preference.current.zenModeEnabled);
   const welcomeAdmission = $derived(panelInteractive && !listOpen && page.state.shallowRoute == null);
-  const viewingSessionId = $derived(panelInteractive && !listOpen && page.state.shallowRoute == null ? selected.current : null);
+  let visibilityState = $state<DocumentVisibilityState>('hidden');
+  const viewingSessionId = $derived(
+    visibilityState === 'visible' && panelInteractive && !listOpen && page.state.shallowRoute == null ? selected.current : null,
+  );
   let prevPanelOpen: boolean | null = null;
 
   $effect(() => {
@@ -624,15 +629,21 @@
     }
 
     const id = selected.current;
+    const viewedId = viewingSessionId;
     untrack(() => {
       void chat.load(id);
-      if (id !== null) markSeen(id);
+      if (id === null || id !== viewedId) return;
+
+      const session = currentSession;
+      if (session === null || session.id !== id || (session.unseenResponseCount === 0 && session.unseenReviewCount === 0)) {
+        markSeen(id);
+      }
     });
   });
 
   $effect(() => {
     const session = currentSession;
-    if (session === null || session.unseenReviewCount === 0 || !app.preference.current.prismPanelOpen) {
+    if (session === null || session.id !== viewingSessionId || (session.unseenResponseCount === 0 && session.unseenReviewCount === 0)) {
       return;
     }
 
@@ -854,6 +865,8 @@
   };
 </script>
 
+<svelte:document bind:visibilityState />
+
 {#snippet currentTitleTooltip()}
   <span class={css({ display: 'block', maxWidth: '280px', overflowWrap: 'break-word', textWrap: 'balance', wordBreak: 'keep-all' })}>
     {currentTitle}
@@ -1002,7 +1015,7 @@
 
       <button
         class={cx(buttonClass, listOpen ? css({ color: 'text.default', backgroundColor: 'surface.muted' }) : undefined)}
-        aria-label="대화 목록"
+        aria-label={app.state.prismBadge ? '대화 목록, 확인할 항목 있음' : '대화 목록'}
         aria-pressed={listOpen}
         onclick={() => (listOpen = !listOpen)}
         type="button"

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismSessionList.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismSessionList.svelte
@@ -20,6 +20,7 @@
     archivedAt?: string | null;
     updatedAt: string;
     awaitingUser: boolean;
+    unseenResponseCount: number;
     unseenReviewCount: number;
   };
 
@@ -352,7 +353,7 @@
         <span class={`title ${rowTitle}`}>{labelOf(session)}</span>
         {#if unread(session)}
           <span class={rowDot} aria-hidden="true"></span>
-          <span class={css({ srOnly: true })}>새 상태 변화 있음</span>
+          <span class={css({ srOnly: true })}>확인할 항목 있음</span>
         {/if}
         <TimeAgo
           style={css.raw({ flexShrink: '0', fontSize: '11px', color: 'text.faint' })}

--- a/apps/website/src/routes/website/(dashboard)/@prism/lib/session-groups.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/lib/session-groups.test.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import { describe, expect, it } from 'vitest';
-import { groupSessionsByRecency, matchesSessionQuery } from './session-groups.ts';
+import { groupSessionsByRecency, hasUnread, matchesSessionQuery } from './session-groups.ts';
 
 const now = dayjs('2026-08-21T15:00:00+09:00');
 const at = (iso: string) => ({ updatedAt: dayjs(iso).toISOString() });
@@ -54,5 +54,19 @@ describe('matchesSessionQuery', () => {
     expect(matchesSessionQuery('추리 트릭 검증', ' 트릭 ')).toBe(true);
     expect(matchesSessionQuery('Plot Holes', 'plot')).toBe(true);
     expect(matchesSessionQuery(null, 'x')).toBe(false);
+  });
+});
+
+describe('hasUnread', () => {
+  it('확인이 필요한 상태는 표시하고 보관된 세션은 제외한다', () => {
+    const read = { awaitingUser: false, unseenResponseCount: 0, unseenReviewCount: 0 };
+
+    expect(hasUnread(read)).toBe(false);
+    expect(hasUnread({ ...read, awaitingUser: true })).toBe(true);
+    expect(hasUnread({ ...read, unseenResponseCount: 1 })).toBe(true);
+    expect(hasUnread({ ...read, unseenReviewCount: 1 })).toBe(true);
+    expect(hasUnread({ ...read, archivedAt: now.toISOString(), awaitingUser: true, unseenResponseCount: 1, unseenReviewCount: 1 })).toBe(
+      false,
+    );
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/@prism/lib/session-groups.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/lib/session-groups.ts
@@ -4,8 +4,12 @@ export type SessionGroup<T> = { key: string; label: string; sessions: T[] };
 
 export const sessionLabel = (session: { title?: string | null }): string => session.title ?? '새 대화';
 
-export const hasUnread = (session: { archivedAt?: string | null; awaitingUser: boolean; unseenReviewCount: number }): boolean =>
-  session.archivedAt == null && (session.awaitingUser || session.unseenReviewCount > 0);
+export const hasUnread = (session: {
+  archivedAt?: string | null;
+  awaitingUser: boolean;
+  unseenResponseCount: number;
+  unseenReviewCount: number;
+}): boolean => session.archivedAt == null && (session.awaitingUser || session.unseenResponseCount > 0 || session.unseenReviewCount > 0);
 
 export const groupSessionsByRecency = <T extends { updatedAt: string }>(sessions: readonly T[], now = dayjs()): SessionGroup<T>[] => {
   const today = now.startOf('day');

--- a/apps/website/src/routes/website/(dashboard)/AppHeader.svelte
+++ b/apps/website/src/routes/website/(dashboard)/AppHeader.svelte
@@ -67,7 +67,7 @@
   {#if app.state.prismAccess}
     <button
       class={css(button, open ? { backgroundColor: 'surface.muted' } : {})}
-      aria-label="PRISM 열기/닫기"
+      aria-label={app.state.prismBadge ? 'PRISM 열기/닫기, 확인할 항목 있음' : 'PRISM 열기/닫기'}
       aria-pressed={open}
       onclick={() => {
         const next = !open;


### PR DESCRIPTION
## 변경 사항

- 마지막 열람 이후 완료·실패한 PRISM turn 수를 `unseenResponseCount`로 제공합니다.
- terminal run이 반영된 뒤 기존 badge stream을 갱신합니다.
- 기존 unread 판정에 일반 채팅 turn 종료를 포함합니다.
- 페이지가 visible하고 실제 해당 대화를 보고 있을 때만 세션을 읽음 처리합니다.
- 배지의 접근성 문구를 `확인할 항목 있음`으로 정리합니다.

## 배경

기존 PRISM 배지는 사용자 액션이 필요하거나 완료된 리뷰가 있을 때만 표시했습니다. 일반 채팅 turn 종료는 배지에 반영되지 않아 알림음은 울리지만 dot은 표시되지 않았습니다.

또한 세션이 선택돼 있다는 이유만으로 대화 목록이나 hidden 탭에서도 읽음 처리될 수 있었습니다. 실제 대화 화면을 보고 있는 경우에만 `seenAt`을 갱신하도록 열람 조건을 좁혔습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>