### PR TITLE
프리즘 챗 메시지 액션 추가

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -1865,6 +1865,7 @@ input SendPrismMessageInput {
 }
 
 type SendPrismMessageResult {
+  runId: ID!
   runSeq: Int!
   session: PrismSession!
 }

--- a/apps/api/src/graphql/resolvers/prism.ts
+++ b/apps/api/src/graphql/resolvers/prism.ts
@@ -63,7 +63,7 @@ import { runSite } from '#/utils/prism-serve.ts';
 import { recordToolResolution, withToolLedger } from '#/utils/prism-tool-calls.ts';
 import { ERROR_MESSAGE } from '#/utils/prism-tool-messages.ts';
 import { prismTools } from '#/utils/prism-tools.ts';
-import { materialize } from '#/utils/prism-transcript.ts';
+import { joinRunRows, materialize } from '#/utils/prism-transcript.ts';
 import { cancelActiveRun, cancelSessionWorkflows, closeRun } from '#/utils/prism-workflows.ts';
 import { entityRefFilter } from '#/utils/prism-workspace.ts';
 import { wasm as wasmFfi } from '#/utils/wasm-ffi.ts';
@@ -338,16 +338,13 @@ const loadTranscript = async ({ id: sessionId, cursor }: { id: string; cursor: n
   }
 
   const wire = toGraphQL(materialize(storedEvents(events), workflowEvents));
-  const rowOf = new Map(runs.map((run) => [run.runSeq, run]));
-  const shaped: PrismRunShape[] = [];
+  const rowSequences = new Set(runs.map((run) => run.runSeq));
   for (const run of wire.runs) {
-    const row = run.runSeq === null ? undefined : rowOf.get(run.runSeq);
-    if (row === undefined) {
+    if (run.runSeq === null || !rowSequences.has(run.runSeq)) {
       log.warn('prism run row missing for transcript: {sessionId} run {runSeq}', { sessionId, runSeq: run.runSeq });
-      continue;
     }
-    shaped.push({ ...run, row });
   }
+  const shaped: PrismRunShape[] = joinRunRows(runs, wire.runs);
   return { ...wire, cursor: Math.max(wire.cursor, cursor), runs: shaped };
 };
 
@@ -608,7 +605,7 @@ builder.queryFields((t) => ({
 }));
 
 const SendPrismMessageResult = builder.simpleObject('SendPrismMessageResult', {
-  fields: (t) => ({ session: t.field({ type: PrismSession }), runSeq: t.int() }),
+  fields: (t) => ({ session: t.field({ type: PrismSession }), runId: t.id(), runSeq: t.int() }),
 });
 
 builder.mutationFields((t) => ({
@@ -626,13 +623,17 @@ builder.mutationFields((t) => ({
       if (message.length === 0) throw new TypieError({ code: 'empty_message', status: 400 });
       const key = nanoid();
 
-      const attachRunSite = async (sessionId: string, runSeq: number) => {
-        if (!input.siteId) return;
-        await assertSitePermission({ userId: ctx.session.userId, siteId: input.siteId });
-        await db
+      const ensureRun = async (sessionId: string, runSeq: number) => {
+        if (input.siteId) await assertSitePermission({ userId: ctx.session.userId, siteId: input.siteId });
+        return await db
           .insert(PrismRuns)
-          .values({ sessionId, runSeq, siteId: input.siteId, startedAt: dayjs() })
-          .onConflictDoUpdate({ target: [PrismRuns.sessionId, PrismRuns.runSeq], set: { siteId: input.siteId } });
+          .values({ sessionId, runSeq, ...(input.siteId && { siteId: input.siteId }), startedAt: dayjs() })
+          .onConflictDoUpdate({
+            target: [PrismRuns.sessionId, PrismRuns.runSeq],
+            set: { runSeq, ...(input.siteId && { siteId: input.siteId }) },
+          })
+          .returning({ id: PrismRuns.id })
+          .then(firstOrThrow);
       };
 
       if (input.sessionId) {
@@ -648,9 +649,9 @@ builder.mutationFields((t) => ({
           .where(eq(PrismSessions.id, session.id))
           .returning()
           .then(firstOrThrow);
-        await attachRunSite(session.id, runSeq);
+        const run = await ensureRun(session.id, runSeq);
         await ensureIngest({ kind: 'agent', sessionId: session.id });
-        return { session: updated, runSeq };
+        return { session: updated, runId: run.id, runSeq };
       }
       const agentId = newAgentId();
       const { runSeq } = await prism.invokeAgent({ agentId, message, key, metadata: { userId: ctx.session.userId } }).catch(prismError);
@@ -665,9 +666,9 @@ builder.mutationFields((t) => ({
         })
         .returning()
         .then(firstOrThrow);
-      await attachRunSite(session.id, runSeq);
+      const run = await ensureRun(session.id, runSeq);
       await ensureIngest({ kind: 'agent', sessionId: session.id });
-      return { session, runSeq };
+      return { session, runId: run.id, runSeq };
     },
   }),
 

--- a/apps/api/src/utils/prism-transcript.test.ts
+++ b/apps/api/src/utils/prism-transcript.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { materialize } from './prism-transcript.ts';
+import { joinRunRows, materialize } from './prism-transcript.ts';
 import type { StoredEvent } from './prism-transcript.ts';
 
 const agent = { id: 'chat-1', name: 'chat' };
@@ -16,6 +16,27 @@ const ev = (seq: number, kind: string, context: StoredEvent['context'], data: Re
 const run = { agent, run: 1 };
 const turn = { ...run, turn: 1, attempt: 1 };
 const inv = { ...turn, toolCallId: 'c1', invocation: 'inv_1' };
+
+test('run metadata는 DB 행을 기준으로 두고 아직 적재되지 않은 run도 보존한다', () => {
+  const rows = [
+    { id: 'PRRN2', runSeq: 2 },
+    { id: 'PRRN1', runSeq: 1 },
+  ];
+  const runs = [
+    {
+      runSeq: 1,
+      items: [{ kind: 'user' as const, key: 'u1', text: '안녕', at: '2026-08-31T00:00:00.000Z' }],
+    },
+  ];
+
+  assert.deepEqual(
+    joinRunRows(rows, runs).map(({ row, items }) => ({ id: row.id, items: items.map((item) => item.key) })),
+    [
+      { id: 'PRRN1', items: ['u1'] },
+      { id: 'PRRN2', items: [] },
+    ],
+  );
+});
 
 test('워크플로 이벤트는 invocation.started 직후에 끼워 넣어 같은 run 안에 묶인다', () => {
   const session = [

--- a/apps/api/src/utils/prism-transcript.ts
+++ b/apps/api/src/utils/prism-transcript.ts
@@ -1,7 +1,7 @@
 // 순수 — env·DB·네트워크 import 없음(node:test 직접 로드)
 import { applyFrame, emptyTranscript } from '@typie/prism';
 import { projectFrame } from './prism-events.ts';
-import type { Context, Transcript } from '@typie/prism';
+import type { Context, RunItemsWire, Transcript } from '@typie/prism';
 
 export type StoredEvent = {
   seq: number;
@@ -10,6 +10,11 @@ export type StoredEvent = {
   loggedAt: number;
   context: Context | null;
   data: Record<string, unknown>;
+};
+
+export const joinRunRows = <Row extends { runSeq: number }>(rows: Row[], runs: RunItemsWire[]): (RunItemsWire & { row: Row })[] => {
+  const itemsOf = new Map(runs.flatMap((run) => (run.runSeq === null ? [] : [[run.runSeq, run.items] as const])));
+  return rows.toSorted((a, b) => a.runSeq - b.runSeq).map((row) => ({ runSeq: row.runSeq, items: itemsOf.get(row.runSeq) ?? [], row }));
 };
 
 const workflowIdOf = (event: StoredEvent): string | null => {

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismMessage.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismMessage.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { css } from '@typie/styled-system/css';
+  import { css, cx } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import PrismMessageActions from './PrismMessageActions.svelte';
   import type { TranscriptMessage } from '@typie/prism';
 
   type Props = {
@@ -11,19 +13,24 @@
 
 {#if message.role === 'user'}
   <div
-    class={css({
-      alignSelf: 'flex-end',
-      maxWidth: '[86%]',
-      paddingX: '12px',
-      paddingY: '8px',
-      borderRadius: '12px',
-      borderBottomRightRadius: '2px',
-      backgroundColor: 'surface.muted',
-      fontSize: '14px',
-      lineHeight: '[1.6]',
-      whiteSpace: 'pre-wrap',
-    })}
+    class={cx('group', flex({ alignSelf: 'flex-end', alignItems: 'flex-end', flexDirection: 'column', maxWidth: '[86%]' }))}
+    data-message-actions-host
+    data-message-role="user"
   >
-    {message.text}
+    <div
+      class={css({
+        paddingX: '12px',
+        paddingY: '8px',
+        borderRadius: '12px',
+        borderBottomRightRadius: '2px',
+        backgroundColor: 'surface.muted',
+        fontSize: '14px',
+        lineHeight: '[1.6]',
+        whiteSpace: 'pre-wrap',
+      })}
+    >
+      {message.text}
+    </div>
+    <PrismMessageActions at={message.at} role="user" text={message.text} />
   </div>
 {/if}

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismMessageActions.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismMessageActions.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import { Icon } from '@typie/ui/components';
+  import { Toast } from '@typie/ui/notification';
+  import { onDestroy } from 'svelte';
+  import CheckIcon from '~icons/lucide/check';
+  import CopyIcon from '~icons/lucide/copy';
+  import ThumbsDownIcon from '~icons/lucide/thumbs-down';
+  import ThumbsUpIcon from '~icons/lucide/thumbs-up';
+  import { expand } from './lib/motion.ts';
+  import PrismReactionNote from './PrismReactionNote.svelte';
+  import type { PrismRunMeta } from './prism-data.ts';
+
+  type Props = {
+    role: 'assistant' | 'user';
+    text: string;
+    at: number;
+    persistent?: boolean;
+    run?: PrismRunMeta;
+    onReact?: (runId: string, reaction: 'UP' | 'DOWN' | null, note: string | null) => Promise<boolean>;
+  };
+
+  let { role, text, at, persistent = false, run, onReact }: Props = $props();
+
+  const timeFormat = new Intl.DateTimeFormat('ko-KR', { hour: 'numeric', minute: '2-digit' });
+  const sameYearFormat = new Intl.DateTimeFormat('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  const otherYearFormat = new Intl.DateTimeFormat('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  const COPY_FEEDBACK_MS = 2000;
+
+  const formatTimestamp = (value: number) => {
+    const date = new Date(value);
+    const today = new Date();
+    const sameYear = date.getFullYear() === today.getFullYear();
+    const sameDay = sameYear && date.getMonth() === today.getMonth() && date.getDate() === today.getDate();
+
+    if (sameDay) return timeFormat.format(date);
+    if (sameYear) return sameYearFormat.format(date);
+    return otherYearFormat.format(date);
+  };
+
+  let copied = $state(false);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+      if (copyTimer !== null) clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => {
+        copied = false;
+        copyTimer = null;
+      }, COPY_FEEDBACK_MS);
+    } catch {
+      Toast.error('복사하지 못했어요');
+    }
+  };
+
+  onDestroy(() => {
+    if (copyTimer !== null) clearTimeout(copyTimer);
+  });
+
+  let editing = $state(false);
+  let note = $state('');
+  let sending = $state(false);
+
+  const send = async (reaction: 'UP' | 'DOWN' | null, reactionNote: string | null) => {
+    if (!run || !onReact || sending) return false;
+    sending = true;
+    try {
+      return await onReact(run.id, reaction, reactionNote);
+    } finally {
+      sending = false;
+    }
+  };
+
+  const react = async (value: 'UP' | 'DOWN') => {
+    if (!run) return;
+    const clearing = run.reaction === value;
+    const draft = note.trim();
+    const kept = draft.length > 0 ? draft : run.reactionNote;
+    const ok = clearing ? await send(null, null) : await send(value, kept);
+    if (!ok) return;
+
+    if (clearing) {
+      note = '';
+      editing = false;
+    } else {
+      editing = kept === null;
+    }
+  };
+
+  const saveNote = async () => {
+    if (!run?.reaction) return;
+    if (await send(run.reaction, note.trim() || null)) editing = false;
+  };
+
+  const rowStyle = css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: '2px',
+    marginTop: '6px',
+    minHeight: '26px',
+    color: 'text.faint',
+    opacity: '0',
+    transition: '[opacity 120ms ease]',
+    '.group:hover &': { opacity: '100' },
+    _groupFocusWithin: { opacity: '100' },
+    '&[data-persistent]': { opacity: '100' },
+  });
+  const actionStyle = css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    size: '26px',
+    borderRadius: '6px',
+    color: 'text.faint',
+    transition: '[color 120ms ease, background-color 120ms ease]',
+    _hover: { color: 'text.default', backgroundColor: 'surface.muted' },
+    _focusVisible: { color: 'text.default', outline: '2px solid token(colors.border.focus)', outlineOffset: '1px' },
+    _pressed: { color: 'text.default', backgroundColor: 'surface.muted' },
+    _disabled: { cursor: 'default', opacity: '[0.5]' },
+  });
+  const timeStyle = css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    height: '26px',
+    paddingX: '4px',
+    fontSize: '11px',
+    lineHeight: '[1]',
+    color: 'text.faint',
+    whiteSpace: 'nowrap',
+    opacity: '0',
+    transition: '[opacity 120ms ease]',
+    '.group:hover &': { opacity: '100' },
+    _groupFocusWithin: { opacity: '100' },
+  });
+  const noteVisibleStyle = css.raw({
+    gridTemplateRows: '[1fr]',
+    marginTop: '6px',
+    opacity: '100',
+    pointerEvents: 'auto',
+  });
+  const noteStyle = css({
+    display: 'grid',
+    width: 'full',
+    gridTemplateRows: '[0fr]',
+    marginTop: '0',
+    opacity: '0',
+    pointerEvents: 'none',
+    transition: '[grid-template-rows 160ms ease, margin-top 160ms ease, opacity 120ms ease]',
+    '& > *': { minHeight: '0', overflow: 'hidden' },
+    '.group:hover &': noteVisibleStyle,
+    _groupFocusWithin: noteVisibleStyle,
+    '&[data-persistent]': noteVisibleStyle,
+  });
+</script>
+
+{#snippet timestamp()}
+  <time class={timeStyle} data-message-time datetime={new Date(at).toISOString()}>{formatTimestamp(at)}</time>
+{/snippet}
+
+{#snippet copyButton()}
+  <button class={actionStyle} aria-label={copied ? '복사됨' : '복사'} onclick={() => void copy()} type="button">
+    <Icon icon={copied ? CheckIcon : CopyIcon} size={14} />
+  </button>
+{/snippet}
+
+<div class={flex({ flexDirection: 'column', alignItems: role === 'user' ? 'flex-end' : 'flex-start' })}>
+  <div class={rowStyle} data-message-actions data-persistent={persistent ? '' : undefined}>
+    {#if role === 'user'}
+      {@render timestamp()}
+      {@render copyButton()}
+    {:else}
+      {@render copyButton()}
+      <button
+        class={actionStyle}
+        aria-label="좋았어요"
+        aria-pressed={run?.reaction === 'UP'}
+        disabled={sending}
+        onclick={() => void react('UP')}
+        type="button"
+      >
+        <Icon icon={ThumbsUpIcon} size={14} />
+      </button>
+      <button
+        class={actionStyle}
+        aria-label="아쉬웠어요"
+        aria-pressed={run?.reaction === 'DOWN'}
+        disabled={sending}
+        onclick={() => void react('DOWN')}
+        type="button"
+      >
+        <Icon icon={ThumbsDownIcon} size={14} />
+      </button>
+      {@render timestamp()}
+    {/if}
+  </div>
+
+  {#if role === 'assistant' && run?.reaction}
+    <div class={css({ width: 'full', maxWidth: '360px' })} transition:expand>
+      <div class={noteStyle} data-persistent={persistent ? '' : undefined} data-reaction-note-container>
+        <div>
+          <PrismReactionNote onSubmit={() => void saveNote()} savedNote={run.reactionNote} {sending} bind:editing bind:draft={note} />
+        </div>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
@@ -183,6 +183,7 @@
     graphql(`
       mutation DashboardLayout_PrismPanel_Send_Mutation($input: SendPrismMessageInput!) {
         sendPrismMessage(input: $input) {
+          runId
           runSeq
 
           session {
@@ -202,6 +203,18 @@
       mutation DashboardLayout_PrismPanel_Cancel_Mutation($input: CancelPrismRunInput!) {
         cancelPrismRun(input: $input) {
           id
+        }
+      }
+    `),
+  );
+
+  const [reactPrismRun] = createMutation(
+    graphql(`
+      mutation DashboardLayout_PrismPanel_ReactRun_Mutation($input: ReactPrismRunInput!) {
+        reactPrismRun(input: $input) {
+          id
+          reaction
+          reactionNote
         }
       }
     `),
@@ -261,7 +274,7 @@
       const resp = await sendPrismMessage({
         input: { sessionId: sessionId ?? undefined, message, siteId: currentSiteId, toolPolicy: sessionId ? undefined : pendingPolicy },
       });
-      return { sessionId: resp.sendPrismMessage.session.id, runSeq: resp.sendPrismMessage.runSeq };
+      return { sessionId: resp.sendPrismMessage.session.id, runId: resp.sendPrismMessage.runId, runSeq: resp.sendPrismMessage.runSeq };
     },
     cancel: async (sessionId) => {
       await cancelPrismRun({ input: { sessionId } });
@@ -333,6 +346,21 @@
 
   const resolveTool = async (agentId: string, toolCallId: string, input: unknown) => {
     await resolveToolForSession(chat.sessionId, chat.transcript.agentId, agentId, toolCallId, input);
+  };
+
+  const reactRun = async (runId: string, reaction: 'UP' | 'DOWN' | null, note: string | null) => {
+    try {
+      const response = await reactPrismRun({ input: { runId, reaction: reaction ?? undefined, note: note ?? undefined } });
+      chat.updateRunReaction(
+        response.reactPrismRun.id,
+        response.reactPrismRun.reaction ?? null,
+        response.reactPrismRun.reactionNote ?? null,
+      );
+      return true;
+    } catch {
+      Toast.error('반응을 남기지 못했어요');
+      return false;
+    }
   };
 
   const autoResolver = new AutoResolver({
@@ -1079,8 +1107,10 @@
 
     {#key chat.generation}
       <PrismTranscript
+        answers={chat.answers}
         failedIds={autoResolver.failedIds}
         loading={chat.loading}
+        onReact={reactRun}
         onResolve={resolveTool}
         onRetry={(toolCallId) => autoResolver.retry(toolCallId)}
         onSpinnerPlaybackChange={(startedAt) => (indicatorSpinnerPlaybackStartedAt = startedAt)}

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismReactionNote.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismReactionNote.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { flex } from '@typie/styled-system/patterns';
+  import { autosize } from '@typie/ui/actions';
+  import { Icon, RingSpinner } from '@typie/ui/components';
+  import ArrowUpIcon from '~icons/lucide/arrow-up';
+
+  type Props = {
+    savedNote: string | null;
+    sending: boolean;
+    editing?: boolean;
+    draft?: string;
+    onSubmit: () => void;
+  };
+
+  let { savedNote, sending, onSubmit, editing = $bindable(false), draft = $bindable('') }: Props = $props();
+  let input = $state<HTMLTextAreaElement>();
+
+  $effect(() => {
+    if (!editing) draft = savedNote ?? '';
+  });
+
+  $effect(() => {
+    if (editing) input?.focus();
+  });
+
+  const draftStyle = flex({
+    alignItems: 'flex-end',
+    gap: '6px',
+    width: 'full',
+    minHeight: '34px',
+    paddingLeft: '10px',
+    paddingRight: '4px',
+    paddingY: '4px',
+    borderWidth: '1px',
+    borderColor: 'border.default',
+    borderRadius: '8px',
+    backgroundColor: 'surface.subtle',
+  });
+  const savedStyle = flex({
+    alignItems: 'center',
+    gap: '6px',
+    width: 'full',
+    maxWidth: 'full',
+    minHeight: '34px',
+    paddingX: '8px',
+    paddingY: '4px',
+    borderRadius: '8px',
+    backgroundColor: 'surface.muted',
+  });
+  const textStyle = css({
+    flexGrow: '1',
+    minWidth: '0',
+    fontSize: '12px',
+    lineHeight: '[1.5]',
+    color: 'text.subtle',
+    whiteSpace: 'pre-wrap',
+  });
+  const editStyle = css({
+    flexShrink: '0',
+    marginLeft: 'auto',
+    fontSize: '11px',
+    fontWeight: 'semibold',
+    color: 'text.faint',
+    _hover: { color: 'text.default' },
+  });
+  const submitStyle = flex({
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: '0',
+    size: '22px',
+    borderRadius: 'full',
+    backgroundColor: 'surface.dark',
+    color: 'text.bright',
+  });
+</script>
+
+{#if !editing && savedNote}
+  <div class={savedStyle} data-reaction-note data-reaction-note-state="saved">
+    <p class={textStyle} data-reaction-note-text>{savedNote}</p>
+    <button
+      class={editStyle}
+      aria-label="반응 메모 수정"
+      onclick={() => {
+        draft = savedNote;
+        editing = true;
+      }}
+      type="button"
+    >
+      수정
+    </button>
+  </div>
+{:else}
+  <div class={draftStyle} data-reaction-note data-reaction-note-state="draft">
+    <textarea
+      bind:this={input}
+      class={css({
+        flexGrow: '1',
+        minWidth: '0',
+        maxHeight: '120px',
+        paddingY: '3px',
+        fontSize: '12px',
+        lineHeight: '[1.5]',
+        backgroundColor: 'transparent',
+        resize: 'none',
+        outline: 'none',
+        _placeholder: { color: 'text.faint' },
+      })}
+      onkeydown={(event) => {
+        if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
+          event.preventDefault();
+          onSubmit();
+        }
+      }}
+      placeholder="몇 자 덧붙이기"
+      readonly={sending}
+      rows={1}
+      bind:value={draft}
+      use:autosize={{ value: draft }}></textarea>
+    <button
+      class={submitStyle}
+      aria-busy={sending}
+      aria-label={sending ? '남기는 중' : '남기기'}
+      disabled={sending}
+      onclick={onSubmit}
+      type="button"
+    >
+      {#if sending}
+        <span class={flex({ alignItems: 'center', justifyContent: 'center', size: '10px' })} data-reaction-note-submit-spinner>
+          <RingSpinner style={css.raw({ size: '10px' })} />
+        </span>
+      {:else}
+        <Icon icon={ArrowUpIcon} size={10} />
+      {/if}
+    </button>
+  </div>
+{/if}

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.svelte
@@ -16,6 +16,7 @@
   import { labelForRequest } from './lib/tool-labels.ts';
   import PrismMarkdown from './PrismMarkdown.svelte';
   import PrismMessage from './PrismMessage.svelte';
+  import PrismMessageActions from './PrismMessageActions.svelte';
   import PrismToolCalls from './PrismToolCalls.svelte';
   import PrismToolRequest from './PrismToolRequest.svelte';
   import PrismWaitRow from './PrismWaitRow.svelte';
@@ -23,11 +24,13 @@
   import { toolCallLabels, toolCards } from './tools/index.ts';
   import type { ToolPolicy, ToolRequestMessage, Transcript, TranscriptMessage } from '@typie/prism';
   import type { BlockNode } from './lib/markdown.ts';
+  import type { PrismAnswer, PrismPendingMessage } from './prism-chat.svelte.ts';
 
   type Props = {
     transcript: Transcript;
+    answers: PrismAnswer[];
     loading: boolean;
-    pending: string | null;
+    pending: PrismPendingMessage | null;
     sessionId: string | null;
     failedIds: ReadonlySet<string>;
     unavailableMessage?: string;
@@ -37,10 +40,12 @@
     waitSpinnerAnchor?: HTMLElement;
     onResolve: (agentId: string, toolCallId: string, input: unknown) => Promise<void>;
     onRetry: (toolCallId: string) => void;
+    onReact: (runId: string, reaction: 'UP' | 'DOWN' | null, note: string | null) => Promise<boolean>;
   };
 
   let {
     transcript,
+    answers,
     loading,
     pending,
     sessionId,
@@ -52,6 +57,7 @@
     waitSpinnerAnchor = $bindable(),
     onResolve,
     onRetry,
+    onReact,
   }: Props = $props();
 
   // 카드는 작가의 승인을 받는 자리다 — 해소된 요청은 실제로 누가 해소했는지(resolvedBy)에 매이고, 아직 열린 요청만 지금 정책을
@@ -285,7 +291,14 @@
 
   type RenderEntry = (typeof entries)[number];
   type RenderItem =
-    | { kind: 'markdown'; key: string; blocks: BlockNode[]; plain: number; settled: boolean }
+    | {
+        kind: 'markdown';
+        key: string;
+        blocks: BlockNode[];
+        plain: number;
+        settled: boolean;
+        message: Extract<TranscriptMessage, { role: 'assistant' }> | null;
+      }
     | { kind: 'entry'; key: string; entry: RenderEntry };
 
   // assistant 마크다운은 라이브·드레인·봉인 세 국면을 같은 키의 같은 항목으로 잇는다 — 위치 이동 재마운트가 카드를 한 프레임 스켈레톤으로 되돌리지 않도록.
@@ -295,21 +308,31 @@
         const drain = drainOf(entry.key);
         const key = aliases.get(entry.key) ?? entry.key;
         return drain
-          ? { kind: 'markdown', key, blocks: drain.paced.blocks, plain: drain.paced.plain, settled: false }
-          : { kind: 'markdown', key, blocks: parsedBlocks(entry.key, entry.text), plain: Number.MAX_SAFE_INTEGER, settled: true };
+          ? { kind: 'markdown', key, blocks: drain.paced.blocks, plain: drain.paced.plain, settled: false, message: entry }
+          : {
+              kind: 'markdown',
+              key,
+              blocks: parsedBlocks(entry.key, entry.text),
+              plain: Number.MAX_SAFE_INTEGER,
+              settled: true,
+              message: entry,
+            };
       }
 
       return { kind: 'entry', key: entry.key, entry };
     });
 
     if (live && !draining && transcript.live && live.boundary > 0) {
-      items.push({ kind: 'markdown', key: liveKey, blocks: live.blocks, plain: live.plain, settled: false });
+      items.push({ kind: 'markdown', key: liveKey, blocks: live.blocks, plain: live.plain, settled: false, message: null });
     }
 
     return items;
   });
 
-  let prevPending: string | null = null;
+  const answerByKey = $derived(new Map(answers.map((answer) => [answer.key, answer])));
+  const latestAnswerKey = $derived(answers.at(-1)?.key ?? null);
+
+  let prevPending: PrismPendingMessage | null = null;
 
   $effect.pre(() => {
     if (pending !== null && prevPending === null) resumeFollow();
@@ -458,7 +481,8 @@
       overflowY: 'auto',
       scrollbarWidth: 'none',
       paddingX: '16px',
-      paddingY: '16px',
+      paddingTop: '16px',
+      paddingBottom: '40px',
     })}
     onscroll={onScroll}
   >
@@ -490,7 +514,20 @@
             }}
           >
             {#if item.kind === 'markdown'}
-              <PrismMarkdown blocks={item.blocks} plain={item.plain} settled={item.settled} />
+              {@const answer = item.message === null ? undefined : answerByKey.get(item.message.key)}
+              <div class="group" data-message-actions-host={answer ? '' : undefined} data-message-role={answer ? 'assistant' : undefined}>
+                <PrismMarkdown blocks={item.blocks} plain={item.plain} settled={item.settled} />
+                {#if item.settled && answer && item.message !== null && item.message.text !== null}
+                  <PrismMessageActions
+                    at={item.message.at}
+                    {onReact}
+                    persistent={answer.key === latestAnswerKey}
+                    role="assistant"
+                    run={answer.run}
+                    text={item.message.text}
+                  />
+                {/if}
+              </div>
             {:else if item.entry.role === 'tool-calls'}
               <PrismToolCalls count={item.entry.count} rows={item.entry.rows} />
             {:else if item.entry.role === 'tool-request'}
@@ -528,22 +565,13 @@
 
         {#if pending !== null}
           <div
-            class={css({
-              alignSelf: 'flex-end',
-              maxWidth: '[86%]',
-              paddingX: '12px',
-              paddingY: '8px',
-              borderRadius: '12px',
-              borderBottomRightRadius: '2px',
-              backgroundColor: 'surface.muted',
-              fontSize: '14px',
-              lineHeight: '[1.6]',
-              whiteSpace: 'pre-wrap',
+            class={flex({
+              flexDirection: 'column',
               animation: '[rise-in 200ms cubic-bezier(0.23, 1, 0.32, 1) both]',
               _motionReduce: { animation: 'none' },
             })}
           >
-            {pending}
+            <PrismMessage message={pending} />
           </div>
         {/if}
 

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-chat.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-chat.svelte.ts
@@ -1,9 +1,28 @@
 import { applyFrame, emptyTranscript } from '@typie/prism';
-import type { ProjectedStreamFrame, Transcript } from '@typie/prism';
+import type { ProjectedStreamFrame, Transcript, TranscriptMessage } from '@typie/prism';
+import type { PrismRunMeta, PrismTranscriptSnapshot } from './prism-data.ts';
+
+export type PrismAnswer = { key: string; run: PrismRunMeta };
+export type PrismPendingMessage = Extract<TranscriptMessage, { role: 'user' }>;
+
+const answerKeys = (transcript: Transcript): Record<number, string> => {
+  const keys: Record<number, string> = {};
+  let runSeq: number | null = null;
+
+  for (const message of transcript.messages) {
+    if (message.role === 'user') {
+      runSeq = message.runSeq;
+    } else if (runSeq !== null && message.role === 'assistant' && message.text !== null) {
+      keys[runSeq] = message.key;
+    }
+  }
+
+  return keys;
+};
 
 export type PrismChatDeps = {
-  load: (sessionId: string) => Promise<Transcript>;
-  send: (sessionId: string | null, message: string) => Promise<{ sessionId: string; runSeq: number }>;
+  load: (sessionId: string) => Promise<PrismTranscriptSnapshot>;
+  send: (sessionId: string | null, message: string) => Promise<{ sessionId: string; runId: string; runSeq: number }>;
   cancel: (sessionId: string) => Promise<void>;
 };
 
@@ -13,8 +32,10 @@ export const createPrismChat = (deps: PrismChatDeps) => {
   let error = $state<string | null>(null);
   let sessionId = $state<string | null>(null);
   let seedCursor = $state(0);
-  let pending = $state<string | null>(null);
+  let pending = $state<PrismPendingMessage | null>(null);
   let loadGen = $state(0);
+  let runs = $state<PrismRunMeta[]>([]);
+  let terminalStates: Partial<Record<number, PrismRunMeta['state']>> = {};
 
   const load = async (id: string | null) => {
     if (id !== null && id === sessionId && error === null) {
@@ -28,6 +49,8 @@ export const createPrismChat = (deps: PrismChatDeps) => {
     seedCursor = 0;
     pending = null;
     transcript = emptyTranscript();
+    runs = [];
+    terminalStates = {};
 
     if (id === null) {
       loading = false;
@@ -42,11 +65,9 @@ export const createPrismChat = (deps: PrismChatDeps) => {
         return;
       }
 
-      transcript = next;
-      seedCursor = next.cursor;
-      if (next.messages.length > 0) {
-        pending = null;
-      }
+      transcript = next.transcript;
+      runs = next.runs;
+      seedCursor = next.transcript.cursor;
     } catch {
       if (gen !== loadGen) {
         return;
@@ -79,6 +100,17 @@ export const createPrismChat = (deps: PrismChatDeps) => {
     get pending() {
       return pending;
     },
+    get runs() {
+      return runs;
+    },
+    get answers(): PrismAnswer[] {
+      const keyOf = answerKeys(transcript);
+      return runs.flatMap((run) => {
+        if (run.state !== 'COMPLETED') return [];
+        const key = keyOf[run.runSeq];
+        return key === undefined ? [] : [{ key, run }];
+      });
+    },
     get generation() {
       return loadGen;
     },
@@ -89,17 +121,40 @@ export const createPrismChat = (deps: PrismChatDeps) => {
       if (frame.type === 'event' && frame.event.kind === 'run.started') {
         pending = null;
       }
+      if (frame.type === 'event') {
+        const state =
+          frame.event.kind === 'run.completed'
+            ? 'COMPLETED'
+            : frame.event.kind === 'run.failed'
+              ? 'FAILED'
+              : frame.event.kind === 'run.canceled'
+                ? 'CANCELED'
+                : null;
+        const runSeq = frame.event.context.run;
+        if (state !== null && runSeq !== undefined) {
+          terminalStates[runSeq] = state;
+          runs = runs.map((run) => (run.runSeq === runSeq ? { ...run, state } : run));
+        }
+      }
     },
     async send(message: string) {
       const gen = loadGen;
       error = null;
-      pending = message;
+      pending = { role: 'user', key: 'pending', text: message, at: Date.now(), runSeq: null };
 
       try {
         const result = await deps.send(sessionId, message);
         if (gen !== loadGen) return result;
 
         sessionId = result.sessionId;
+        const run: PrismRunMeta = {
+          id: result.runId,
+          runSeq: result.runSeq,
+          state: terminalStates[result.runSeq] ?? 'RUNNING',
+          reaction: null,
+          reactionNote: null,
+        };
+        runs = [...runs.filter((item) => item.runSeq !== result.runSeq), run];
         return result;
       } catch (err) {
         if (gen === loadGen) pending = null;
@@ -110,6 +165,9 @@ export const createPrismChat = (deps: PrismChatDeps) => {
       if (sessionId !== null) {
         await deps.cancel(sessionId);
       }
+    },
+    updateRunReaction(runId: string, reaction: PrismRunMeta['reaction'], reactionNote: string | null) {
+      runs = runs.map((run) => (run.id === runId ? { ...run, reaction, reactionNote } : run));
     },
   };
 };

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-chat.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-chat.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createPrismChat } from './prism-chat.svelte.ts';
 import type { ProjectedEventData, ProjectedStreamFrame, Transcript } from '@typie/prism';
 import type { PrismChatDeps } from './prism-chat.svelte.ts';
+import type { PrismTranscriptSnapshot } from './prism-data.ts';
 
 const agent = { id: 'typie-1', name: 'assistant' };
 
@@ -25,9 +26,10 @@ const startWorkflow = (seq: number, workflowId: string, id: string) =>
 const finishWorkflow = (seq: number, id: string) => ev(seq, 'invocation.completed', invocation(seq, id), {});
 
 const sessionLog = [startWorkflow(1, 'workflow_1', 'i1'), startWorkflow(2, 'workflow_2', 'i2'), finishWorkflow(3, 'i2')];
+const snapshot = (transcript: Transcript): PrismTranscriptSnapshot => ({ transcript, runs: [] });
 
 const deps = (over: Partial<PrismChatDeps>): PrismChatDeps => ({
-  load: vi.fn().mockResolvedValue(sessionLog.reduce((transcript, frame) => applyFrame(transcript, frame), emptyTranscript())),
+  load: vi.fn().mockResolvedValue(snapshot(sessionLog.reduce((transcript, frame) => applyFrame(transcript, frame), emptyTranscript()))),
   send: vi.fn(),
   cancel: vi.fn(),
   ...over,
@@ -46,7 +48,7 @@ describe('createPrismChat.load', () => {
   });
 
   it('같은 세션 재호출은 no-op이고, 실패는 에러 문면을 세운다', async () => {
-    const load = vi.fn().mockRejectedValueOnce(new Error('x')).mockResolvedValue(emptyTranscript());
+    const load = vi.fn().mockRejectedValueOnce(new Error('x')).mockResolvedValue(snapshot(emptyTranscript()));
     const chat = createPrismChat(deps({ load }));
 
     await chat.load('PRSS1');
@@ -61,16 +63,16 @@ describe('createPrismChat.load', () => {
   });
 
   it('늦게 끝난 이전 로드는 무시된다', async () => {
-    let resolveFirst!: (transcript: Transcript) => void;
+    let resolveFirst!: (value: PrismTranscriptSnapshot) => void;
     const load = vi
       .fn()
-      .mockImplementationOnce(() => new Promise<Transcript>((resolve) => (resolveFirst = resolve)))
-      .mockResolvedValueOnce({ ...emptyTranscript(), cursor: 9 });
+      .mockImplementationOnce(() => new Promise<PrismTranscriptSnapshot>((resolve) => (resolveFirst = resolve)))
+      .mockResolvedValueOnce(snapshot({ ...emptyTranscript(), cursor: 9 }));
     const chat = createPrismChat(deps({ load }));
 
     const first = chat.load('PRSS1');
     await chat.load('PRSS2');
-    resolveFirst({ ...emptyTranscript(), cursor: 1 });
+    resolveFirst(snapshot({ ...emptyTranscript(), cursor: 1 }));
     await first;
 
     expect(chat.sessionId).toBe('PRSS2');
@@ -78,10 +80,10 @@ describe('createPrismChat.load', () => {
   });
 
   it('새 대화로 전환하면 아직 스트림에 합류하지 않은 사용자 메시지를 비운다', async () => {
-    const chat = createPrismChat(deps({ send: vi.fn().mockResolvedValue({ sessionId: 'PRSS1', runSeq: 1 }) }));
+    const chat = createPrismChat(deps({ send: vi.fn().mockResolvedValue({ sessionId: 'PRSS1', runId: 'PRRN1', runSeq: 1 }) }));
 
     await chat.send('안녕');
-    expect(chat.pending).toBe('안녕');
+    expect(chat.pending).toMatchObject({ role: 'user', text: '안녕', runSeq: null });
 
     await chat.load(null);
 
@@ -90,13 +92,13 @@ describe('createPrismChat.load', () => {
   });
 
   it('새 대화 전환 뒤 끝난 이전 전송은 현재 세션을 되돌리지 않는다', async () => {
-    let resolveSend!: (value: { sessionId: string; runSeq: number }) => void;
+    let resolveSend!: (value: { sessionId: string; runId: string; runSeq: number }) => void;
     const send = vi.fn().mockImplementation(() => new Promise((resolve) => (resolveSend = resolve)));
     const chat = createPrismChat(deps({ send }));
 
     const sending = chat.send('안녕');
     await chat.load(null);
-    resolveSend({ sessionId: 'PRSS1', runSeq: 1 });
+    resolveSend({ sessionId: 'PRSS1', runId: 'PRRN1', runSeq: 1 });
     await sending;
 
     expect(chat.sessionId).toBeNull();
@@ -106,14 +108,52 @@ describe('createPrismChat.load', () => {
 
 describe('createPrismChat.receive', () => {
   it('프레임을 리듀서에 적용하고 run.started에서 pending을 지운다', async () => {
-    const chat = createPrismChat(deps({ send: vi.fn().mockResolvedValue({ sessionId: 'PRSS1', runSeq: 1 }) }));
+    const chat = createPrismChat(deps({ send: vi.fn().mockResolvedValue({ sessionId: 'PRSS1', runId: 'PRRN1', runSeq: 1 }) }));
 
     await chat.send('안녕');
-    expect(chat.pending).toBe('안녕');
+    expect(chat.pending).toMatchObject({ role: 'user', text: '안녕', runSeq: null });
 
     chat.receive(ev(1, 'run.started', { agent, run: 1 }, { message: '안녕', command: null }));
 
     expect(chat.pending).toBeNull();
     expect(chat.transcript.messages[0]).toMatchObject({ role: 'user', text: '안녕' });
+  });
+
+  it('전송 응답의 run ID를 현재 run 메타데이터로 등록한다', async () => {
+    const chat = createPrismChat(deps({ send: vi.fn().mockResolvedValue({ sessionId: 'PRSS1', runSeq: 2, runId: 'PRRN2' }) }));
+
+    await chat.send('새 질문');
+
+    expect(chat.runs).toEqual([{ id: 'PRRN2', runSeq: 2, state: 'RUNNING', reaction: null, reactionNote: null }]);
+  });
+
+  it('완료된 run의 마지막 assistant 텍스트만 답변 액션에 연결한다', async () => {
+    const chat = createPrismChat(deps({ send: vi.fn().mockResolvedValue({ sessionId: 'PRSS1', runSeq: 2, runId: 'PRRN2' }) }));
+    const context = { agent, run: 2 };
+
+    await chat.send('새 질문');
+    chat.receive(ev(1, 'run.started', context, { message: '새 질문', command: null }));
+    chat.receive(ev(2, 'turn.started', { ...context, turn: 1, attempt: 1 }, {}));
+    chat.receive(ev(3, 'turn.completed', { ...context, turn: 1, attempt: 1 }, { text: '중간', toolCalls: [{ id: 'c1', name: 'read' }] }));
+    chat.receive(ev(4, 'turn.started', { ...context, turn: 2, attempt: 1 }, {}));
+    chat.receive(ev(5, 'turn.completed', { ...context, turn: 2, attempt: 1 }, { text: '최종 답변', toolCalls: [] }));
+    chat.receive(ev(6, 'run.completed', context, {}));
+
+    expect(chat.runs[0]?.state).toBe('COMPLETED');
+    expect(chat.answers).toEqual([
+      {
+        key: 'e5',
+        run: { id: 'PRRN2', runSeq: 2, state: 'COMPLETED', reaction: null, reactionNote: null },
+      },
+    ]);
+  });
+
+  it('저장된 run 반응과 note를 현재 답변에 반영한다', async () => {
+    const chat = createPrismChat(deps({ send: vi.fn().mockResolvedValue({ sessionId: 'PRSS1', runSeq: 2, runId: 'PRRN2' }) }));
+
+    await chat.send('새 질문');
+    chat.updateRunReaction('PRRN2', 'DOWN', '아쉬운 점');
+
+    expect(chat.runs).toEqual([{ id: 'PRRN2', runSeq: 2, state: 'RUNNING', reaction: 'DOWN', reactionNote: '아쉬운 점' }]);
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-data.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-data.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { toRunItem } from './prism-data.ts';
+import { fetchTranscript, toRunItem } from './prism-data.ts';
 
 vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+const { query } = vi.hoisted(() => ({ query: vi.fn() }));
+vi.mock('$lib/graphql/client', () => ({ mearieClient: { query } }));
 
 describe('toRunItem', () => {
   it('PrismUserMessage — userText 별칭을 text로 옮긴다', () => {
@@ -117,5 +120,37 @@ describe('toRunItem', () => {
       key: 'f1',
       at: '2026-08-24T00:00:08.000Z',
     });
+  });
+});
+
+describe('fetchTranscript', () => {
+  it('메시지와 함께 run의 저장 ID·상태·반응을 보존한다', async () => {
+    query.mockResolvedValueOnce({
+      prismSession: {
+        transcript: {
+          cursor: 3,
+          title: null,
+          agentId: 'typie-1',
+          turn: 'IDLE',
+          retrying: false,
+          runs: [
+            {
+              id: 'PRRN1',
+              runSeq: 1,
+              state: 'COMPLETED',
+              reaction: 'UP',
+              reactionNote: '좋았어요',
+              items: [],
+            },
+          ],
+        },
+      },
+    });
+
+    const loaded = await fetchTranscript('PRSS1');
+
+    expect((loaded as { runs?: unknown }).runs).toEqual([
+      { id: 'PRRN1', runSeq: 1, state: 'COMPLETED', reaction: 'UP', reactionNote: '좋았어요' },
+    ]);
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-data.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-data.ts
@@ -2,7 +2,17 @@ import { fromGraphQL } from '@typie/prism';
 import { mearieClient } from '$lib/graphql/client';
 import { graphql } from '$mearie';
 import type { DataOf } from '@mearie/svelte';
-import type { ProjectedStreamFrame, RunItemWire, Transcript, TranscriptWire } from '@typie/prism';
+import type { ProjectedStreamFrame, RunItemWire, RunStateWire, Transcript, TranscriptWire } from '@typie/prism';
+
+export type PrismRunMeta = {
+  id: string;
+  runSeq: number;
+  state: RunStateWire;
+  reaction: 'UP' | 'DOWN' | null;
+  reactionNote: string | null;
+};
+
+export type PrismTranscriptSnapshot = { transcript: Transcript; runs: PrismRunMeta[] };
 
 const transcriptQuery = graphql(`
   query DashboardLayout_PrismPanel_Transcript_Query($sessionId: ID!) {
@@ -18,6 +28,8 @@ const transcriptQuery = graphql(`
           id
           runSeq
           state
+          reaction
+          reactionNote
           items {
             __typename
             ... on PrismUserMessage {
@@ -182,7 +194,7 @@ export const toRunItem = (item: TranscriptQueryItem): RunItemWire => {
   }
 };
 
-export const fetchTranscript = async (sessionId: string): Promise<Transcript> => {
+export const fetchTranscript = async (sessionId: string): Promise<PrismTranscriptSnapshot> => {
   const data = await mearieClient.query(transcriptQuery, { sessionId }, { fetchPolicy: 'network-only' });
   const { transcript } = data.prismSession;
 
@@ -199,5 +211,14 @@ export const fetchTranscript = async (sessionId: string): Promise<Transcript> =>
     })),
   };
 
-  return fromGraphQL(wire);
+  return {
+    transcript: fromGraphQL(wire),
+    runs: transcript.runs.map((run) => ({
+      id: run.id,
+      runSeq: run.runSeq,
+      state: run.state,
+      reaction: run.reaction ?? null,
+      reactionNote: run.reactionNote ?? null,
+    })),
+  };
 };

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-transcript-actions.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-transcript-actions.browser.test.ts
@@ -1,0 +1,279 @@
+import '../../../../app.css';
+
+import { emptyTranscript } from '@typie/prism';
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import PrismTranscript from './PrismTranscript.svelte';
+import { reactiveProps } from './PrismTranscript.test-props.svelte.ts';
+import type { Transcript, TranscriptMessage, TurnLive } from '@typie/prism';
+import type { PrismAnswer, PrismPendingMessage } from './prism-chat.svelte.ts';
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+const user = (key: string, runSeq: number | null, text: string, at: number): TranscriptMessage => ({
+  role: 'user',
+  key,
+  runSeq,
+  text,
+  at,
+});
+
+const assistant = (key: string, text: string, at: number): TranscriptMessage => ({
+  role: 'assistant',
+  key,
+  text,
+  toolCalls: [],
+  at,
+  streamed: false,
+});
+
+const awaitingRequest = (at: number): TranscriptMessage => ({
+  role: 'tool-request',
+  key: 'awaiting',
+  seq: 1,
+  tool: 'unknown-tool',
+  toolCallId: 'call-1',
+  agentId: 'agent-1',
+  data: null,
+  status: 'pending',
+  at,
+});
+
+let component: Record<string, unknown> | undefined;
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  document.body.replaceChildren();
+});
+
+describe('PRISM transcript message actions', () => {
+  it('전송 중인 사용자 메시지도 확정 전부터 같은 footer 높이를 차지한다', async () => {
+    const at = Date.parse('2026-09-01T00:00:00+09:00');
+    const pending = user('pending', null, '방금 보낸 메시지', at) as PrismPendingMessage;
+    const awaiting = awaitingRequest(at);
+    const initialTranscript: Transcript = { ...emptyTranscript(), run: 'running', messages: [awaiting] };
+    const props = reactiveProps({
+      transcript: initialTranscript,
+      answers: [],
+      loading: false,
+      pending: pending as PrismPendingMessage | null,
+      sessionId: 'PRSS1',
+      failedIds: new Set<string>(),
+      reconnecting: false,
+      policy: 'STANDARD',
+      onResolve: vi.fn().mockResolvedValue(undefined),
+      onRetry: vi.fn(),
+      onReact: vi.fn().mockResolvedValue(true),
+    });
+
+    const target = document.createElement('div');
+    Object.assign(target.style, { display: 'flex', flexDirection: 'column', height: '320px', width: '420px' });
+    document.body.append(target);
+    component = mount(PrismTranscript, { target, props: props as never });
+    await tick();
+
+    const pendingHost = target.querySelector<HTMLElement>('[data-message-actions-host][data-message-role="user"]');
+    expect(pendingHost).not.toBeNull();
+    if (!pendingHost) return;
+    expect(pendingHost.querySelector('[data-message-actions]')).not.toBeNull();
+    const pendingHeight = pendingHost.getBoundingClientRect().height;
+
+    props.pending = null;
+    props.transcript = {
+      ...emptyTranscript(),
+      run: 'running',
+      messages: [awaiting, user('u1', 1, pending.text, pending.at)],
+    };
+    await tick();
+
+    const confirmedHost = target.querySelector<HTMLElement>('[data-message-actions-host][data-message-role="user"]');
+    expect(confirmedHost).not.toBeNull();
+    expect(Math.abs((confirmedHost?.getBoundingClientRect().height ?? 0) - pendingHeight)).toBeLessThan(1);
+  });
+
+  it('완료된 답변도 pacer가 마지막 텍스트를 마친 뒤에 footer를 표시한다', async () => {
+    const at = Date.parse('2026-09-01T00:00:00+09:00');
+    const text = '마지막 문장까지 차분하게 표시한 다음 메시지 동작을 보여 줍니다. '.repeat(3);
+    const awaiting = awaitingRequest(at);
+    const question = user('u1', 1, '질문', at);
+    const live: TurnLive = {
+      context: { agent: { id: 'agent-1', name: 'assistant' }, run: 1, turn: 1, attempt: 1 },
+      text,
+      textBroken: false,
+      thinkingChars: 0,
+      toolInput: null,
+      last: 'text',
+      seeded: false,
+    };
+    const initialTranscript: Transcript = {
+      ...emptyTranscript(),
+      messages: [awaiting, question],
+      run: 'running',
+      turn: 'active',
+      live,
+    };
+    const props = reactiveProps({
+      transcript: initialTranscript,
+      answers: [
+        {
+          key: 'a1',
+          run: { id: 'PRRN1', runSeq: 1, state: 'COMPLETED', reaction: null, reactionNote: null },
+        },
+      ] satisfies PrismAnswer[],
+      loading: false,
+      pending: null as PrismPendingMessage | null,
+      sessionId: 'PRSS1',
+      failedIds: new Set<string>(),
+      reconnecting: false,
+      policy: 'STANDARD',
+      onResolve: vi.fn().mockResolvedValue(undefined),
+      onRetry: vi.fn(),
+      onReact: vi.fn().mockResolvedValue(true),
+    });
+
+    const target = document.createElement('div');
+    Object.assign(target.style, { display: 'flex', flexDirection: 'column', height: '320px', width: '420px' });
+    document.body.append(target);
+    component = mount(PrismTranscript, { target, props: props as never });
+    await vi.waitFor(() => expect(target.querySelector('[data-role="assistant"]')).not.toBeNull());
+
+    props.transcript = {
+      ...emptyTranscript(),
+      messages: [awaiting, question, assistant('a1', text, at + 1)],
+    };
+    await tick();
+
+    const answerHost = target.querySelector('[data-message-actions-host][data-message-role="assistant"]');
+    expect(answerHost).not.toBeNull();
+    expect(answerHost?.querySelector(':scope > [data-message-actions]')).toBeNull();
+  });
+
+  it('사용자와 완료 답변의 액션·시간·반응 note를 메시지 위치와 상태에 맞게 표시한다', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    const previousYear = new Date().getFullYear() - 1;
+    const oldMessageAt = new Date(previousYear, 7, 30, 10, 0).getTime();
+
+    const messages = [
+      user('u1', 1, '첫 질문', oldMessageAt),
+      assistant('a1', '첫 답변', Date.parse('2026-08-31T10:01:00+09:00')),
+      user('u2', 2, '둘째 질문', Date.parse('2026-08-31T10:02:00+09:00')),
+      assistant('a2', '둘째 답변', Date.parse('2026-08-31T10:03:00+09:00')),
+    ];
+    const transcript: Transcript = { ...emptyTranscript(), messages };
+    const answers: PrismAnswer[] = [
+      {
+        key: 'a1',
+        run: { id: 'PRRN1', runSeq: 1, state: 'COMPLETED', reaction: 'UP', reactionNote: '도움 됐어요' },
+      },
+      {
+        key: 'a2',
+        run: { id: 'PRRN2', runSeq: 2, state: 'COMPLETED', reaction: null, reactionNote: null },
+      },
+    ];
+    const noteSubmit = Promise.withResolvers<boolean>();
+    const onReact = vi.fn(async (runId: string, reaction: 'UP' | 'DOWN' | null, note: string | null) => {
+      if (note !== null) await noteSubmit.promise;
+      props.answers = props.answers.map((answer) =>
+        answer.run.id === runId ? { ...answer, run: { ...answer.run, reaction, reactionNote: reaction === null ? null : note } } : answer,
+      );
+      await tick();
+      return true;
+    });
+    const props = reactiveProps({
+      transcript,
+      answers,
+      loading: false,
+      pending: null,
+      sessionId: 'PRSS1',
+      failedIds: new Set<string>(),
+      reconnecting: false,
+      policy: 'STANDARD',
+      onResolve: vi.fn().mockResolvedValue(undefined),
+      onRetry: vi.fn(),
+      onReact,
+    });
+
+    const target = document.createElement('div');
+    Object.assign(target.style, { display: 'flex', flexDirection: 'column', height: '640px', width: '420px' });
+    document.body.append(target);
+    component = mount(PrismTranscript, { target, props: props as never });
+    await tick();
+
+    const userHosts = [...target.querySelectorAll<HTMLElement>('[data-message-actions-host][data-message-role="user"]')];
+    const assistantHosts = [...target.querySelectorAll<HTMLElement>('[data-message-actions-host][data-message-role="assistant"]')];
+    expect(userHosts).toHaveLength(2);
+    expect(assistantHosts).toHaveLength(2);
+    const firstUserHost = userHosts[0];
+    const latestAssistantHost = assistantHosts[1];
+    if (!firstUserHost || !latestAssistantHost) return;
+
+    const userActions = userHosts[0]?.querySelector<HTMLElement>('[data-message-actions]');
+    const previousActions = assistantHosts[0]?.querySelector<HTMLElement>('[data-message-actions]');
+    const latestActions = assistantHosts[1]?.querySelector<HTMLElement>('[data-message-actions]');
+    expect(userActions).not.toBeNull();
+    expect(previousActions).not.toBeNull();
+    expect(latestActions).not.toBeNull();
+    if (!userActions || !previousActions || !latestActions) return;
+
+    expect(getComputedStyle(userActions).opacity).toBe('0');
+    expect(getComputedStyle(previousActions).opacity).toBe('0');
+    await vi.waitFor(() => expect(getComputedStyle(latestActions).opacity).toBe('1'));
+    expect(getComputedStyle(latestActions.querySelector('[data-message-time]') as Element).opacity).toBe('0');
+
+    const previousNote = assistantHosts[0]?.querySelector<HTMLElement>('[data-reaction-note-container]');
+    expect(previousNote).not.toBeNull();
+    expect(previousNote?.getBoundingClientRect().height).toBe(0);
+    await userEvent.hover(assistantHosts[0] as HTMLElement);
+    await vi.waitFor(() => expect((previousNote?.getBoundingClientRect().height ?? 0) > 0).toBe(true));
+
+    await userEvent.hover(firstUserHost);
+    await vi.waitFor(() => expect(getComputedStyle(userActions).opacity).toBe('1'));
+    const userTime = userActions.querySelector('time');
+    const userCopy = userActions.querySelector<HTMLButtonElement>('[aria-label="복사"]');
+    expect(userTime?.nextElementSibling).toBe(userCopy);
+    expect(userTime?.textContent).toContain(`${previousYear}년 8월 30일`);
+    userCopy?.click();
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith('첫 질문'));
+    await vi.waitFor(() => expect(userActions.querySelector('[aria-label="복사됨"]')).not.toBeNull());
+
+    const latestTime = latestActions.querySelector('time');
+    const latestButtons = latestActions.querySelectorAll('button');
+    expect(latestButtons).toHaveLength(3);
+    expect(latestButtons[0]?.nextElementSibling).toBe(latestButtons[1]);
+    expect(latestButtons[1]?.nextElementSibling).toBe(latestButtons[2]);
+    expect(latestButtons[2]?.nextElementSibling).toBe(latestTime);
+
+    await userEvent.hover(latestAssistantHost);
+    await vi.waitFor(() => expect(getComputedStyle(latestTime as Element).opacity).toBe('1'));
+    const down = latestActions.querySelector<HTMLButtonElement>('[aria-label="아쉬웠어요"]');
+    down?.click();
+    await tick();
+    expect(onReact).toHaveBeenLastCalledWith('PRRN2', 'DOWN', null);
+
+    const noteShell = latestAssistantHost.querySelector<HTMLElement>('[data-reaction-note]');
+    expect(noteShell).not.toBeNull();
+    expect(noteShell?.dataset.reactionNoteState).toBe('draft');
+    const note = latestAssistantHost.querySelector<HTMLTextAreaElement>('[placeholder="몇 자 덧붙이기"]');
+    expect(note).not.toBeNull();
+    if (!note) return;
+    await vi.waitFor(() => expect(document.activeElement).toBe(note));
+    await userEvent.fill(note, '조금 더 간결하면 좋아요');
+    await userEvent.keyboard('{Enter}');
+    const submit = noteShell?.querySelector<HTMLButtonElement>('[aria-label="남기는 중"]');
+    await vi.waitFor(() => expect(submit?.getAttribute('aria-busy')).toBe('true'));
+    expect(note.readOnly).toBe(true);
+    expect(submit?.querySelector('[data-reaction-note-submit-spinner]')).not.toBeNull();
+    expect(onReact).toHaveBeenLastCalledWith('PRRN2', 'DOWN', '조금 더 간결하면 좋아요');
+    noteSubmit.resolve(true);
+    await tick();
+    await vi.waitFor(() => expect(latestAssistantHost.querySelector('[data-reaction-note-state="saved"]')).not.toBeNull());
+    const savedNote = latestAssistantHost.querySelector<HTMLElement>('[data-reaction-note-state="saved"]');
+    const savedText = savedNote?.querySelector('[data-reaction-note-text]');
+    const edit = savedNote?.querySelector('[aria-label="반응 메모 수정"]');
+    expect(savedText?.textContent).toBe('조금 더 간결하면 좋아요');
+    expect(edit).not.toBeNull();
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/@prism/prism-transcript-scroll.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@prism/prism-transcript-scroll.browser.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import PrismTranscript from './PrismTranscript.svelte';
 import { reactiveProps } from './PrismTranscript.test-props.svelte.ts';
 import type { Transcript, TranscriptMessage } from '@typie/prism';
+import type { PrismPendingMessage } from './prism-chat.svelte.ts';
 
 vi.mock('$env/dynamic/public', () => ({ env: {} }));
 
@@ -38,14 +39,16 @@ describe('PRISM transcript bottom follow', () => {
     const messages = Array.from({ length: 30 }, (_, index) => userMessage(index));
     const props = reactiveProps({
       transcript: transcriptWith(messages),
+      answers: [],
       loading: false,
-      pending: null as string | null,
+      pending: null as PrismPendingMessage | null,
       sessionId: 'session-1' as string | null,
       failedIds: new Set<string>(),
       reconnecting: false,
       policy: 'STANDARD' as const,
       onResolve: vi.fn().mockResolvedValue(undefined),
       onRetry: vi.fn(),
+      onReact: vi.fn().mockResolvedValue(true),
     });
     const target = document.createElement('div');
     Object.assign(target.style, { display: 'flex', flexDirection: 'column', height: '320px', width: '360px' });

--- a/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewResult.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewResult.svelte
@@ -2,11 +2,9 @@
   import { createMutation } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
-  import { autosize } from '@typie/ui/actions';
   import { Button, Icon } from '@typie/ui/components';
   import { Toast } from '@typie/ui/notification';
   import mixpanel from 'mixpanel-browser';
-  import ArrowUpIcon from '~icons/lucide/arrow-up';
   import MessageSquareTextIcon from '~icons/lucide/message-square-text';
   import RepeatIcon from '~icons/lucide/repeat';
   import SparklesIcon from '~icons/lucide/sparkles';
@@ -16,7 +14,8 @@
   import { goto } from '$app/navigation';
   import { requestMarginJump } from '$lib/prism/margin-jump.svelte';
   import { graphql } from '$mearie';
-  import { expand, swap } from '../lib/motion.ts';
+  import { expand } from '../lib/motion.ts';
+  import PrismReactionNote from '../PrismReactionNote.svelte';
   import PrismReviewDetail from './PrismReviewDetail.svelte';
   import type { Component } from 'svelte';
   import type { ReviewRound } from './round-view.ts';
@@ -58,16 +57,6 @@
   let sending = $state(false);
   let detailOpen = $state(false);
 
-  let noteEl = $state<HTMLElement>();
-  let noteFrom = $state<number>();
-  let prevNoteMode: string | undefined;
-
-  $effect.pre(() => {
-    const mode = !editing && round.reactionNote ? 'saved' : 'draft';
-    if (prevNoteMode !== undefined && mode !== prevNoteMode) noteFrom = noteEl?.offsetHeight;
-    prevNoteMode = mode;
-  });
-
   const send = async (roundId: string, value: 'DOWN' | 'UP' | null, text: string | null) => {
     if (sending) {
       return false;
@@ -92,9 +81,13 @@
     const clearing = (round.reaction ?? null) === value;
     const ok = clearing ? await send(round.id, null, null) : await send(round.id, value, kept);
 
-    if (ok && clearing) {
-      note = '';
-      editing = false;
+    if (ok) {
+      if (clearing) {
+        note = '';
+        editing = false;
+      } else {
+        editing = kept === null;
+      }
     }
   };
 
@@ -242,97 +235,7 @@
 
   {#if reaction !== null}
     <div class={css({ marginTop: '10px' })} transition:expand>
-      <div bind:this={noteEl}>
-        {#if round.reactionNote && !editing}
-          {@const saved = round.reactionNote}
-          <div class={flex({ alignItems: 'center', gap: '8px' })} in:swap={{ box: noteEl, from: noteFrom }}>
-            <p
-              class={css({
-                flexGrow: '1',
-                minWidth: '0',
-                fontSize: '12px',
-                lineHeight: '[1.55]',
-                color: 'text.subtle',
-                whiteSpace: 'pre-wrap',
-              })}
-            >
-              {saved}
-            </p>
-            <button
-              class={css({
-                flexShrink: '0',
-                fontSize: '11px',
-                fontWeight: 'semibold',
-                color: 'text.subtle',
-                _hover: { color: 'text.default' },
-              })}
-              onclick={() => {
-                note = saved;
-                editing = true;
-              }}
-              type="button"
-            >
-              수정
-            </button>
-          </div>
-        {:else}
-          <div
-            class={flex({
-              alignItems: 'flex-end',
-              gap: '6px',
-              paddingLeft: '10px',
-              paddingRight: '4px',
-              paddingY: '4px',
-              borderWidth: '1px',
-              borderColor: 'border.default',
-              borderRadius: '8px',
-              backgroundColor: 'surface.subtle',
-            })}
-            in:swap={{ box: noteEl, from: noteFrom }}
-          >
-            <textarea
-              class={css({
-                flexGrow: '1',
-                minWidth: '0',
-                maxHeight: '120px',
-                paddingY: '3px',
-                fontSize: '12px',
-                lineHeight: '[1.5]',
-                backgroundColor: 'transparent',
-                resize: 'none',
-                outline: 'none',
-                _placeholder: { color: 'text.faint' },
-              })}
-              onkeydown={(event) => {
-                if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
-                  event.preventDefault();
-                  void saveNote();
-                }
-              }}
-              placeholder="몇 자 덧붙이기"
-              rows={1}
-              bind:value={note}
-              use:autosize={{ value: note }}></textarea>
-            <button
-              class={flex({
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: '0',
-                size: '22px',
-                borderRadius: 'full',
-                backgroundColor: 'surface.dark',
-                color: 'text.bright',
-              })}
-              aria-label="남기기"
-              disabled={sending}
-              onclick={() => void saveNote()}
-              type="button"
-            >
-              <Icon icon={ArrowUpIcon} size={10} />
-            </button>
-          </div>
-        {/if}
-      </div>
+      <PrismReactionNote onSubmit={() => void saveNote()} savedNote={round.reactionNote ?? null} {sending} bind:editing bind:draft={note} />
     </div>
   {/if}
 </div>


### PR DESCRIPTION
- 사용자 메시지에 복사와 작성 시간을, 완료된 프리즘 답변에 복사·반응·작성 시간을 추가했습니다.
- 마지막 답변의 액션은 항상 표시하고, 이전 답변의 액션과 작성 시간은 메시지 hover 또는 focus 시 표시합니다.
- 프리즘 run과 반응 상태를 대화 transcript에 연결하고, 좋아요·아쉬워요 반응에 메모를 추가하거나 수정할 수 있게 했습니다.
- 챗과 리뷰에서 반응 메모 UI를 공유하도록 정리했습니다.
- optimistic 사용자 메시지부터 동일한 footer 공간을 사용하고, 답변 pacer가 마지막 텍스트를 표시한 뒤 footer가 나타나도록 했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>