### PR TITLE
브라우저 알림 설정 및 토큰 수명주기 관리

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -1048,6 +1048,7 @@ type Mutation {
   unarchivePrismSession(input: UnarchivePrismSessionInput!): PrismSession!
   unfurlEmbed(input: UnfurlEmbedInput!): Embed!
   unlockDocumentView(input: UnlockDocumentViewInput!): DocumentView!
+  unregisterPushNotificationToken(input: UnregisterPushNotificationTokenInput!): Boolean!
   unresolveDocumentCommentThread(input: UnresolveDocumentCommentThreadInput!): DocumentCommentThread!
   updateBillingKey(input: UpdateBillingKeyInput!): UserBillingKey!
   updateBillingKeyWithEasyPay(input: UpdateBillingKeyWithEasyPayInput!): UserBillingKey!
@@ -2017,6 +2018,10 @@ input UnfurlEmbedInput {
 input UnlockDocumentViewInput {
   documentId: ID!
   password: String!
+}
+
+input UnregisterPushNotificationTokenInput {
+  token: String!
 }
 
 input UnresolveDocumentCommentThreadInput {

--- a/apps/api/src/graphql/resolvers/user.ts
+++ b/apps/api/src/graphql/resolvers/user.ts
@@ -996,6 +996,17 @@ builder.mutationFields((t) => ({
     },
   }),
 
+  unregisterPushNotificationToken: t.withAuth({ session: true }).fieldWithInput({
+    type: 'Boolean',
+    input: { token: t.input.string() },
+    resolve: async (_, { input }, ctx) => {
+      await db
+        .delete(UserPushNotificationTokens)
+        .where(and(eq(UserPushNotificationTokens.userId, ctx.session.userId), eq(UserPushNotificationTokens.token, input.token)));
+      return true;
+    },
+  }),
+
   revokeUserDevice: t.withAuth({ session: true }).fieldWithInput({
     type: UserDevice,
     input: { deviceId: t.input.id({ validate: validateDbId(TableCode.USER_DEVICES) }) },

--- a/apps/website/src/lib/browser-push.test.ts
+++ b/apps/website/src/lib/browser-push.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BROWSER_PUSH_STORAGE_KEY, browserPushEnabled, createBrowserPushManager, readBrowserPushIntent } from './browser-push';
+import type { BrowserPushDependencies } from './browser-push';
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+function setup(overrides: Partial<BrowserPushDependencies> = {}) {
+  const storage = overrides.storage ?? new MemoryStorage();
+  const dependencies: BrowserPushDependencies = {
+    acquireToken: vi.fn(async () => 'browser-token'),
+    deleteToken: vi.fn(async () => true),
+    getPermission: () => 'granted',
+    isSupported: vi.fn(async () => true),
+    registerToken: vi.fn(() => Promise.resolve()),
+    requestPermission: vi.fn(async (): Promise<NotificationPermission> => 'granted'),
+    storage,
+    unregisterToken: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+
+  return { dependencies, manager: createBrowserPushManager(dependencies), storage };
+}
+
+describe('browser push lifecycle', () => {
+  it('treats existing granted browsers as enabled and registers them on reconcile', async () => {
+    const { dependencies, manager, storage } = setup();
+
+    await expect(manager.reconcile()).resolves.toBe(true);
+
+    expect(dependencies.registerToken).toHaveBeenCalledWith('browser-token');
+    expect(readBrowserPushIntent(storage)).toMatchObject({ enabled: true });
+    expect(browserPushEnabled('granted', readBrowserPushIntent(storage))).toBe(true);
+  });
+
+  it('reconciles an existing enabled intent without publishing another cross-tab operation', async () => {
+    const { manager, storage } = setup();
+    storage.setItem('typie:browser-push', JSON.stringify({ enabled: true, operationId: 'other-tab' }));
+
+    await expect(manager.reconcile()).resolves.toBe(true);
+
+    expect(readBrowserPushIntent(storage)).toEqual({ enabled: true, operationId: 'other-tab' });
+  });
+
+  it('does not create a new token while reconciling a browser that is already disabled', async () => {
+    const { dependencies, manager, storage } = setup();
+    storage.setItem('typie:browser-push', JSON.stringify({ enabled: false, operationId: 'existing' }));
+
+    await expect(manager.reconcile()).resolves.toBe(true);
+
+    expect(dependencies.acquireToken).not.toHaveBeenCalled();
+    expect(dependencies.deleteToken).toHaveBeenCalledOnce();
+  });
+
+  it('keeps an explicit first enable visibly off when registration fails', async () => {
+    const { manager, storage } = setup({
+      registerToken: vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    });
+
+    await expect(manager.enable()).resolves.toBe(false);
+
+    expect(readBrowserPushIntent(storage)).toMatchObject({ enabled: false });
+  });
+
+  it('does not roll back or remove a newer enabled intent when an earlier enable fails', async () => {
+    const storage = new MemoryStorage();
+    const deleteToken = vi.fn(async () => true);
+    const unregisterToken = vi.fn(() => Promise.resolve());
+    const { manager } = setup({
+      deleteToken,
+      registerToken: vi.fn(async () => {
+        storage.setItem('typie:browser-push', JSON.stringify({ enabled: true, operationId: 'newer-enable' }));
+        throw new Error('offline');
+      }),
+      storage,
+      unregisterToken,
+    });
+
+    await expect(manager.enable()).resolves.toBe(false);
+
+    expect(readBrowserPushIntent(storage)).toEqual({ enabled: true, operationId: 'newer-enable' });
+    expect(unregisterToken).not.toHaveBeenCalled();
+    expect(deleteToken).not.toHaveBeenCalled();
+  });
+
+  it('notifies the current document when the browser preference changes', async () => {
+    const listener = vi.fn();
+    window.addEventListener('storage', listener);
+
+    try {
+      const { manager } = setup();
+
+      await manager.disable();
+
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ key: BROWSER_PUSH_STORAGE_KEY }));
+    } finally {
+      window.removeEventListener('storage', listener);
+    }
+  });
+
+  it('reports failure without changing registration when the browser preference cannot be stored', async () => {
+    const storage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+    };
+    const { dependencies, manager } = setup({ storage });
+
+    await expect(manager.disable()).resolves.toBe(false);
+
+    expect(dependencies.acquireToken).not.toHaveBeenCalled();
+    expect(dependencies.deleteToken).not.toHaveBeenCalled();
+  });
+
+  it('does not register when a disabled browser preference cannot be replaced', async () => {
+    const storage = {
+      getItem: () => JSON.stringify({ enabled: false, operationId: 'existing' }),
+      setItem: () => {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+    };
+    const { dependencies, manager } = setup({ storage });
+
+    await expect(manager.enable()).resolves.toBe(false);
+
+    expect(dependencies.acquireToken).not.toHaveBeenCalled();
+    expect(dependencies.registerToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps the browser disabled when Firebase deletion succeeds even if server unregister fails', async () => {
+    const unregisterToken = vi.fn(async () => {
+      throw new Error('server unavailable');
+    });
+    const { dependencies, manager, storage } = setup({ unregisterToken });
+
+    await expect(manager.disable()).resolves.toBe(true);
+
+    expect(unregisterToken).toHaveBeenCalledWith('browser-token');
+    expect(dependencies.deleteToken).toHaveBeenCalledOnce();
+    expect(readBrowserPushIntent(storage)).toMatchObject({ enabled: false });
+  });
+
+  it('restores registration when Firebase deletion fails', async () => {
+    const registerToken = vi.fn(() => Promise.resolve());
+    const { manager, storage } = setup({ deleteToken: vi.fn(async () => false), registerToken });
+
+    await expect(manager.disable()).resolves.toBe(false);
+
+    expect(registerToken).toHaveBeenCalledWith('browser-token');
+    expect(readBrowserPushIntent(storage)).toMatchObject({ enabled: true });
+  });
+
+  it('compensates when another tab disables push during registration', async () => {
+    const storage = new MemoryStorage();
+    const unregisterToken = vi.fn(() => Promise.resolve());
+    const deleteToken = vi.fn(async () => true);
+    const { manager } = setup({
+      deleteToken,
+      registerToken: vi.fn(async () => {
+        storage.setItem('typie:browser-push', JSON.stringify({ enabled: false, operationId: 'other-tab' }));
+      }),
+      storage,
+      unregisterToken,
+    });
+
+    await expect(manager.enable()).resolves.toBe(false);
+
+    expect(unregisterToken).toHaveBeenCalledWith('browser-token');
+    expect(deleteToken).toHaveBeenCalledOnce();
+    expect(readBrowserPushIntent(storage)).toEqual({ enabled: false, operationId: 'other-tab' });
+  });
+
+  it('cleans both registrations on logout without changing the browser preference', async () => {
+    const { dependencies, manager, storage } = setup();
+    storage.setItem('typie:browser-push', JSON.stringify({ enabled: true, operationId: 'existing' }));
+
+    await expect(manager.cleanupForLogout()).resolves.toBeUndefined();
+
+    expect(dependencies.unregisterToken).toHaveBeenCalledWith('browser-token');
+    expect(dependencies.deleteToken).toHaveBeenCalledOnce();
+    expect(readBrowserPushIntent(storage)).toEqual({ enabled: true, operationId: 'existing' });
+  });
+});

--- a/apps/website/src/lib/browser-push.ts
+++ b/apps/website/src/lib/browser-push.ts
@@ -1,0 +1,177 @@
+export const BROWSER_PUSH_STORAGE_KEY = 'typie:browser-push';
+
+export type BrowserPushIntent = {
+  enabled: boolean;
+  operationId: string;
+};
+
+type BrowserPushStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+type BrowserPushOperation = {
+  intent: BrowserPushIntent;
+  persisted: boolean;
+};
+
+export type BrowserPushDependencies = {
+  acquireToken: () => Promise<string | null>;
+  deleteToken: () => Promise<boolean>;
+  getPermission: () => NotificationPermission | null;
+  isSupported: () => Promise<boolean>;
+  registerToken: (token: string) => Promise<void>;
+  requestPermission: () => Promise<NotificationPermission>;
+  storage: BrowserPushStorage;
+  unregisterToken: (token: string) => Promise<void>;
+};
+
+export type BrowserPushManager = {
+  cleanupForLogout: () => Promise<void>;
+  disable: () => Promise<boolean>;
+  enable: () => Promise<boolean>;
+  reconcile: () => Promise<boolean>;
+};
+
+export function readBrowserPushIntent(storage: BrowserPushStorage): BrowserPushIntent | null {
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(BROWSER_PUSH_STORAGE_KEY) ?? 'null');
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof Reflect.get(parsed, 'enabled') === 'boolean' &&
+      typeof Reflect.get(parsed, 'operationId') === 'string'
+    ) {
+      return parsed as BrowserPushIntent;
+    }
+  } catch {
+    // Storage can be unavailable in private browsing modes.
+  }
+  return null;
+}
+
+export function readCurrentBrowserPushIntent(): BrowserPushIntent | null {
+  try {
+    return readBrowserPushIntent(localStorage);
+  } catch {
+    return null;
+  }
+}
+
+export function browserPushEnabled(permission: NotificationPermission | null, intent: BrowserPushIntent | null): boolean {
+  return permission === 'granted' && intent?.enabled !== false;
+}
+
+export function createBrowserPushManager(dependencies: BrowserPushDependencies): BrowserPushManager {
+  const writeIntent = (enabled: boolean): BrowserPushOperation => {
+    const intent = { enabled, operationId: crypto.randomUUID() };
+    const serialized = JSON.stringify(intent);
+    try {
+      dependencies.storage.setItem(BROWSER_PUSH_STORAGE_KEY, serialized);
+    } catch {
+      return { intent, persisted: false };
+    }
+
+    // Native storage events only notify other documents.
+    if (typeof window !== 'undefined' && typeof StorageEvent !== 'undefined') {
+      window.dispatchEvent(new StorageEvent('storage', { key: BROWSER_PUSH_STORAGE_KEY, newValue: serialized }));
+    }
+    return { intent, persisted: true };
+  };
+
+  const operationIsCurrent = (operation: BrowserPushIntent): boolean =>
+    readBrowserPushIntent(dependencies.storage)?.operationId === operation.operationId;
+
+  const removeRegistration = async (token: string | null): Promise<boolean> => {
+    const results = await Promise.allSettled([
+      token === null ? Promise.resolve() : dependencies.unregisterToken(token),
+      dependencies.deleteToken(),
+    ]);
+    return results[1].status === 'fulfilled' && results[1].value;
+  };
+
+  async function cleanupRegistration(operation: BrowserPushIntent, token: string | null): Promise<boolean> {
+    const before = readBrowserPushIntent(dependencies.storage);
+    if (before?.enabled === true && before.operationId !== operation.operationId) return false;
+
+    const deleted = await removeRegistration(token);
+    const after = readBrowserPushIntent(dependencies.storage);
+    if (after?.enabled === true && after.operationId !== operation.operationId) await applyEnabledIntent(after);
+    return deleted;
+  }
+
+  async function applyEnabledIntent(operation: BrowserPushIntent): Promise<boolean> {
+    const token = await dependencies.acquireToken().catch(() => null);
+    if (token === null) return false;
+
+    try {
+      await dependencies.registerToken(token);
+    } catch {
+      await cleanupRegistration(operation, token);
+      return false;
+    }
+
+    const latest = readBrowserPushIntent(dependencies.storage);
+    if (latest?.enabled === false) {
+      await cleanupRegistration(latest, token);
+      return false;
+    }
+    return true;
+  }
+
+  const enable = async (): Promise<boolean> => {
+    if (!(await dependencies.isSupported())) return false;
+
+    let permission = dependencies.getPermission();
+    if (permission === 'default') {
+      try {
+        permission = await dependencies.requestPermission();
+      } catch {
+        writeIntent(false);
+        return false;
+      }
+    }
+    if (permission !== 'granted') {
+      writeIntent(false);
+      return false;
+    }
+
+    const operation = writeIntent(true);
+    if (!operation.persisted && readBrowserPushIntent(dependencies.storage)?.enabled === false) return false;
+    const succeeded = await applyEnabledIntent(operation.intent);
+    if (!succeeded && operation.persisted && operationIsCurrent(operation.intent)) writeIntent(false);
+    return succeeded;
+  };
+
+  const disable = async (): Promise<boolean> => {
+    const operation = writeIntent(false);
+    if (!operation.persisted) return false;
+    if (dependencies.getPermission() !== 'granted') return true;
+    const token = await dependencies.acquireToken().catch(() => null);
+    const deleted = await cleanupRegistration(operation.intent, token);
+    const latest = readBrowserPushIntent(dependencies.storage);
+
+    if (latest?.enabled === true) {
+      return false;
+    }
+    if (!operationIsCurrent(operation.intent)) return deleted;
+    if (deleted) return true;
+
+    writeIntent(true);
+    if (token !== null) await dependencies.registerToken(token).catch(() => null);
+    return false;
+  };
+
+  const reconcile = async (): Promise<boolean> => {
+    if (!(await dependencies.isSupported()) || dependencies.getPermission() !== 'granted') return false;
+    const intent = readBrowserPushIntent(dependencies.storage);
+    if (intent?.enabled === false) return cleanupRegistration(intent, null);
+    return applyEnabledIntent(intent ?? writeIntent(true).intent);
+  };
+
+  const cleanupForLogout = async (): Promise<void> => {
+    if (!(await dependencies.isSupported()) || dependencies.getPermission() !== 'granted') return;
+    const token =
+      readBrowserPushIntent(dependencies.storage)?.enabled === false ? null : await dependencies.acquireToken().catch(() => null);
+    await removeRegistration(token);
+  };
+
+  return { cleanupForLogout, disable, enable, reconcile };
+}

