### PR TITLE
웹 esc 처리 우선순위 정리

### DIFF
--- a/apps/website/src/lib/components/admin/AdminModal.svelte
+++ b/apps/website/src/lib/components/admin/AdminModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
+  import { pushEscapeHandler } from '@typie/ui/utils';
   import XIcon from '~icons/lucide/x';
   import { AdminIcon } from '$lib/components/admin';
   import type { Snippet } from 'svelte';
@@ -33,11 +34,21 @@
     }
   };
 
-  const handleKeydown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
+  const handleBackdropKeydown = (e: KeyboardEvent) => {
+    if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
       open = false;
     }
   };
+
+  $effect(() => {
+    if (!open) return;
+
+    return pushEscapeHandler(() => {
+      open = false;
+      return true;
+    });
+  });
 </script>
 
 {#if open}
@@ -54,7 +65,7 @@
       zIndex: '[1000]',
     })}
     onclick={handleBackdropClick}
-    onkeydown={handleKeydown}
+    onkeydown={handleBackdropKeydown}
     role="button"
     tabindex="-1"
   >

--- a/apps/website/src/lib/dnd-handler.test.ts
+++ b/apps/website/src/lib/dnd-handler.test.ts
@@ -1,4 +1,4 @@
-import { createDndHandler } from '@typie/ui/utils';
+import { createDndHandler, pushEscapeHandler, runEscapeStack } from '@typie/ui/utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const pointerEvent = (type: string, pointerId = 1, clientX = 0) => {
@@ -169,5 +169,31 @@ describe('createDndHandler', () => {
 
     expect(onDragCancel).toHaveBeenCalledOnce();
     expect(handler.state().isDragging).toBe(false);
+  });
+
+  it('places an active drag above an existing Escape owner and removes it after cancellation', () => {
+    const element = createElement();
+    installPointerCapture(element);
+    const frames = installAnimationFrames();
+    const lowerEscapeHandler = vi.fn(() => true);
+    const removeLowerEscapeHandler = pushEscapeHandler(lowerEscapeHandler);
+    const onDragCancel = vi.fn();
+    const handler = createDndHandler(element, { threshold: 0, showGhost: false, onDragCancel });
+
+    try {
+      element.dispatchEvent(pointerEvent('pointerdown'));
+      element.dispatchEvent(pointerEvent('pointermove', 1, 10));
+      frames.flush();
+
+      expect(runEscapeStack()).toBe(true);
+      expect(onDragCancel).toHaveBeenCalledOnce();
+      expect(lowerEscapeHandler).not.toHaveBeenCalled();
+
+      expect(runEscapeStack()).toBe(true);
+      expect(lowerEscapeHandler).toHaveBeenCalledOnce();
+    } finally {
+      handler.destroy();
+      removeLowerEscapeHandler();
+    }
   });
 });

--- a/apps/website/src/lib/editor-ffi/components/ExternalImageEnlarge.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ExternalImageEnlarge.svelte
@@ -3,6 +3,7 @@
   import { center } from '@typie/styled-system/patterns';
   import { portal, scrollLock } from '@typie/ui/actions';
   import { ContentProtect, Icon, Img } from '@typie/ui/components';
+  import { pushEscapeHandler } from '@typie/ui/utils';
   import { cubicOut } from 'svelte/easing';
   import { Tween } from 'svelte/motion';
   import XIcon from '~icons/lucide/x';
@@ -71,9 +72,16 @@
     await progress.set(0);
     onclose();
   };
+
+  $effect(() =>
+    pushEscapeHandler(() => {
+      void handleClose();
+      return true;
+    }),
+  );
 </script>
 
-<svelte:window onclickcapture={handleClose} onkeydown={(event) => event.key === 'Escape' && handleClose()} />
+<svelte:window onclickcapture={handleClose} />
 
 <div class={css({ position: 'fixed', inset: '0', size: 'full', zIndex: 'modal' })} use:portal use:scrollLock>
   <ContentProtect>

