### PR TITLE
프리즘 새 챗 열기 디버그

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismComposer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismComposer.svelte
@@ -17,6 +17,7 @@
   import type { PrismCommand } from './lib/commands.ts';
 
   type Props = {
+    generation: number;
     running: boolean;
     sendDisabled: boolean;
     blocked: boolean;
@@ -28,7 +29,7 @@
     text?: string;
   };
 
-  let { running, sendDisabled, blocked, commands, status, policy, onSend, onStop, text = $bindable('') }: Props = $props();
+  let { generation, running, sendDisabled, blocked, commands, status, policy, onSend, onStop, text = $bindable('') }: Props = $props();
 
   const policyOptions: { value: ToolPolicy; label: string; description: string; icon: Component }[] = [
     { value: 'READ_ONLY', label: '읽기 전용', description: '스페이스를 읽기만 하고 바꾸지 않아요.', icon: BookOpenIcon },
@@ -81,7 +82,8 @@
     _active: { transform: 'scale(0.97)' },
   });
 
-  let busy = $state(false);
+  let busyGeneration = $state<number | null>(null);
+  const busy = $derived(busyGeneration === generation);
   let commandError = $state(false);
   let textarea = $state<HTMLTextAreaElement>();
   let boxEl = $state<HTMLElement>();
