### PR TITLE
사이드바 트리 sticky header 디버그

### DIFF
--- a/apps/website/src/lib/scrollbar.browser.test.ts
+++ b/apps/website/src/lib/scrollbar.browser.test.ts
@@ -40,7 +40,7 @@ const wheel = (target: HTMLElement, init: WheelEventInit) => {
   return event;
 };
 
-const mountFixture = async (orientation: Orientation, size: Size) => {
+const mountFixture = async (orientation: Orientation, size: Size, trackInsetStart?: number) => {
   const layout = {
     horizontal: {
       wrapper: 'width:240px;height:64px',
@@ -77,6 +77,7 @@ const mountFixture = async (orientation: Orientation, size: Size) => {
         orientation,
         scrollContainer: container,
         size,
+        trackInsetStart,
       },
     }),
   );
@@ -135,6 +136,25 @@ describe('shared custom scrollbar', () => {
     await frame();
     expect(vertical.container.scrollTop).toBeGreaterThan(0);
     expect(vertical.container.scrollLeft).toBe(0);
+  });
+
+  it('starts the track after its logical start inset', async () => {
+    const horizontal = await mountFixture('horizontal', 'sm', 24);
+    const vertical = await mountFixture('vertical', 'md', 36);
+
+    const horizontalWrapperBounds = horizontal.wrapper.getBoundingClientRect();
+    const horizontalTrackBounds = horizontal.track.getBoundingClientRect();
+    const verticalWrapperBounds = vertical.wrapper.getBoundingClientRect();
+    const verticalTrackBounds = vertical.track.getBoundingClientRect();
+
+    expect(horizontalTrackBounds.left - horizontalWrapperBounds.left).toBeCloseTo(24, 0);
+    expect(horizontalTrackBounds.width).toBeCloseTo(horizontalWrapperBounds.width - 24, 0);
+    expect(verticalTrackBounds.top - verticalWrapperBounds.top).toBeCloseTo(36, 0);
+    expect(verticalTrackBounds.height).toBeCloseTo(verticalWrapperBounds.height - 36, 0);
+
+    drag(vertical.thumb, 0, verticalTrackBounds.height);
+    await frame();
+    expect(vertical.container.scrollTop).toBe(vertical.container.scrollHeight - vertical.container.clientHeight);
   });
 
   it('removes the control when its container no longer overflows', async () => {

--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
@@ -953,7 +953,8 @@
   bind:this={tree}
   class={flex({
     flexDirection: 'column',
-    minHeight: 'full',
+    flexGrow: '1',
+    flexShrink: '0',
     paddingX: '12px',
     paddingY: '4px',
     userSelect: 'none',

--- a/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
@@ -317,6 +317,7 @@
 
   let treeScrollEl = $state<HTMLDivElement>();
   const treeScrollId = 'sidebar-entity-tree-scroll';
+  let treeSectionHeaderHeight = $state(0);
   let canScrollUp = $state(false);
   let canScrollDown = $state(false);
 
@@ -698,7 +699,8 @@
         <div
           bind:this={treeScrollEl}
           id={treeScrollId}
-          class={css({
+          class={flex({
+            flexDirection: 'column',
             height: 'full',
             overflowY: 'auto',
             overflowX: 'hidden',
@@ -715,6 +717,7 @@
               position: 'sticky',
               top: '0',
               zIndex: '1',
+              flexShrink: '0',
               justifyContent: 'space-between',
               alignItems: 'center',
               paddingX: '12px',
@@ -725,6 +728,7 @@
               borderColor: 'border.subtle',
               transition: '[border-width 150ms ease]',
             })}
+            bind:offsetHeight={treeSectionHeaderHeight}
           >
             <span class={css({ paddingX: '8px', fontSize: '13px', fontWeight: 'semibold', color: 'text.faint' })}>글</span>
 
@@ -806,7 +810,14 @@
           <EntityTree site$key={site} />
         </div>
 
-        <Scrollbar controls={treeScrollId} label="트리 세로 스크롤" orientation="vertical" scrollContainer={treeScrollEl} size="md" />
+        <Scrollbar
+          controls={treeScrollId}
+          label="트리 세로 스크롤"
+          orientation="vertical"
+          scrollContainer={treeScrollEl}
+          size="md"
+          trackInsetStart={treeSectionHeaderHeight}
+        />
       </div>
     </div>
 

--- a/packages/ui/src/components/Scrollbar.svelte
+++ b/packages/ui/src/components/Scrollbar.svelte
@@ -40,6 +40,7 @@
     orientation: Orientation;
     scrollContainer: HTMLElement | undefined;
     size: ScrollbarSize;
+    trackInsetStart?: number;
   };
 
   type Metrics = {
@@ -55,7 +56,7 @@
     thumbTravel: number;
   };
 
-  let { controls, label, orientation, scrollContainer, size }: Props = $props();
+  let { controls, label, orientation, scrollContainer, size, trackInsetStart = 0 }: Props = $props();
 
   let metrics = $state<Metrics>({ contentSize: 0, scrollPosition: 0, viewportSize: 0 });
   let transientVisible = $state(false);
@@ -70,7 +71,7 @@
 
   const geometry = $derived.by(() => {
     const maxScroll = Math.max(0, metrics.contentSize - metrics.viewportSize);
-    const trackSize = Math.max(0, metrics.viewportSize - TRACK_PADDING * 2);
+    const trackSize = Math.max(0, metrics.viewportSize - trackInsetStart - TRACK_PADDING * 2);
     const canScroll = scrollContainer !== undefined && maxScroll > 0 && trackSize > 0;
     const idealThumbSize = metrics.contentSize > 0 ? (metrics.viewportSize / metrics.contentSize) * trackSize : trackSize;
     const thumbSize = Math.min(trackSize, Math.max(MIN_THUMB_SIZE, idealThumbSize));
@@ -215,10 +216,10 @@
 
 {#if geometry.canScroll}
   <div
-    style:top={vertical ? '0' : undefined}
+    style:top={vertical ? `${trackInsetStart}px` : undefined}
     style:right="0"
     style:bottom="0"
-    style:left={vertical ? undefined : '0'}
+    style:left={vertical ? undefined : `${trackInsetStart}px`}
     style:width={vertical ? `${dimensions.hitLane}px` : undefined}
     style:height={vertical ? undefined : `${dimensions.hitLane}px`}
     style:opacity={visible ? 1 : 0}


### PR DESCRIPTION
## 문제

사이드바의 문서 트리가 충분히 짧아도 sticky 헤더 높이만큼 불필요한 overflow가 생겨 스크롤바가 표시됐습니다.

스크롤이 필요한 경우에도 커스텀 스크롤바의 트랙과 드래그 영역이 sticky 헤더까지 차지해, 섹션 헤더 위에 스크롤바가 겹쳐 보였습니다.

## 변경 사항

- 문서 트리가 헤더를 제외한 남은 공간을 채우도록 레이아웃을 조정했습니다.
- sticky 헤더의 실제 높이를 기준으로 스크롤바 트랙이 헤더 아래에서 시작하도록 했습니다.
- 공용 `Scrollbar`에 트랙 시작 여백을 지정할 수 있는 옵션을 추가했습니다.
- 트랙 여백이 thumb 크기와 이동 거리, 드래그 좌표 계산에도 일관되게 반영되도록 했습니다.
- 가로·세로 스크롤바의 트랙 위치와 끝 지점 드래그 동작을 브라우저 테스트로 검증했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>