--- a/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarFontSize.svelte
+++ b/apps/website/src/lib/editor-ffi/components/toolbar/ToolbarFontSize.svelte
@@ -97,6 +97,8 @@
   });
 
   const handleKeydown = (e: KeyboardEvent) => {
+    if (e.isComposing || e.defaultPrevented) return;
+
     if (e.key === 'Enter') {
       e.preventDefault();
       e.stopPropagation();
@@ -105,6 +107,8 @@
       close();
       ctx.editor?.focus();
     } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
       inputValue = displayFontSize === undefined ? '' : String(displayFontSize);
       inputElement?.blur();
       close();

--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -6,7 +6,7 @@ import { page } from 'vitest/browser';
 import { CURSOR_VISIBLE_MARGIN, PAGE_GAP } from './constants';
 import { Editor } from './editor.svelte';
 import EditorFrameSyncTestHost from './editor-frame-sync-test-host.svelte';
-import { pageRectsToClientRect, pageRectToClientRect, selectionHeadRect } from './geometry';
+import { isSelectionCollapsed, pageRectsToClientRect, pageRectToClientRect, selectionHeadRect } from './geometry';
 import { computeSelectionHandleVisual } from './gesture.svelte';
 import type { PlainDoc, PlainNode, PlainNodeEntry } from '@typie/editor-ffi/browser';
 import type { EditorFrameSyncTestHarness } from './editor-frame-sync-test-host.svelte';
@@ -657,6 +657,72 @@ function expectActualCanvas(editor: Editor, pageIndex: number, requirePaintedPix
 }
 
 describe('web editor frame synchronization', () => {
+  it('orders text selection collapse, focus-mode exit, and editor blur across Escape presses', async () => {
+    const { editor } = await mountEditor(doc('hello'));
+    const range = editor.proseToSelection(1, 4);
+    expect(range).toBeDefined();
+    if (!range) throw new Error('Expected a text range');
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set', selection: range } }));
+
+    let focusModeEnabled = true;
+    editor.escapeKeyHandler = () => {
+      if (!focusModeEnabled || editor.appliedSnapshot.selectionKind === 'range') return false;
+      focusModeEnabled = false;
+      return true;
+    };
+    editor.focus();
+    expect(editor.focused).toBe(true);
+
+    editor.inputEl?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    expect(focusModeEnabled).toBe(true);
+    expect(isSelectionCollapsed(editor.appliedSnapshot.selection)).toBe(true);
+    const collapsed = editor.appliedSnapshot.selection;
+
+    editor.inputEl?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    expect(focusModeEnabled).toBe(false);
+    expect(editor.appliedSnapshot.selection).toEqual(collapsed);
+    expect(editor.focused).toBe(true);
+
+    editor.inputEl?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+    expect(editor.appliedSnapshot.selection).toBeUndefined();
+    await expect.poll(() => editor.focused).toBe(false);
+  });
+
+  it('exits focus mode without clearing a unit selection or blurring the editor', async () => {
+    const { editor } = await mountEditor(externalComponentDoc({ type: 'image', id: 'asset', proportion: 100 }));
+    const image = editor.appliedSnapshot.externalElements[0];
+    expect(image).toBeDefined();
+    if (!image) throw new Error('Expected an image external element');
+    editor.updateNow((request) =>
+      request.enqueue({
+        type: 'selection',
+        op: {
+          type: 'set_at',
+          page: image.page_idx,
+          x: image.bounds.x + image.bounds.width / 2,
+          y: image.bounds.y + image.bounds.height / 2,
+        },
+      }),
+    );
+    const unitSelection = editor.appliedSnapshot.selection;
+    expect(unitSelection).toBeDefined();
+    expect(editor.appliedSnapshot.selectionKind).toBe('unit');
+
+    let focusModeEnabled = true;
+    editor.escapeKeyHandler = () => {
+      if (!focusModeEnabled || editor.appliedSnapshot.selectionKind === 'range') return false;
+      focusModeEnabled = false;
+      return true;
+    };
+    editor.focus();
+
+    editor.inputEl?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+
+    expect(focusModeEnabled).toBe(false);
+    expect(editor.appliedSnapshot.selection).toEqual(unitSelection);
+    expect(editor.focused).toBe(true);
+  });
+
   it('resolves pointer coordinates from the document track without measuring individual pages', async () => {
     const { editor } = await mountEditor(paginatedDocWithPageBreaks(3));
     await waitForPresentation(editor);

--- a/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-publication-preparation.test.ts
@@ -9,6 +9,7 @@ const snapshot = (overrides: Partial<EditorSnapshot>): EditorSnapshot => ({
   cursor: undefined,
   placeholder: undefined,
   selection: undefined,
+  selectionKind: undefined,
   selectionEndpoints: undefined,
   lastHistoryTag: undefined,
   pageSizes: [],

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -43,6 +43,7 @@ import type {
   ResourceUpdate,
   Selection,
   SelectionEndpoints,
+  SelectionKind,
   Size,
   StableSelection,
   StateField,
@@ -102,6 +103,7 @@ export type EditorSnapshot = Readonly<{
   cursor: CursorMetrics | undefined;
   placeholder: PlaceholderMetrics | undefined;
   selection: Selection | undefined;
+  selectionKind: SelectionKind | undefined;
   selectionEndpoints: SelectionEndpoints | undefined;
   lastHistoryTag: HistoryTag | undefined;
   pageSizes: Size[];
@@ -357,6 +359,7 @@ export class Editor {
     cursor: undefined,
     placeholder: undefined,
     selection: undefined,
+    selectionKind: undefined,
     selectionEndpoints: undefined,
     lastHistoryTag: undefined,
     pageSizes: [],
@@ -469,6 +472,7 @@ export class Editor {
   readOnly = $state(false);
   protectContent = $state(false);
   editBlockedHandler: (() => void) | null = null;
+  escapeKeyHandler: (() => boolean) | null = null;
 
   imageAssets = $state(new SvelteMap<string, ImageAsset>());
   inflightImages = $state(new SvelteMap<string, { uploadId: string; url?: string; width: number; height: number }>());
@@ -632,6 +636,7 @@ export class Editor {
         cursor: fields.has('cursor') ? core.cursor() : previous.cursor,
         placeholder: fields.has('placeholder') ? (core.placeholder() ?? undefined) : previous.placeholder,
         selection: fields.has('selection') || fields.has('doc') ? core.selection() : previous.selection,
+        selectionKind: fields.has('selection') || fields.has('doc') ? core.selection_kind() : previous.selectionKind,
         selectionEndpoints:
           fields.has('selection') || fields.has('cursor') || fields.has('doc') || fields.has('page_sizes')
             ? core.selection_endpoints()

--- a/apps/website/src/lib/editor-ffi/handlers/keyboard.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/keyboard.test.ts
@@ -1,13 +1,15 @@
+import { pushEscapeHandler } from '@typie/ui/utils';
 import { describe, expect, it, vi } from 'vitest';
 import { handleKeyDown } from './keyboard';
 import type { Message } from '@typie/editor-ffi/browser';
 import type { Editor } from '../editor.svelte';
 
-const createEditor = (messages: Message[]) =>
+const createEditor = (messages: Message[], escapeKeyHandler: (() => boolean) | null = null) =>
   ({
     enqueue: vi.fn((message: Message) => {
       messages.push(message);
     }),
+    escapeKeyHandler,
     scrollIntoView: vi.fn(),
     updateNow: vi.fn((build: () => void) => {
       build();
@@ -105,6 +107,65 @@ describe('handleKeyDown', () => {
     expect(messages).toEqual([]);
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it('leaves composing Escape before the document Escape handler', () => {
+    const messages: Message[] = [];
+    const escapeKeyHandler = vi.fn(() => true);
+    const editor = createEditor(messages, escapeKeyHandler);
+    const event = composingEvent('Escape');
+
+    handleKeyDown(editor, event);
+
+    expect(escapeKeyHandler).not.toHaveBeenCalled();
+    expect(messages).toEqual([]);
+  });
+
+  it('lets the document consume Escape before the core binding', () => {
+    const messages: Message[] = [];
+    const escapeKeyHandler = vi.fn(() => true);
+    const editor = createEditor(messages, escapeKeyHandler);
+    const event = { ...composingEvent('Escape'), isComposing: false } as TestKeyboardEvent;
+
+    handleKeyDown(editor, event);
+
+    expect(escapeKeyHandler).toHaveBeenCalledOnce();
+    expect(messages).toEqual([]);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+  });
+
+  it('lets the topmost transient UI consume Escape before the document handler', () => {
+    const messages: Message[] = [];
+    const transientHandler = vi.fn(() => true);
+    const removeTransientHandler = pushEscapeHandler(transientHandler);
+    const escapeKeyHandler = vi.fn(() => true);
+    const editor = createEditor(messages, escapeKeyHandler);
+    const event = { ...composingEvent('Escape'), isComposing: false } as TestKeyboardEvent;
+
+    try {
+      handleKeyDown(editor, event);
+
+      expect(transientHandler).toHaveBeenCalledOnce();
+      expect(escapeKeyHandler).not.toHaveBeenCalled();
+      expect(messages).toEqual([]);
+    } finally {
+      removeTransientHandler();
+    }
+  });
+
+  it('runs the core Escape binding when the document declines it', () => {
+    const messages: Message[] = [];
+    const escapeKeyHandler = vi.fn(() => false);
+    const editor = createEditor(messages, escapeKeyHandler);
+    const event = { ...composingEvent('Escape'), isComposing: false } as TestKeyboardEvent;
+
+    handleKeyDown(editor, event);
+
+    expect(escapeKeyHandler).toHaveBeenCalledOnce();
+    expect(messages).toEqual([{ type: 'key', event: { key: 'escape' } }]);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
   });
 
   it('defers Mod+Enter until after the active composition is committed', () => {

--- a/apps/website/src/lib/editor-ffi/handlers/keyboard.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/keyboard.ts
@@ -322,6 +322,12 @@ export const handleKeyDown = (editor: Editor, e: KeyboardEvent & { currentTarget
     return;
   }
 
+  if (e.key === 'Escape' && editor.escapeKeyHandler?.()) {
+    e.preventDefault();
+    e.stopPropagation();
+    return;
+  }
+
   if (binding) {
     e.preventDefault();
     e.stopPropagation();

--- a/apps/website/src/lib/escape-stack.test.ts
+++ b/apps/website/src/lib/escape-stack.test.ts
@@ -1,0 +1,53 @@
+import { pushEscapeHandler } from '@typie/ui/utils';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('Escape stack', () => {
+  it('leaves composing Escape to the native input method', () => {
+    const handler = vi.fn(() => true);
+    const remove = pushEscapeHandler(handler);
+    const event = new KeyboardEvent('keydown', { key: 'Escape', isComposing: true, bubbles: true, cancelable: true });
+
+    try {
+      window.dispatchEvent(event);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    } finally {
+      remove();
+    }
+  });
+
+  it('does not run after an earlier handler consumes Escape', () => {
+    const handler = vi.fn(() => true);
+    const remove = pushEscapeHandler(handler);
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+    event.preventDefault();
+
+    try {
+      window.dispatchEvent(event);
+
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      remove();
+    }
+  });
+
+  it('runs only the topmost accepting handler', () => {
+    const lower = vi.fn(() => true);
+    const upper = vi.fn(() => true);
+    const removeLower = pushEscapeHandler(lower);
+    const removeUpper = pushEscapeHandler(upper);
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+
+    try {
+      window.dispatchEvent(event);
+
+      expect(upper).toHaveBeenCalledOnce();
+      expect(lower).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(true);
+    } finally {
+      removeUpper();
+      removeLower();
+    }
+  });
+});

--- a/apps/website/src/lib/pane-dnd.test.ts
+++ b/apps/website/src/lib/pane-dnd.test.ts
@@ -1,3 +1,4 @@
+import { pushEscapeHandler, runEscapeStack } from '@typie/ui/utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { dragPane } from '../routes/website/(dashboard)/[slug]/@pane/dnd';
 import type { PaneGroup } from '../routes/website/(dashboard)/[slug]/@pane/context.svelte';
@@ -101,5 +102,28 @@ describe('dragPane', () => {
 
     expect(element.setPointerCapture).not.toHaveBeenCalled();
     action?.destroy?.();
+  });
+
+  it('places a pane drag above an existing Escape owner and removes it after cancellation', () => {
+    const element = createElement();
+    const paneGroup = createPaneGroup();
+    const lowerEscapeHandler = vi.fn(() => true);
+    const removeLowerEscapeHandler = pushEscapeHandler(lowerEscapeHandler);
+    const action = dragPane(element, { paneGroup, paneId: 'pane-1' });
+
+    try {
+      element.dispatchEvent(pointerEvent({ type: 'pointerdown' }));
+      element.dispatchEvent(pointerEvent({ type: 'pointermove', clientX: 20 }));
+
+      expect(runEscapeStack()).toBe(true);
+      expect(paneGroup.cancelDrag).toHaveBeenCalledOnce();
+      expect(lowerEscapeHandler).not.toHaveBeenCalled();
+
+      expect(runEscapeStack()).toBe(true);
+      expect(lowerEscapeHandler).toHaveBeenCalledOnce();
+    } finally {
+      action?.destroy?.();
+      removeLowerEscapeHandler();
+    }
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/@preference/PresetTab.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/PresetTab.svelte
@@ -224,6 +224,8 @@
   });
 
   const handleFontSizeKeydown = (e: KeyboardEvent) => {
+    if (e.isComposing || e.defaultPrevented) return;
+
     if (e.key === 'Enter') {
       e.preventDefault();
       e.stopPropagation();
@@ -231,6 +233,8 @@
       fontSizeInputElement?.blur();
       closeFontSizeDropdown();
     } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
       fontSizeInputValue = String(fontSize / 100);
       fontSizeInputElement?.blur();
       closeFontSizeDropdown();

--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
@@ -6,7 +6,7 @@
   import { Icon } from '@typie/ui/components';
   import { entityIconMap } from '@typie/ui/constants';
   import { Toast } from '@typie/ui/notification';
-  import { createDragScroll, elementScrollViewport } from '@typie/ui/utils';
+  import { createDragScroll, elementScrollViewport, pushEscapeHandler } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
   import { onDestroy, tick, untrack } from 'svelte';
   import { on } from 'svelte/events';
@@ -243,6 +243,7 @@
   let dragScroll: ReturnType<typeof createDragScroll> | null = null;
   let folderHoverTimeout = $state<NodeJS.Timeout | null>(null);
   let hoveredFolderId = $state<string | null>(null);
+  let removeDragEscapeHandler: (() => void) | null = null;
 
   let lastPointerX = $state<number>(0);
   let lastPointerY = $state<number>(0);
@@ -350,6 +351,18 @@
   const clearPendingTouchDrag = () => {
     clearDragTimeout();
     pendingTouchDrag = null;
+    if (!dragging) {
+      removeDragEscapeHandler?.();
+      removeDragEscapeHandler = null;
+    }
+  };
+
+  const registerDragEscapeHandler = () => {
+    removeDragEscapeHandler?.();
+    removeDragEscapeHandler = pushEscapeHandler(() => {
+      endDragging(true);
+      return true;
+    });
   };
 
   const handlePointerDown: PointerEventHandler<HTMLDivElement> = (e) => {
@@ -381,6 +394,7 @@
         startY: e.clientY,
         lastY: e.clientY,
       };
+      registerDragEscapeHandler();
       dragTimeout = setTimeout(() => {
         if (!pendingTouchDrag || pendingTouchDrag.event.pointerId !== e.pointerId) {
           return;
@@ -430,6 +444,7 @@
         element,
         indicator: {},
       };
+      registerDragEscapeHandler();
     }
   };
 
@@ -928,11 +943,6 @@
     } else {
       e.preventDefault();
       e.stopPropagation();
-    }
-  }}
-  onkeydown={(e) => {
-    if (e.key === 'Escape') {
-      endDragging(true);
     }
   }}
 />

--- a/apps/website/src/routes/website/(dashboard)/@tree/Folder.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/Folder.svelte
@@ -315,11 +315,12 @@
           defaultValue={folder.data.name}
           onblur={(e) => e.currentTarget.form?.requestSubmit()}
           onkeydown={(e) => {
-            if (e.key !== 'Escape') {
+            if (e.key !== 'Escape' || e.isComposing || e.defaultPrevented) {
               return;
             }
 
             e.preventDefault();
+            e.stopPropagation();
             e.currentTarget.form?.reset();
             editing = false;
           }}

--- a/apps/website/src/routes/website/(dashboard)/CommandPalette.svelte
+++ b/apps/website/src/routes/website/(dashboard)/CommandPalette.svelte
@@ -371,12 +371,15 @@
   });
 
   const handleKeyDown = async (event: KeyboardEvent) => {
+    if (event.isComposing || event.defaultPrevented) return;
+
     const metaOrCtrlKeyOnly = (event.metaKey && !event.ctrlKey) || (event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey);
     if (metaOrCtrlKeyOnly && event.key === 'k') {
       event.preventDefault();
       app.state.commandPaletteOpen = !app.state.commandPaletteOpen;
     } else if (app.state.commandPaletteOpen) {
       if (event.key === 'Escape') {
+        event.preventDefault();
         event.stopPropagation();
         close();
         return;

--- a/apps/website/src/routes/website/(dashboard)/Shortcuts.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Shortcuts.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createFragment } from '@mearie/svelte';
   import { getAppContext } from '@typie/ui/context';
+  import { runEscapeStack } from '@typie/ui/utils';
   import mixpanel from 'mixpanel-browser';
   import { IS_MAC } from '$lib/editor-ffi/constants';
   import { graphql } from '$mearie';
@@ -65,6 +66,14 @@
     }
 
     if (event.code === 'Escape') {
+      if (event.isComposing || event.defaultPrevented) return;
+
+      if (runEscapeStack()) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
       if (paneGroup.state.current.focusedPaneId && paneGroup.findReplaceOpenByPaneId[paneGroup.state.current.focusedPaneId]) {
         return;
       }

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/dnd.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/dnd.ts
@@ -1,4 +1,5 @@
 import { pointerCapture } from '@typie/ui/actions';
+import { pushEscapeHandler } from '@typie/ui/utils';
 import mixpanel from 'mixpanel-browser';
 import { findMemberById } from './tree';
 import type { Action } from 'svelte/action';
@@ -128,6 +129,7 @@ export const dragPane: Action<HTMLElement, DragPaneOptions> = (node, options) =>
   let holdActivated = false;
   let holdTimer: ReturnType<typeof setTimeout> | null = null;
   let activeSession: DragPaneSession | null = null;
+  let removeEscapeHandler: (() => void) | null = null;
   const HOLD_DURATION = 300;
   const IMMEDIATE_DRAG_THRESHOLD = 8;
   const POST_HOLD_DRAG_THRESHOLD = 5;
@@ -149,6 +151,8 @@ export const dragPane: Action<HTMLElement, DragPaneOptions> = (node, options) =>
     isDragging = false;
     holdActivated = false;
     activeSession = null;
+    removeEscapeHandler?.();
+    removeEscapeHandler = null;
     options.paneGroup.draggingPaneId = null;
     node.style.cursor = 'grab';
     document.body.style.cursor = '';
@@ -167,6 +171,10 @@ export const dragPane: Action<HTMLElement, DragPaneOptions> = (node, options) =>
 
     const session = { startX: e.clientX, startY: e.clientY };
     activeSession = session;
+    removeEscapeHandler = pushEscapeHandler(() => {
+      capture.cancel();
+      return true;
+    });
 
     holdActivated = false;
     holdTimer = setTimeout(() => {
@@ -232,21 +240,12 @@ export const dragPane: Action<HTMLElement, DragPaneOptions> = (node, options) =>
     cancel: handlePointerCancel,
   });
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape' && (holdActivated || holdTimer)) {
-      capture.cancel();
-    }
-  };
-
-  document.addEventListener('keydown', handleKeyDown);
-
   return {
     update(newOptions: DragPaneOptions) {
       options = newOptions;
     },
     destroy() {
       capture.destroy();
-      document.removeEventListener('keydown', handleKeyDown);
     },
   };
 };

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/BreadcrumbEntityTree.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/BreadcrumbEntityTree.svelte
@@ -17,7 +17,6 @@
     labelledBy: string;
     onActivateDocument: (slug: string) => void;
     documentDrag: BreadcrumbDocumentDragController;
-    onDismiss: () => void;
     onToggleFolder: (entityId: string) => void;
     treeId: string;
   };
@@ -30,7 +29,6 @@
     highlightedEntityId,
     labelledBy,
     onActivateDocument,
-    onDismiss,
     onToggleFolder,
     treeId,
   }: Props = $props();
@@ -95,13 +93,6 @@
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      event.stopPropagation();
-      if (!documentDrag.cancel({ suppressClick: true })) onDismiss();
-      return;
-    }
-
     const current = event.target instanceof HTMLElement ? event.target.closest<HTMLElement>('[role="treeitem"]') : null;
     if (!current) return;
     const items = visibleItems();

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
@@ -5,6 +5,7 @@
   import { Icon } from '@typie/ui/components';
   import { entityIconMap } from '@typie/ui/constants';
   import { prefersReducedMotion } from '@typie/ui/state';
+  import { pushEscapeHandler } from '@typie/ui/utils';
   import { onDestroy, tick } from 'svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import { scale } from 'svelte/transition';
@@ -116,15 +117,17 @@
     dismiss(false);
   }
 
-  function handleWindowKeydown(event: KeyboardEvent) {
-    if (activeSegmentId === null || event.defaultPrevented) return;
-    if (event.key !== 'Escape') return;
-    event.preventDefault();
-    if (!documentDrag.cancel({ suppressClick: true })) dismiss(true);
-  }
-
   $effect(() => {
     if (!isOwner) dismiss(false);
+  });
+
+  $effect(() => {
+    if (activeSegmentId === null) return;
+
+    return pushEscapeHandler(() => {
+      dismiss(true);
+      return true;
+    });
   });
 
   onDestroy(() => {
@@ -133,7 +136,7 @@
   });
 </script>
 
-<svelte:window oncontextmenu={(event) => documentDrag.contextMenu(event)} onkeydown={handleWindowKeydown} />
+<svelte:window oncontextmenu={(event) => documentDrag.contextMenu(event)} />
 
 <nav
   bind:this={navigationElement}
@@ -224,7 +227,6 @@
       highlightedEntityId={activeSegment.id}
       labelledBy={activeTriggerId}
       onActivateDocument={activateDocument}
-      onDismiss={() => dismiss(true)}
       onToggleFolder={toggleFolder}
       treeId={popupId}
     />

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag.svelte.ts
@@ -1,4 +1,5 @@
 import { pointerCapture } from '@typie/ui/actions';
+import { pushEscapeHandler } from '@typie/ui/utils';
 import type { PointerCaptureCancelReason } from '@typie/ui/actions';
 import type { Action } from 'svelte/action';
 import type { PaneGroup } from '../../@pane/context.svelte';
@@ -58,6 +59,7 @@ export class BreadcrumbDocumentDragController {
   #session = $state.raw<PointerSession | null>(null);
   #clickSuppression: ClickSuppression | null = null;
   #cancelCapture: (() => void) | null = null;
+  #removeEscapeHandler: (() => void) | null = null;
   #suppressProgrammaticCancelClick = false;
 
   ghost = $state<BreadcrumbDocumentDragGhost | null>(null);
@@ -123,6 +125,8 @@ export class BreadcrumbDocumentDragController {
     if (this.#session !== session) return;
     this.#session = null;
     this.#cancelCapture = null;
+    this.#removeEscapeHandler?.();
+    this.#removeEscapeHandler = null;
     this.ghost = null;
 
     if (session.holdTimeout) clearTimeout(session.holdTimeout);
@@ -151,6 +155,10 @@ export class BreadcrumbDocumentDragController {
       touchHoldCanceled: false,
     };
     this.#session = session;
+    this.#removeEscapeHandler = pushEscapeHandler(() => {
+      this.cancel({ suppressClick: true });
+      return true;
+    });
 
     if (session.pointerType === 'touch') {
       session.holdTimeout = setTimeout(() => {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentCard.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentCard.svelte
@@ -89,6 +89,8 @@
       e.preventDefault();
       void save();
     } else if (e.key === 'Escape') {
+      if (e.isComposing || e.defaultPrevented) return;
+      e.preventDefault();
       e.stopPropagation();
       if (editText === comment.data.content) {
         cancel();

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentComposer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-comments/CommentComposer.svelte
@@ -69,6 +69,8 @@
       e.preventDefault();
       void submit();
     } else if (e.key === 'Escape') {
+      if (e.isComposing || e.defaultPrevented) return;
+      e.preventDefault();
       e.stopPropagation();
       if (value.trim() === '') {
         oncancel?.();

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelSettings.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelSettings.svelte
@@ -202,7 +202,7 @@
   };
 
   const handleFontSizeKeydown = (e: KeyboardEvent) => {
-    if (e.isComposing) return;
+    if (e.isComposing || e.defaultPrevented) return;
 
     if (e.key === 'Enter') {
       e.preventDefault();
@@ -211,6 +211,8 @@
       fontSizeInputElement?.blur();
       fontSizeOpened = false;
     } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
       fontSizeInputValue = String(currentFontSize / 100);
       fontSizeInputElement?.blur();
       fontSizeOpened = false;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -835,6 +835,25 @@
 
   $effect(() => {
     const editor = ctx.liveEditor;
+    if (!editor) return;
+
+    const handler = () => {
+      if (!currentViewZenModeEnabled || editor.appliedSnapshot.selectionKind === 'range') return false;
+
+      app.preference.current.zenModeEnabled = false;
+      mixpanel.track('zen_mode_disabled', { via: 'esc' });
+      return true;
+    };
+
+    editor.escapeKeyHandler = handler;
+
+    return () => {
+      if (editor.escapeKeyHandler === handler) editor.escapeKeyHandler = null;
+    };
+  });
+
+  $effect(() => {
+    const editor = ctx.liveEditor;
     if (editor) {
       editor.readOnly = (document?.locked ?? false) || !query.data.me.entitled;
     }

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentFindReplace.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentFindReplace.svelte
@@ -4,6 +4,7 @@
   import { tooltip } from '@typie/ui/actions';
   import { Icon } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
+  import { pushEscapeHandler } from '@typie/ui/utils';
   import { onMount, tick, untrack } from 'svelte';
   import ArrowDownIcon from '~icons/lucide/arrow-down';
   import ArrowUpIcon from '~icons/lucide/arrow-up';
@@ -81,18 +82,13 @@
   });
 
   const handleKeydown = (e: KeyboardEvent) => {
+    if (e.isComposing || e.defaultPrevented) return;
+
     if ((IS_MAC ? e.metaKey : e.ctrlKey) && e.code === 'KeyF') {
       e.preventDefault();
       tick().then(() => {
         findInputEl?.select();
       });
-      return;
-    }
-
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      e.stopPropagation();
-      close();
     }
   };
 
@@ -117,6 +113,10 @@
   };
 
   onMount(() => {
+    const removeEscapeHandler = pushEscapeHandler(() => {
+      close();
+      return true;
+    });
     const selectionText = editor && !editor.isSelectionCollapsed ? editor.copySelection()?.text : undefined;
     if (selectionText !== undefined) {
       findText = toSingleLineText(selectionText);
@@ -127,6 +127,7 @@
     });
 
     return () => {
+      removeEscapeHandler();
       const session = focusReturnSession;
       focusReturnSession = null;
       session?.discard();

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use editor_commands::{self as commands};
-use editor_state::Selection;
+use editor_state::{Selection, SelectionKind, selection_kind};
 use editor_transaction::HistoryMeta;
 
 use crate::editor::Editor;
@@ -164,16 +164,13 @@ pub fn handle_key_event(editor: &mut Editor, event: KeyEvent) -> Result<(), Edit
         }),
         (Key::Escape, _) => editor.transact(|tr| {
             if let Some(current) = tr.selection() {
-                let collapsed = Selection::collapsed(current.head);
-                let normalized = collapsed.normalize(&tr.view()).unwrap_or(collapsed);
-                // Unit selections re-normalize to the direction-flipped form;
-                // an anchor/head swap brackets the same content.
-                let unchanged = normalized == current
-                    || (normalized.anchor == current.head && normalized.head == current.anchor);
-                if unchanged {
-                    tr.set_selection(None)?;
-                } else {
-                    tr.set_selection(Some(collapsed))?;
+                match selection_kind(&current, &tr.view()) {
+                    SelectionKind::Range => {
+                        tr.set_selection(Some(Selection::collapsed(current.head)))?;
+                    }
+                    SelectionKind::Caret | SelectionKind::Unit => {
+                        tr.set_selection(None)?;
+                    }
                 }
                 tr.clear_pending_format()?;
             }

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -702,6 +702,8 @@ export type RootNodeAttr = { type: "layout_mode"; value: LayoutMode };
 
 export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
+export type SelectionKind = "caret" | "unit" | "range";
+
 export type SelectionOp = { type: "set"; selection: Selection } | { type: "set_frozen"; selection: StableSelection } | { type: "unset" } | { type: "set_at"; page: number; x: number; y: number } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor: Position; head_page: number; head_x: number; head_y: number; base_selection: Selection | undefined; allow_collapse?: boolean } | { type: "select_unit_at"; page: number; x: number; y: number; unit: SelectionPointUnit } | { type: "expand"; unit: SelectionExpansionUnit };
 
 export type SelectionPointUnit = "word" | "sentence" | "paragraph";
@@ -826,6 +828,7 @@ declare class Editor {
     selection_endpoints(): SelectionEndpoints | undefined;
     selection_hit_rects(): PageRect[];
     selection_hit_test(page: number, x: number, y: number): boolean;
+    selection_kind(): SelectionKind | undefined;
     set_doc(plain: PlainDoc): void;
     split_changesets(payload: Uint8Array): ChangesetEntry[];
     surface_backend(page: number): string;

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -410,6 +410,16 @@ impl Editor {
         self.with_inner(|inner| Ok(inner.editor.state().selection.into_ffi()?))
     }
 
+    pub fn selection_kind(&self) -> EditorResult<Option<Complex<editor_state::SelectionKind>>> {
+        self.with_inner(|inner| {
+            let state = inner.editor.state();
+            let Some(selection) = state.selection.as_ref() else {
+                return Ok(None);
+            };
+            Ok(Some(editor_state::selection_kind(selection, &state.view())).into_ffi()?)
+        })
+    }
+
     pub fn copy_selection(
         &self,
     ) -> EditorResult<Option<Complex<editor_clipboard::ClipboardPayload>>> {

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -82,7 +82,7 @@ pub use position::{Position, ResolvedPosition, inline_leaf_dots_in_range};
 pub use projected_state::*;
 pub use prose::{ProseText, prose, prose_annotated};
 pub use replacement::replacement_paint;
-pub use selection::{ResolvedSelection, Selection};
+pub use selection::{ResolvedSelection, Selection, SelectionKind, selection_kind};
 pub use selection_expansion::{
     resolve_paragraph_selection_expansion, resolve_sentence_selection_expansion,
     resolve_word_selection_expansion,

--- a/crates/editor-state/src/selection.rs
+++ b/crates/editor-state/src/selection.rs
@@ -8,6 +8,15 @@ use crate::{Position, ResolvedPosition};
 #[ffi]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum SelectionKind {
+    Caret,
+    Unit,
+    Range,
+}
+
+#[ffi]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct Selection {
     pub anchor: Position,
     pub head: Position,
@@ -37,6 +46,22 @@ impl Selection {
         let anchor = self.anchor.resolve(view)?;
         let head = self.head.resolve(view)?;
         Some(ResolvedSelection { view, anchor, head })
+    }
+}
+
+pub fn selection_kind(selection: &Selection, view: &DocView) -> SelectionKind {
+    if selection.is_collapsed() {
+        return SelectionKind::Caret;
+    }
+
+    let collapsed = Selection::collapsed(selection.head);
+    let normalized = collapsed.normalize(view).unwrap_or(collapsed);
+    if normalized == *selection
+        || (normalized.anchor == selection.head && normalized.head == selection.anchor)
+    {
+        SelectionKind::Unit
+    } else {
+        SelectionKind::Range
     }
 }
 

--- a/packages/ui/src/components/SearchableDropdown.svelte
+++ b/packages/ui/src/components/SearchableDropdown.svelte
@@ -130,9 +130,11 @@
   };
 
   const handleKeydown = (e: KeyboardEvent) => {
-    if (e.isComposing) return;
+    if (e.isComposing || e.defaultPrevented) return;
 
     if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
       inputValue = currentLabel;
       inputElement?.blur();
       close();

--- a/packages/ui/src/utils/dnd-handler.ts
+++ b/packages/ui/src/utils/dnd-handler.ts
@@ -1,5 +1,6 @@
 import { token } from '@typie/styled-system/tokens';
 import { thresholdDrag } from '../actions/threshold-drag.svelte';
+import { pushEscapeHandler } from './escape-stack';
 
 export type Ghost = {
   element: HTMLElement;
@@ -89,6 +90,7 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
   let isDragActive = false;
   let ghost: Ghost | null = null;
   let hoveredTarget: HTMLElement | null = null;
+  let removeEscapeHandler: (() => void) | null = null;
 
   const updateCursor = (e: PointerEvent | null) => {
     if (dragging) {
@@ -126,6 +128,8 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
     }
     dragging = false;
     isDragActive = false;
+    removeEscapeHandler?.();
+    removeEscapeHandler = null;
     updateCursor(null);
   };
 
@@ -152,6 +156,10 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
       }
 
       dragging = true;
+      removeEscapeHandler = pushEscapeHandler(() => {
+        drag.cancel();
+        return true;
+      });
       updateCursor(e);
       return { target: extractedTarget };
     },
@@ -185,16 +193,7 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
     updateCursor(e);
   };
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (!(dragging && e.key === 'Escape')) {
-      return;
-    }
-
-    drag.cancel();
-  };
-
   node.addEventListener('pointermove', handlePointerHoverMove);
-  window.addEventListener('keydown', handleKeyDown);
 
   updateCursor(null);
 
@@ -206,7 +205,6 @@ export const createDndHandler = (node: HTMLElement, options: DndHandlerOptions) 
     destroy: () => {
       drag.destroy();
       node.removeEventListener('pointermove', handlePointerHoverMove);
-      window.removeEventListener('keydown', handleKeyDown);
     },
   };
 };

--- a/packages/ui/src/utils/escape-stack.ts
+++ b/packages/ui/src/utils/escape-stack.ts
@@ -13,7 +13,7 @@ export function runEscapeStack(): boolean {
 }
 
 function handleGlobalEscape(e: KeyboardEvent) {
-  if (!(e.key === 'Escape' && runEscapeStack())) {
+  if (e.isComposing || e.defaultPrevented || !(e.key === 'Escape' && runEscapeStack())) {
     return;
   }
 


### PR DESCRIPTION
## 변경 사항

- Escape가 IME 조합과 이미 처리된 키 입력을 침범하지 않도록 소비 규칙을 통일했습니다.
- 활성 드래그, 팝오버·모달, 찾기/바꾸기와 로컬 입력 편집이 집중 모드보다 먼저 Escape를 처리하도록 정리했습니다.
- Escape stack을 LIFO로 처리해 팝오버에서 시작한 드래그는 첫 Escape로 드래그가 취소되고, 다음 Escape로 팝오버가 닫히도록 했습니다.
- 엔티티 트리, pane, breadcrumb 및 공용 DnD가 드래그 세션 동안 Escape stack을 소유하도록 변경하고, 개별 document/window 키 리스너를 제거했습니다.
- selection을 caret, unit, range로 구분해 에디터 런타임 상태로 전달하도록 했습니다.
- range selection은 먼저 collapse하고, 다음 Escape에서 집중 모드를 해제한 뒤 기존 selection clear 및 editor blur 흐름으로 이어지도록 했습니다.
- unit selection은 집중 모드 해제 과정에서 불필요하게 해제되지 않도록 유지했습니다.

최종적인 Escape 처리 순서는 다음과 같습니다.

1. IME 및 이미 처리된 입력
2. 현재 로컬 입력·편집
3. 활성 드래그, 팝오버·모달, 찾기/바꾸기
4. range selection collapse
5. 집중 모드 해제
6. selection clear 및 editor blur

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>