@@ -128,6 +130,7 @@
 
   const submit = async () => {
     const value = text.trim();
+    const submissionGeneration = generation;
 
     if (busy || running || sendDisabled || blocked || value.length === 0) {
       return;
@@ -138,18 +141,20 @@
       return;
     }
 
-    busy = true;
+    busyGeneration = submissionGeneration;
     text = '';
 
     try {
       await onSend(value);
     } catch {
-      if (text.length === 0) {
+      if (generation === submissionGeneration && text.length === 0) {
         text = value;
       }
     } finally {
-      busy = false;
-      textarea?.focus();
+      if (generation === submissionGeneration) {
+        busyGeneration = null;
+        textarea?.focus();
+      }
     }
   };
 

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
@@ -435,7 +435,11 @@
   });
 
   export const startNewChat = async (via: 'command_palette' | 'header', nextDraft?: string) => {
-    selected.current = null;
+    if (selected.current === null) {
+      void chat.load(null);
+    } else {
+      selected.current = null;
+    }
     listOpen = false;
     if (nextDraft !== undefined) draft = nextDraft;
 
@@ -789,6 +793,7 @@
   );
 
   const onSend = async (text: string) => {
+    const generation = chat.generation;
     const creating = chat.sessionId === null;
     indicatorWaitSeen = false;
     indicatorSpinnerPlaybackStartedAt = undefined;
@@ -796,7 +801,7 @@
 
     try {
       const result = await chat.send(text);
-      selected.current = result.sessionId;
+      if (generation === chat.generation) selected.current = result.sessionId;
 
       const gate = commandGate(text, commands);
       mixpanel.track('send_prism_message', {
@@ -809,6 +814,8 @@
         cache.invalidate({ __typename: 'User', id: user.data.id, $field: 'prismSessions' });
       }
     } catch (err) {
+      if (generation !== chat.generation) return;
+
       const error = unwrapError(err);
       const code = error instanceof TypieError ? error.code : null;
 
@@ -1147,6 +1154,7 @@
       bind:this={composer}
       {blocked}
       {commands}
+      generation={chat.generation}
       {onSend}
       {onStop}
       policy={{ current: policy, onChange: onPolicyChange }}

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-chat.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-chat.svelte.ts
@@ -26,6 +26,7 @@ export const createPrismChat = (deps: PrismChatDeps) => {
     sessionId = id;
     error = null;
     seedCursor = 0;
+    pending = null;
     transcript = emptyTranscript();
 
     if (id === null) {
@@ -90,15 +91,18 @@ export const createPrismChat = (deps: PrismChatDeps) => {
       }
     },
     async send(message: string) {
+      const gen = loadGen;
       error = null;
       pending = message;
 
       try {
         const result = await deps.send(sessionId, message);
+        if (gen !== loadGen) return result;
+
         sessionId = result.sessionId;
         return result;
       } catch (err) {
-        pending = null;
+        if (gen === loadGen) pending = null;
         throw err;
       }
     },

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-chat.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-chat.test.ts
@@ -76,6 +76,32 @@ describe('createPrismChat.load', () => {
     expect(chat.sessionId).toBe('PRSS2');
     expect(chat.seedCursor).toBe(9);
   });
+
+  it('새 대화로 전환하면 아직 스트림에 합류하지 않은 사용자 메시지를 비운다', async () => {
+    const chat = createPrismChat(deps({ send: vi.fn().mockResolvedValue({ sessionId: 'PRSS1', runSeq: 1 }) }));
+
+    await chat.send('안녕');
+    expect(chat.pending).toBe('안녕');
+
+    await chat.load(null);
+
+    expect(chat.sessionId).toBeNull();
+    expect(chat.pending).toBeNull();
+  });
+
+  it('새 대화 전환 뒤 끝난 이전 전송은 현재 세션을 되돌리지 않는다', async () => {
+    let resolveSend!: (value: { sessionId: string; runSeq: number }) => void;
+    const send = vi.fn().mockImplementation(() => new Promise((resolve) => (resolveSend = resolve)));
+    const chat = createPrismChat(deps({ send }));
+
+    const sending = chat.send('안녕');
+    await chat.load(null);
+    resolveSend({ sessionId: 'PRSS1', runSeq: 1 });
+    await sending;
+
+    expect(chat.sessionId).toBeNull();
+    expect(chat.pending).toBeNull();
+  });
 });
 
 describe('createPrismChat.receive', () => {

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-composer.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-composer.browser.test.ts
@@ -1,0 +1,107 @@
+import '../../../../app.css';
+
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import PrismComposer from './PrismComposer.svelte';
+import { reactiveProps } from './PrismTranscript.test-props.svelte.ts';
+
+let component: Record<string, unknown> | undefined;
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  document.body.replaceChildren();
+});
+
+describe('PRISM composer submission lifetime', () => {
+  it('이전 generation의 전송이 끝나지 않아도 새 대화에서 제출한다', async () => {
+    const firstSend = Promise.withResolvers<boolean>();
+    const secondSend = Promise.withResolvers<boolean>();
+    const onSend = vi
+      .fn()
+      .mockImplementationOnce(() => firstSend.promise)
+      .mockImplementationOnce(() => secondSend.promise);
+    const props = reactiveProps({
+      generation: 0,
+      running: false,
+      sendDisabled: false,
+      blocked: false,
+      commands: null,
+      status: null,
+      policy: { current: 'STANDARD' as const, onChange: vi.fn() },
+      onSend,
+      onStop: vi.fn().mockResolvedValue(undefined),
+      text: '',
+    });
+    const target = document.createElement('div');
+    document.body.append(target);
+    component = mount(PrismComposer, { target, props: props as never });
+
+    const composer = target.querySelector<HTMLTextAreaElement>('[placeholder="메시지를 입력하세요"]');
+    const send = target.querySelector<HTMLButtonElement>('[aria-label="보내기"]');
+    expect(composer).not.toBeNull();
+    expect(send).not.toBeNull();
+    if (!composer || !send) return;
+
+    await userEvent.fill(composer, '첫 메시지');
+    await userEvent.click(send);
+    await vi.waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(send.disabled).toBe(true);
+
+    props.generation = 1;
+    await tick();
+    await userEvent.fill(composer, '둘째 메시지');
+    await vi.waitFor(() => expect(send.disabled).toBe(false));
+    await userEvent.click(send);
+
+    expect(onSend).toHaveBeenCalledTimes(2);
+    expect(onSend).toHaveBeenLastCalledWith('둘째 메시지');
+    await userEvent.fill(composer, '셋째 메시지');
+    expect(send.disabled).toBe(true);
+
+    firstSend.resolve(true);
+    await firstSend.promise;
+    await tick();
+    expect(send.disabled).toBe(true);
+
+    secondSend.resolve(true);
+    await vi.waitFor(() => expect(send.disabled).toBe(false));
+  });
+
+  it('이전 generation의 실패한 메시지를 새 대화에 복원하지 않는다', async () => {
+    const firstSend = Promise.withResolvers<boolean>();
+    const props = reactiveProps({
+      generation: 0,
+      running: false,
+      sendDisabled: false,
+      blocked: false,
+      commands: null,
+      status: null,
+      policy: { current: 'STANDARD' as const, onChange: vi.fn() },
+      onSend: vi.fn().mockImplementation(() => firstSend.promise),
+      onStop: vi.fn().mockResolvedValue(undefined),
+      text: '',
+    });
+    const target = document.createElement('div');
+    document.body.append(target);
+    component = mount(PrismComposer, { target, props: props as never });
+
+    const composer = target.querySelector<HTMLTextAreaElement>('[placeholder="메시지를 입력하세요"]');
+    const send = target.querySelector<HTMLButtonElement>('[aria-label="보내기"]');
+    expect(composer).not.toBeNull();
+    expect(send).not.toBeNull();
+    if (!composer || !send) return;
+
+    await userEvent.fill(composer, '이전 메시지');
+    await userEvent.click(send);
+    props.generation = 1;
+    await tick();
+
+    firstSend.reject(new Error('failed'));
+    await firstSend.promise.catch(() => false);
+    await tick();
+
+    expect(composer.value).toBe('');
+  });
+});


### PR DESCRIPTION
## 문제

새 대화에서 메시지를 전송한 직후 다시 새 대화를 열면 이전 대화의 비동기 상태가 남아 다음 문제가 발생했습니다.

- 이전 메시지와 웰컴 프리즘이 동시에 표시됨
- 이전 응답이 끝날 때까지 새 대화에서 메시지를 제출할 수 없음
- 이전 전송의 늦은 성공·실패가 새 대화의 세션이나 draft 상태를 변경할 수 있음

## 변경 사항

- 새 대화 전환 시 아직 스트림에 반영되지 않은 pending 메시지를 초기화했습니다.
- 전송 결과를 대화 generation에 귀속시켜 이전 대화의 늦은 결과가 현재 세션을 덮지 않도록 했습니다.
- composer의 제출 상태도 generation별로 관리해 이전 응답을 기다리지 않고 새 대화에서 바로 전송할 수 있도록 했습니다.
- 이전 전송 실패가 새 대화에 메시지를 복원하거나 포커스를 변경하지 않도록 했습니다.


<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>