--- a/apps/website/src/lib/push.ts
+++ b/apps/website/src/lib/push.ts
@@ -1,9 +1,31 @@
 import { initializeApp } from 'firebase/app';
-import { getMessaging, getToken, isSupported } from 'firebase/messaging';
+import { deleteToken, getMessaging, getToken, isSupported } from 'firebase/messaging';
 import { env } from '$env/dynamic/public';
+import { createBrowserPushManager } from '$lib/browser-push';
+import { mearieClient } from '$lib/graphql';
+import { graphql } from '$mearie';
 import type { FirebaseApp } from 'firebase/app';
+import type { BrowserPushManager } from '$lib/browser-push';
 
 let app: FirebaseApp | undefined;
+let browserPushManager: BrowserPushManager | undefined;
+const LOGOUT_PUSH_CLEANUP_TIMEOUT_MS = 2000;
+const browserPushStorage = {
+  getItem: (key: string) => localStorage.getItem(key),
+  setItem: (key: string, value: string) => localStorage.setItem(key, value),
+};
+
+const registerPushTokenMutation = graphql(`
+  mutation Push_RegisterPushToken_Mutation($input: RegisterPushNotificationTokenInput!) {
+    registerPushNotificationToken(input: $input)
+  }
+`);
+
+const unregisterPushTokenMutation = graphql(`
+  mutation Push_UnregisterPushToken_Mutation($input: UnregisterPushNotificationTokenInput!) {
+    unregisterPushNotificationToken(input: $input)
+  }
+`);
 
 const firebaseApp = () => {
   app ??= initializeApp({
@@ -27,7 +49,7 @@ export const pushPermission = (): NotificationPermission | null => {
   return Notification.permission;
 };
 
-export const acquirePushToken = async (): Promise<string | null> => {
+const acquirePushToken = async (): Promise<string | null> => {
   if (!(await pushSupported())) {
     return null;
   }
@@ -42,5 +64,39 @@ export const acquirePushToken = async (): Promise<string | null> => {
     });
   } catch {
     return null;
+  }
+};
+
+const deletePushToken = async (): Promise<boolean> => {
+  if (!(await pushSupported())) return true;
+  return deleteToken(getMessaging(firebaseApp()));
+};
+
+export const getBrowserPushManager = (): BrowserPushManager => {
+  browserPushManager ??= createBrowserPushManager({
+    acquireToken: acquirePushToken,
+    deleteToken: deletePushToken,
+    getPermission: pushPermission,
+    isSupported: pushSupported,
+    registerToken: async (token) => {
+      await mearieClient.mutation(registerPushTokenMutation, { input: { token } });
+    },
+    requestPermission: () => Notification.requestPermission(),
+    storage: browserPushStorage,
+    unregisterToken: async (token) => {
+      await mearieClient.mutation(unregisterPushTokenMutation, { input: { token } });
+    },
+  });
+  return browserPushManager;
+};
+
+export const cleanupBrowserPushForLogout = async (): Promise<void> => {
+  try {
+    await Promise.race([
+      getBrowserPushManager().cleanupForLogout(),
+      new Promise<void>((resolve) => setTimeout(resolve, LOGOUT_PUSH_CLEANUP_TIMEOUT_MS)),
+    ]);
+  } catch {
+    // Logout must continue even when browser push cleanup is unavailable.
   }
 };

--- a/apps/website/src/routes/usersite/wildcard/+layout.svelte
+++ b/apps/website/src/routes/usersite/wildcard/+layout.svelte
@@ -21,6 +21,7 @@
   import { EnvironmentBanner, Img } from '$lib/components';
   import { AdminImpersonateBanner } from '$lib/components/admin';
   import { hydrateQuery } from '$lib/graphql';
+  import { cleanupBrowserPushForLogout } from '$lib/push';
   import type { Theme } from '@typie/ui/context';
   import type { Component } from 'svelte';
 
@@ -205,15 +206,13 @@
               icon={LogOutIcon}
               onclick={() => {
                 mixpanel.track('logout', { via: 'header' });
-
-                location.assign(
-                  qs.stringifyUrl({
-                    url: '/logout',
-                    query: {
-                      redirect_uri: page.url.href,
-                    },
-                  }),
-                );
+                const logoutUrl = qs.stringifyUrl({
+                  url: '/logout',
+                  query: {
+                    redirect_uri: page.url.href,
+                  },
+                });
+                void cleanupBrowserPushForLogout().finally(() => location.assign(logoutUrl));
               }}
             >
               로그아웃

--- a/apps/website/src/routes/website/(dashboard)/+layout.svelte
+++ b/apps/website/src/routes/website/(dashboard)/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createMutation, createQuery, createSubscription } from '@mearie/svelte';
+  import { createQuery, createSubscription } from '@mearie/svelte';
   import { css, cx } from '@typie/styled-system/css';
   import { center, flex } from '@typie/styled-system/patterns';
   import { token } from '@typie/styled-system/tokens';
@@ -24,7 +24,7 @@
   import { hydrateQuery } from '$lib/graphql';
   import { setupOpenDocuments } from '$lib/prism/open-documents.svelte';
   import { requestSessionJump } from '$lib/prism/session-jump.svelte';
-  import { acquirePushToken, pushPermission } from '$lib/push';
+  import { cleanupBrowserPushForLogout, getBrowserPushManager } from '$lib/push';
   import { isLegacyTrial, shouldShowOnboarding } from '$lib/subscription-logic';
   import { initWasm } from '$lib/wasm-ffi.svelte';
   import { graphql } from '$mearie';
@@ -223,29 +223,10 @@
     `),
   );
 
-  const [registerPushNotificationToken] = createMutation(
-    graphql(`
-      mutation DashboardLayout_RegisterPushToken_Mutation($input: RegisterPushNotificationTokenInput!) {
-        registerPushNotificationToken(input: $input)
-      }
-    `),
-  );
-
-  const refreshPushToken = async () => {
-    const token = await acquirePushToken();
-    if (token === null) {
-      return;
-    }
-
-    await registerPushNotificationToken({ input: { token } });
-  };
-
   onMount(() => {
-    if (pushPermission() !== 'granted') {
-      return;
-    }
-
-    void refreshPushToken().catch(() => null);
+    void getBrowserPushManager()
+      .reconcile()
+      .catch(() => null);
   });
 
   onMount(() => {
@@ -599,15 +580,13 @@
           style={css.raw({ width: 'full' })}
           onclick={() => {
             mixpanel.track('logout', { via: 'mobile_dashboard' });
-
-            location.assign(
-              qs.stringifyUrl({
-                url: '/logout',
-                query: {
-                  redirect_uri: env.PUBLIC_WEBSITE_URL,
-                },
-              }),
-            );
+            const logoutUrl = qs.stringifyUrl({
+              url: '/logout',
+              query: {
+                redirect_uri: env.PUBLIC_WEBSITE_URL,
+              },
+            });
+            void cleanupBrowserPushForLogout().finally(() => location.assign(logoutUrl));
           }}
           size="lg"
           variant="secondary"

--- a/apps/website/src/routes/website/(dashboard)/@preference/NotificationsTab.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/NotificationsTab.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { createFragment } from '@mearie/svelte';
+  import { css } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import { Icon, Switch } from '@typie/ui/components';
+  import { Toast } from '@typie/ui/notification';
+  import { onMount } from 'svelte';
+  import ChevronRightIcon from '~icons/lucide/chevron-right';
+  import { pushState } from '$app/navigation';
+  import { BROWSER_PUSH_STORAGE_KEY, browserPushEnabled, readCurrentBrowserPushIntent } from '$lib/browser-push';
+  import { SettingsCard, SettingsRow } from '$lib/components';
+  import { getBrowserPushManager, pushPermission, pushSupported } from '$lib/push';
+  import { graphql } from '$mearie';
+  import type { BrowserPushIntent } from '$lib/browser-push';
+  import type { DashboardLayout_PreferenceModal_NotificationsTab_user$key } from '$mearie';
+
+  type Props = {
+    user$key: DashboardLayout_PreferenceModal_NotificationsTab_user$key;
+  };
+
+  let { user$key }: Props = $props();
+
+  const user = createFragment(
+    graphql(`
+      fragment DashboardLayout_PreferenceModal_NotificationsTab_user on User {
+        prismAccess
+      }
+    `),
+    () => user$key,
+  );
+
+  let busy = $state(false);
+  let supported = $state(false);
+  let permission = $state<NotificationPermission | null>(null);
+  let intent = $state<BrowserPushIntent | null>(null);
+  const enabled = $derived(supported && browserPushEnabled(permission, intent));
+  const browserDescription = $derived(
+    supported
+      ? permission === 'denied'
+        ? '브라우저 설정에서 타이피의 알림 권한을 허용해 주세요.'
+        : '이 브라우저에서 타이피 알림을 받아요.'
+      : '이 브라우저에서는 알림을 사용할 수 없어요.',
+  );
+
+  const refresh = async () => {
+    supported = await pushSupported();
+    permission = pushPermission();
+    intent = readCurrentBrowserPushIntent();
+  };
+
+  onMount(() => {
+    void refresh();
+  });
+
+  const reconcile = async () => {
+    await getBrowserPushManager().reconcile();
+    await refresh();
+  };
+
+  const toggle = async () => {
+    busy = true;
+    try {
+      const succeeded = enabled ? await getBrowserPushManager().disable() : await getBrowserPushManager().enable();
+      await refresh();
+      if (!succeeded) Toast.error('브라우저 알림 설정을 바꾸지 못했어요. 잠시 후 다시 시도해 주세요');
+    } finally {
+      busy = false;
+    }
+  };
+
+  const relatedLinkClass = flex({
+    alignItems: 'center',
+    gap: '2px',
+    fontSize: '12px',
+    fontWeight: 'medium',
+    color: 'text.brand',
+    transition: 'common',
+    _hover: { textDecoration: 'underline' },
+  });
+</script>
+
+<svelte:window
+  onfocus={() => {
+    if (!busy) void reconcile();
+  }}
+  onstorage={(event) => {
+    if (event.key === BROWSER_PUSH_STORAGE_KEY) void refresh();
+  }}
+/>
+
+<div class={flex({ direction: 'column', maxWidth: '640px' })}>
+  <h1 class={css({ fontSize: '20px', fontWeight: 'semibold', color: 'text.default', marginBottom: '24px' })}>알림</h1>
+
+  <h2 class={css({ fontSize: '16px', fontWeight: 'semibold', color: 'text.default', marginBottom: '16px' })}>브라우저 알림</h2>
+
+  <SettingsCard>
+    <SettingsRow>
+      {#snippet label()}브라우저 알림{/snippet}
+      {#snippet description()}{browserDescription}{/snippet}
+      {#snippet value()}
+        <Switch
+          checked={enabled}
+          disabled={busy || !supported || permission === 'denied'}
+          onclick={(event) => {
+            event.currentTarget.checked = enabled;
+            void toggle();
+          }}
+        />
+      {/snippet}
+    </SettingsRow>
+  </SettingsCard>
+
+  <p class={css({ marginTop: '10px', paddingX: '2px', fontSize: '12px', lineHeight: '[1.6]', color: 'text.faint' })}>
+    이 설정은 현재 브라우저에서 받는 모든 타이피 알림에만 적용돼요. 다른 브라우저나 모바일 앱의 알림에는 영향을 주지 않아요.
+  </p>
+
+  <h2 class={css({ fontSize: '16px', fontWeight: 'semibold', color: 'text.default', marginTop: '32px', marginBottom: '16px' })}>
+    알림 관련 바로가기
+  </h2>
+
+  <div class={css({ paddingX: '2px' })}>
+    <p class={css({ fontSize: '12px', lineHeight: '[1.6]', color: 'text.faint' })}>
+      알림과 관련해 자주 찾는 설정으로 바로 이동할 수 있어요.
+    </p>
+    <div class={flex({ alignItems: 'center', gap: '16px', marginTop: '8px' })}>
+      {#if user.data.prismAccess}
+        <button class={relatedLinkClass} onclick={() => pushState('', { shallowRoute: '/preference/prism/general' })} type="button">
+          프리즘 알림음 <Icon icon={ChevronRightIcon} size={12} />
+        </button>
+      {/if}
+
+      <button class={relatedLinkClass} onclick={() => pushState('', { shallowRoute: '/preference/profile' })} type="button">
+        마케팅 수신 <Icon icon={ChevronRightIcon} size={12} />
+      </button>
+    </div>
+  </div>
+</div>

--- a/apps/website/src/routes/website/(dashboard)/@preference/PreferenceModal.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/PreferenceModal.svelte
@@ -3,6 +3,7 @@
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { Icon, Modal } from '@typie/ui/components';
+  import BellIcon from '~icons/lucide/bell';
   import CoinsIcon from '~icons/lucide/coins';
   import CreditCardIcon from '~icons/lucide/credit-card';
   import FlaskConicalIcon from '~icons/lucide/flask-conical';
@@ -27,6 +28,7 @@
   import FontTab from './FontTab.svelte';
   import InterfaceTab from './InterfaceTab.svelte';
   import LaboratoryTab from './LaboratoryTab.svelte';
+  import NotificationsTab from './NotificationsTab.svelte';
   import PlanTab from './PlanTab.svelte';
   import PresetTab from './PresetTab.svelte';
   import PrismCreditsTab from './PrismCreditsTab.svelte';
@@ -73,6 +75,7 @@
         ...DashboardLayout_PreferenceModal_ReferralTab_user
         ...DashboardLayout_PreferenceModal_LaboratoryTab_user
         ...DashboardLayout_PreferenceModal_ShortcutsTab_user
+        ...DashboardLayout_PreferenceModal_NotificationsTab_user
         ...DashboardLayout_PreferenceModal_PrismGeneralTab_user
         ...DashboardLayout_PreferenceModal_PrismCreditsTab_user
         ...DashboardLayout_PreferenceModal_TextReplacementTab_user
@@ -118,6 +121,12 @@
           label: '인터페이스',
           icon: LayoutIcon,
           component: InterfaceTab,
+        },
+        {
+          path: '/preference/notifications',
+          label: '알림',
+          icon: BellIcon,
+          component: NotificationsTab,
         },
       ],
     },

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPushCard.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPushCard.svelte
@@ -26,12 +26,13 @@
 </script>
 
 <script lang="ts">
-  import { createMutation } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { Button } from '@typie/ui/components';
-  import { acquirePushToken, pushPermission, pushSupported } from '$lib/push';
-  import { graphql } from '$mearie';
+  import { Toast } from '@typie/ui/notification';
+  import { onMount } from 'svelte';
+  import { BROWSER_PUSH_STORAGE_KEY, readCurrentBrowserPushIntent } from '$lib/browser-push';
+  import { getBrowserPushManager, pushPermission, pushSupported } from '$lib/push';
   import { expand } from './lib/motion.ts';
 
   type Props = {
@@ -40,55 +41,49 @@
 
   let { visible }: Props = $props();
 
-  const [registerPushNotificationToken] = createMutation(
-    graphql(`
-      mutation DashboardLayout_PrismPushCard_RegisterToken_Mutation($input: RegisterPushNotificationTokenInput!) {
-        registerPushNotificationToken(input: $input)
-      }
-    `),
-  );
-
   let dismissed = $state(readDismissed());
+  let offerAvailable = $state(visible);
   let supported = $state(false);
   let busy = $state(false);
   let permission = $state<NotificationPermission | null>(null);
+  let pushEnabled = $state(true);
 
-  $effect(() => {
+  const refresh = async () => {
     permission = pushPermission();
-    void pushSupported().then((value) => (supported = value));
+    supported = await pushSupported();
+    pushEnabled = readCurrentBrowserPushIntent()?.enabled !== false;
+  };
+
+  onMount(() => {
+    void refresh();
   });
 
-  const shown = $derived(visible && !dismissed && supported && permission === 'default');
+  $effect(() => {
+    if (visible) offerAvailable = true;
+  });
+
+  const shown = $derived(offerAvailable && !dismissed && supported && pushEnabled && permission === 'default');
 
   const dismiss = () => {
     dismissed = true;
     writeDismissed();
+    Toast.success('설정 > 알림에서 언제든 켤 수 있어요');
   };
 
-  const register = async (requested: Promise<NotificationPermission>) => {
+  const enable = async () => {
+    busy = true;
     try {
-      permission = await requested;
+      const succeeded = await getBrowserPushManager()
+        .enable()
+        .catch(() => false);
+      await refresh();
 
-      if (permission !== 'granted') {
-        return;
-      }
-
-      const token = await acquirePushToken();
-      if (token === null) {
-        return;
-      }
-
-      await registerPushNotificationToken({ input: { token } });
-    } catch {
-      // 실패해도 알리지 않는다 — 다음 대시보드 진입에서 자동으로 다시 시도된다
+      if (succeeded) Toast.success('브라우저 알림을 켰어요');
+      else if (permission === 'denied') Toast.error('브라우저 설정에서 타이피 알림을 허용해 주세요');
+      else Toast.error('브라우저 알림을 켜지 못했어요. 설정에서 다시 시도해 주세요');
     } finally {
       busy = false;
     }
-  };
-
-  const enable = () => {
-    busy = true;
-    void register(Notification.requestPermission());
   };
 
   const cardClass = flex({
@@ -105,13 +100,19 @@
   const buttonStyle = css.raw({ flexShrink: '0' });
 </script>
 
+<svelte:window
+  onstorage={(event) => {
+    if (event.key === BROWSER_PUSH_STORAGE_KEY) void refresh();
+  }}
+/>
+
 {#if shown}
   <div class={css({ paddingX: '12px', paddingBottom: '8px' })} transition:expand>
     <div class={cardClass}>
-      <span class={textClass}>상태가 바뀌면 알림으로 알려드려요</span>
+      <span class={textClass}>확인이 필요하거나 리뷰가 끝나면 브라우저 알림 받기</span>
 
       <Button style={buttonStyle} onclick={dismiss} size="sm" variant="ghost">나중에</Button>
-      <Button style={buttonStyle} loading={busy} onclick={enable} size="sm" variant="secondary">알림 받기</Button>
+      <Button style={buttonStyle} loading={busy} onclick={() => void enable()} size="sm" variant="secondary">알림 받기</Button>
     </div>
   </div>
 {/if}

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-push-card.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-push-card.test.ts
@@ -1,0 +1,137 @@
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactiveProps } from './PrismPanelIndicator.test-props.svelte.ts';
+import PrismPushCard from './PrismPushCard.svelte';
+
+const mocks = vi.hoisted(() => ({
+  enable: vi.fn<() => Promise<boolean>>(),
+  permission: 'default' as NotificationPermission,
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock('$app/environment', () => ({ browser: false }));
+
+vi.mock('@typie/ui/notification', () => ({ Toast: { error: mocks.toastError, success: mocks.toastSuccess } }));
+
+vi.mock('$lib/browser-push', () => ({
+  BROWSER_PUSH_STORAGE_KEY: 'typie:browser-push',
+  readCurrentBrowserPushIntent: () => null,
+}));
+
+vi.mock('$lib/push', () => ({
+  getBrowserPushManager: () => ({ enable: mocks.enable }),
+  pushPermission: () => mocks.permission,
+  pushSupported: async () => true,
+}));
+
+let originalAnimateDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  mocks.enable.mockReset().mockResolvedValue(true);
+  mocks.permission = 'default';
+  mocks.toastError.mockReset();
+  mocks.toastSuccess.mockReset();
+  originalAnimateDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'animate');
+  Object.defineProperty(Element.prototype, 'animate', {
+    configurable: true,
+    value: vi.fn(() => {
+      const animation = {
+        cancel: vi.fn(),
+        currentTime: 0,
+        effect: null,
+        onfinish: null as (() => void) | null,
+        playState: 'running',
+      };
+      queueMicrotask(() => animation.onfinish?.());
+      return animation as unknown as Animation;
+    }),
+  });
+});
+
+afterEach(() => {
+  if (originalAnimateDescriptor) Object.defineProperty(Element.prototype, 'animate', originalAnimateDescriptor);
+  else Reflect.deleteProperty(Element.prototype, 'animate');
+  document.body.replaceChildren();
+});
+
+describe('PrismPushCard', () => {
+  const clickButton = (target: HTMLElement, label: string) => {
+    const button = [...target.querySelectorAll('button')].find((candidate) => candidate.textContent?.trim() === label);
+    expect(button).toBeDefined();
+    button?.click();
+  };
+
+  it('remains available after opening the panel clears the unread badge', async () => {
+    const props = reactiveProps({ visible: false });
+    const target = document.createElement('div');
+    const component = mount(PrismPushCard, { target, props });
+    try {
+      await tick();
+      await vi.waitFor(() => expect(target.textContent).not.toContain('알림 받기'));
+
+      props.visible = true;
+      await tick();
+      props.visible = false;
+      await tick();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(target.textContent).toContain('알림 받기');
+      expect(target.textContent).toContain('확인이 필요하거나 리뷰가 끝나면 브라우저 알림 받기');
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  it('explains where to enable notifications after dismissing the offer', async () => {
+    const target = document.createElement('div');
+    const component = mount(PrismPushCard, { target, props: { visible: true } });
+    try {
+      await vi.waitFor(() => expect(target.textContent).toContain('나중에'));
+      clickButton(target, '나중에');
+      await tick();
+
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('설정 > 알림에서 언제든 켤 수 있어요');
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  it('reports success after enabling browser notifications', async () => {
+    const target = document.createElement('div');
+    const component = mount(PrismPushCard, { target, props: { visible: true } });
+    try {
+      await vi.waitFor(() => expect(target.textContent).toContain('알림 받기'));
+      clickButton(target, '알림 받기');
+
+      await vi.waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledWith('브라우저 알림을 켰어요'));
+    } finally {
+      await unmount(component);
+    }
+  });
+
+  it('distinguishes blocked permission from other enable failures', async () => {
+    const renderAndEnable = async () => {
+      const target = document.createElement('div');
+      const component = mount(PrismPushCard, { target, props: { visible: true } });
+      await vi.waitFor(() => expect(target.textContent).toContain('알림 받기'));
+      clickButton(target, '알림 받기');
+      return component;
+    };
+
+    mocks.enable.mockImplementationOnce(async () => {
+      mocks.permission = 'denied';
+      return false;
+    });
+    const blocked = await renderAndEnable();
+    await vi.waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('브라우저 설정에서 타이피 알림을 허용해 주세요'));
+    await unmount(blocked);
+
+    mocks.permission = 'default';
+    mocks.toastError.mockReset();
+    mocks.enable.mockResolvedValueOnce(false);
+    const failed = await renderAndEnable();
+    await vi.waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('브라우저 알림을 켜지 못했어요. 설정에서 다시 시도해 주세요'));
+    await unmount(failed);
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/Profile.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Profile.svelte
@@ -38,6 +38,7 @@
   import { env } from '$env/dynamic/public';
   import { Img } from '$lib/components';
   import { desktop } from '$lib/desktop';
+  import { cleanupBrowserPushForLogout } from '$lib/push';
   import { graphql } from '$mearie';
   import type { DashboardLayout_Profile_user$key } from '$mearie';
 
@@ -277,15 +278,13 @@
             })}
             onclick={() => {
               mixpanel.track('logout', { via: 'sidebar' });
-
-              location.assign(
-                qs.stringifyUrl({
-                  url: '/logout',
-                  query: {
-                    redirect_uri: env.PUBLIC_WEBSITE_URL,
-                  },
-                }),
-              );
+              const logoutUrl = qs.stringifyUrl({
+                url: '/logout',
+                query: {
+                  redirect_uri: env.PUBLIC_WEBSITE_URL,
+                },
+              });
+              void cleanupBrowserPushForLogout().finally(() => location.assign(logoutUrl));
             }}
             type="button"
           >


### PR DESCRIPTION
- 설정의 환경 그룹에 브라우저 알림 설정을 추가했습니다.
  - 현재 브라우저의 알림 권한과 로컬 설정을 함께 표시합니다.
  - 프리즘 알림음과 마케팅 수신 설정으로 이동하는 링크를 제공합니다.
- 프리즘의 브라우저 알림 안내 카드를 설정과 동일한 알림 관리 흐름에 연결했습니다.
  - 안내 카드가 unread badge 해제와 무관하게 노출되도록 수정했습니다.
  - 활성화, 보류 및 실패 결과를 토스트로 안내합니다.
- 브라우저별 알림 설정과 FCM 토큰 수명 주기를 한곳에서 관리합니다.
  - 같은 탭과 다른 탭의 설정 변경을 동기화합니다.
  - 기존에 알림 권한을 허용한 브라우저는 로그인 후 토큰을 다시 등록합니다.
  - 비활성화 시 서버 등록과 Firebase 토큰을 함께 정리합니다.
  - 작업이 겹치더라도 최신 설정이 이전 작업에 의해 되돌아가지 않도록 처리했습니다.
- 로그아웃 시 현재 계정의 푸시 토큰을 정리한 후 이동합니다.
  - 정리가 지연되더라도 로그아웃이 막히지 않도록 제한 시간을 두었습니다.
- 현재 사용자에게 속한 푸시 토큰을 해제하는 GraphQL mutation을 추가했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>