### PR TITLE
웹 스크롤 포그 및 smootherstep 공용화

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ui/EditorContextBar.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorContextBar.svelte
@@ -4,6 +4,7 @@
   import { hoverIntent } from '@typie/ui/actions';
   import { VerticalDivider } from '@typie/ui/components';
   import { prefersReducedMotion } from '@typie/ui/state';
+  import { smootherstep } from '@typie/ui/utils';
   import { untrack } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
   import {
@@ -11,7 +12,6 @@
     CONTEXT_BAR_FADE_OUT_MS,
     CONTEXT_BAR_TRANSIENT_VISIBLE_MS,
     ContextBarVisibilityCoordinator,
-    smootherstep,
   } from './editor-context-bar.svelte';
   import EditorContextBarPinControl from './EditorContextBarPinControl.svelte';
   import EditorContextBarSegment from './EditorContextBarSegment.svelte';

--- a/apps/website/src/lib/editor-ffi/components/ui/HorizontalScrollLane.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/HorizontalScrollLane.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
+  import { scrollFog } from '@typie/ui/actions';
   import { Scrollbar } from '@typie/ui/components';
-  import { prefersReducedMotion } from '@typie/ui/state';
   import { tick, untrack } from 'svelte';
-  import { smootherstep } from './editor-context-bar.svelte';
   import type { Snippet } from 'svelte';
 
   type Metrics = {
@@ -21,35 +20,16 @@
     viewportName: string;
   };
 
-  const FOG_WIDTH = 24;
-  const FOG_SAMPLES = 6;
-  const FOG_TRANSITION_MS = 160;
   const AT_END_EPSILON = 1;
 
   let { alignment = 'start', children, contentIdentity, label, onContentChange, viewportId, viewportName }: Props = $props();
   let viewport = $state<HTMLElement>();
   let content = $state<HTMLElement>();
   let metrics = $state<Metrics>({ viewportWidth: 0, contentWidth: 0 });
-  let overflowLeading = $state(false);
-  let overflowTrailing = $state(false);
   let pendingAlignment = true;
   let lastContentIdentity: string | undefined;
   let contentRevision = 0;
-  let fogTransitionReady = $state(false);
-  let fogTransitionFrame: number | undefined;
   let alignmentFrame: number | undefined;
-
-  const leadingMaskStops = Array.from({ length: FOG_SAMPLES + 1 }, (_, index) => {
-    const progress = index / FOG_SAMPLES;
-    const alphaGain = smootherstep(progress);
-    return `rgb(0 0 0 / calc(1 - var(--horizontal-scroll-leading-fog) * ${1 - alphaGain})) ${(index / FOG_SAMPLES) * FOG_WIDTH}px`;
-  });
-  const trailingMaskStops = Array.from({ length: FOG_SAMPLES + 1 }, (_, index) => {
-    const offset = (index / FOG_SAMPLES) * FOG_WIDTH;
-    const alphaLoss = smootherstep(index / FOG_SAMPLES);
-    return `rgb(0 0 0 / calc(1 - var(--horizontal-scroll-trailing-fog) * ${alphaLoss})) calc(100% - ${FOG_WIDTH - offset}px)`;
-  });
-  const maskImage = `linear-gradient(to right, ${leadingMaskStops.join(', ')}, black ${FOG_WIDTH}px, black calc(100% - ${FOG_WIDTH}px), ${trailingMaskStops.join(', ')})`;
 
   function maximumScroll() {
     if (!viewport) return 0;
@@ -60,23 +40,6 @@
     return alignment === 'end' ? maximum : 0;
   }
 
-  function updateOverflow() {
-    if (!viewport) return;
-    const maximum = maximumScroll();
-    overflowLeading = viewport.scrollLeft > AT_END_EPSILON;
-    overflowTrailing = viewport.scrollLeft < maximum - AT_END_EPSILON;
-  }
-
-  function enableFogTransitions() {
-    if (fogTransitionReady || fogTransitionFrame !== undefined) return;
-    fogTransitionFrame = requestAnimationFrame(() => {
-      fogTransitionFrame = requestAnimationFrame(() => {
-        fogTransitionFrame = undefined;
-        fogTransitionReady = true;
-      });
-    });
-  }
-
   function finishAlignment() {
     if (alignmentFrame !== undefined) return;
     alignmentFrame = requestAnimationFrame(() => {
@@ -84,7 +47,6 @@
       if (!pendingAlignment || !viewport) return;
       viewport.scrollLeft = alignedPosition(maximumScroll());
       pendingAlignment = false;
-      updateOverflow();
     });
   }
 
@@ -97,7 +59,6 @@
     };
     if (nextMetrics.viewportWidth <= 0 || nextMetrics.contentWidth <= 0) {
       metrics = nextMetrics;
-      updateOverflow();
       return;
     }
 
@@ -122,9 +83,6 @@
     } else {
       viewport.scrollLeft = Math.min(previousPosition, nextMaximum);
     }
-
-    updateOverflow();
-    enableFogTransitions();
   }
 
   $effect(() => {
@@ -155,7 +113,6 @@
 
   $effect(() => {
     return () => {
-      if (fogTransitionFrame !== undefined) cancelAnimationFrame(fogTransitionFrame);
       if (alignmentFrame !== undefined) cancelAnimationFrame(alignmentFrame);
     };
   });
@@ -165,18 +122,9 @@
   <div
     bind:this={viewport}
     id={viewportId}
-    style:mask-image={maskImage}
-    style:--horizontal-scroll-leading-fog={overflowLeading ? 1 : 0}
-    style:--horizontal-scroll-trailing-fog={overflowTrailing ? 1 : 0}
-    style:transition={fogTransitionReady && !prefersReducedMotion.current
-      ? `--horizontal-scroll-leading-fog ${FOG_TRANSITION_MS}ms ease-out, --horizontal-scroll-trailing-fog ${FOG_TRANSITION_MS}ms ease-out`
-      : 'none'}
     class={css({ width: 'full', height: 'full', minWidth: '0', overflowX: 'auto', overflowY: 'hidden', scrollbarWidth: 'none' })}
-    data-horizontal-scroll-fog-curve="smootherstep"
-    data-horizontal-scroll-fog-leading={overflowLeading}
-    data-horizontal-scroll-fog-trailing={overflowTrailing}
     data-horizontal-scroll-viewport={viewportName}
-    onscroll={updateOverflow}
+    use:scrollFog={{ orientation: 'horizontal' }}
   >
     <div bind:this={content} class={css({ display: 'inline-flex', alignItems: 'center', minWidth: '[max-content]', height: 'full' })}>
       {@render children()}
@@ -185,17 +133,3 @@
 
   <Scrollbar controls={viewportId} {label} orientation="horizontal" scrollContainer={viewport} size="sm" />
 </div>
-
-<style>
-  @property --horizontal-scroll-leading-fog {
-    syntax: '<number>';
-    inherits: false;
-    initial-value: 0;
-  }
-
-  @property --horizontal-scroll-trailing-fog {
-    syntax: '<number>';
-    inherits: false;
-    initial-value: 0;
-  }
-</style>

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.browser.test.ts
@@ -760,37 +760,15 @@ describe('editor context bar', () => {
     expect(breadcrumbViewport.scrollLeft).toBe(0);
   });
 
-  it('derives both scroll fogs from native position without masking the fixed pin and divider', async () => {
+  it('keeps the fixed pin and divider outside the breadcrumb scroll fog', async () => {
     const { breadcrumbViewport } = await mountContextBar({ surfaceWidth: 320, breadcrumbWidth: 600 });
     await vi.waitFor(() => expect(breadcrumbViewport.scrollLeft).toBeGreaterThan(0));
     const pin = document.querySelector<HTMLElement>('[data-context-bar-pin]');
     const divider = document.querySelector<HTMLElement>('[data-context-bar-pin-divider]');
 
-    expect(breadcrumbViewport.dataset.horizontalScrollFogLeading).toBe('true');
-    expect(breadcrumbViewport.style.getPropertyValue('--horizontal-scroll-leading-fog')).toBe('1');
-    expect(breadcrumbViewport.dataset.horizontalScrollFogTrailing).toBe('false');
-    expect(breadcrumbViewport.dataset.horizontalScrollFogCurve).toBe('smootherstep');
+    expect(breadcrumbViewport.style.maskImage).not.toBe('');
     expect(breadcrumbViewport.contains(pin)).toBe(false);
     expect(breadcrumbViewport.contains(divider)).toBe(false);
-
-    breadcrumbViewport.scrollLeft = 0;
-    breadcrumbViewport.dispatchEvent(new Event('scroll'));
-    await tick();
-    expect(breadcrumbViewport.dataset.horizontalScrollFogLeading).toBe('false');
-    expect(breadcrumbViewport.dataset.horizontalScrollFogTrailing).toBe('true');
-
-    breadcrumbViewport.scrollLeft = 40;
-    breadcrumbViewport.dispatchEvent(new Event('scroll'));
-    await tick();
-    expect(breadcrumbViewport.dataset.horizontalScrollFogLeading).toBe('true');
-    expect(breadcrumbViewport.dataset.horizontalScrollFogTrailing).toBe('true');
-
-    reducedMotionPreference.set(true);
-    breadcrumbViewport.scrollLeft = 0;
-    breadcrumbViewport.dispatchEvent(new Event('scroll'));
-    await tick();
-    expect(breadcrumbViewport.dataset.horizontalScrollFogLeading).toBe('false');
-    expect(breadcrumbViewport.style.transition).toBe('none');
   });
 });
 

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.svelte.ts
@@ -26,13 +26,6 @@ export type ContextBarPresentation = {
   viewControls: ContextBarSegmentPresentation;
 };
 
-const clampUnit = (value: number): number => Math.min(1, Math.max(0, value));
-
-export function smootherstep(value: number): number {
-  const x = clampUnit(value);
-  return x * x * x * (x * (x * 6 - 15) + 10);
-}
-
 export function resolveContextBarSegmentRequest(activity: ContextBarSegmentActivity): ContextBarSegmentPresentation {
   const engaged = activity.hovered || activity.focused;
   return {

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ContextBarVisibilityCoordinator, resolveContextBarSegmentRequest, smootherstep } from './editor-context-bar.svelte';
+import { ContextBarVisibilityCoordinator, resolveContextBarSegmentRequest } from './editor-context-bar.svelte';
 import type { ContextBarSegmentActivity } from './editor-context-bar.svelte';
 
 const idle = (): ContextBarSegmentActivity => ({ transient: false, hovered: false, focused: false, holds: [] });
@@ -7,16 +7,6 @@ const idle = (): ContextBarSegmentActivity => ({ transient: false, hovered: fals
 const transient = (): ContextBarSegmentActivity => ({ ...idle(), transient: true });
 
 const engaged = (): ContextBarSegmentActivity => ({ ...idle(), hovered: true });
-
-describe('editor context bar surface', () => {
-  it('uses smootherstep for surface fades', () => {
-    expect(smootherstep(0)).toBe(0);
-    expect(smootherstep(0.25)).toBeCloseTo(0.103515625);
-    expect(smootherstep(0.5)).toBe(0.5);
-    expect(smootherstep(0.75)).toBeCloseTo(0.896484375);
-    expect(smootherstep(1)).toBe(1);
-  });
-});
 
 describe('editor context bar visibility', () => {
   it('counts transient, engagement, and named holds as visibility reasons', () => {

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismToolCalls.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismToolCalls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
+  import { scrollFog } from '@typie/ui/actions';
   import { Icon } from '@typie/ui/components';
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import { expand } from './lib/motion.ts';
@@ -10,49 +11,11 @@
   let { count, rows }: Props = $props();
 
   let open = $state(false);
-  let list = $state<HTMLElement>();
-  let fogTop = $state(false);
-  let fogBottom = $state(false);
-
-  const updateFog = () => {
-    if (!list) return;
-    fogTop = list.scrollTop > 1;
-    fogBottom = list.scrollTop + list.clientHeight < list.scrollHeight - 1;
-  };
-
-  $effect(() => {
-    void list;
-    updateFog();
-  });
 
   const toggleClass = css({ display: 'inline-flex', alignItems: 'center', gap: '4px', fontSize: '12px', color: 'text.faint' });
   const chevronStyle = css.raw({ transition: '[transform 150ms cubic-bezier(0.23, 1, 0.32, 1)]', _motionReduce: { transition: '[none]' } });
   const chevronOpenStyle = css.raw({ transform: 'rotate(180deg)' });
-  const listWrapStyle = css.raw({ position: 'relative', marginTop: '6px' });
-  const fogTopStyle = css.raw({
-    _before: {
-      content: '""',
-      position: 'absolute',
-      left: '0',
-      right: '0',
-      top: '0',
-      height: '16px',
-      backgroundImage: '[linear-gradient(to bottom, token(colors.surface.default), transparent)]',
-      pointerEvents: 'none',
-    },
-  });
-  const fogBottomStyle = css.raw({
-    _after: {
-      content: '""',
-      position: 'absolute',
-      left: '0',
-      right: '0',
-      bottom: '0',
-      height: '16px',
-      backgroundImage: '[linear-gradient(to bottom, transparent, token(colors.surface.default))]',
-      pointerEvents: 'none',
-    },
-  });
+  const listWrapClass = css({ marginTop: '6px' });
   const listClass = css({
     paddingLeft: '10px',
     borderLeftWidth: '2px',
@@ -78,8 +41,8 @@
       <Icon style={css.raw(chevronStyle, open ? chevronOpenStyle : {})} icon={ChevronDownIcon} size={10} />
     </button>
     {#if open}
-      <div class={css(listWrapStyle, fogTop ? fogTopStyle : {}, fogBottom ? fogBottomStyle : {})} transition:expand>
-        <div bind:this={list} class={listClass} onscroll={updateFog}>
+      <div class={listWrapClass} transition:expand>
+        <div class={listClass} use:scrollFog={{ orientation: 'vertical', size: 16 }}>
           {#each rows as entry, index (index)}
             <div class={rowClass}>
               {entry.label}{#if entry.count > 1}<span class={css({ marginLeft: '4px', color: 'text.disabled' })}>×{entry.count}</span>{/if}

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismTranscript.svelte
@@ -3,6 +3,7 @@
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { token } from '@typie/styled-system/tokens';
+  import { scrollFog } from '@typie/ui/actions';
   import { Icon, Scrollbar } from '@typie/ui/components';
   import { tick, untrack } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
@@ -369,19 +370,10 @@
     }
 
     lastTop = element.scrollTop;
-    updateOverflow();
   };
 
   let content = $state<HTMLElement>();
   const transcriptScrollId = 'prism-transcript-scroll';
-  let overflowTop = $state(false);
-  let overflowBottom = $state(false);
-
-  const updateOverflow = () => {
-    if (!container) return;
-    overflowTop = container.scrollTop > 1;
-    overflowBottom = container.scrollTop + container.clientHeight < container.scrollHeight - 1;
-  };
 
   $effect(() => {
     const scroller = container;
@@ -390,7 +382,6 @@
       if (follow) {
         chaseBottom(scroller);
       }
-      updateOverflow();
     });
     observer.observe(scroller);
     observer.observe(content);
@@ -460,20 +451,12 @@
     const id = setTimeout(() => (waitText = next), WAIT_DEBOUNCE_MS);
     return () => clearTimeout(id);
   });
-
-  const maskImage = $derived.by(() => {
-    if (!overflowTop && !overflowBottom) return;
-    const from = overflowTop ? 'transparent, black 24px' : 'black, black 24px';
-    const to = overflowBottom ? 'black calc(100% - 24px), transparent' : 'black calc(100% - 24px), black';
-    return `linear-gradient(to bottom, ${from}, ${to})`;
-  });
 </script>
 
 <div class={flex({ position: 'relative', flexDirection: 'column', flexGrow: '1', minHeight: '0' })}>
   <div
     bind:this={container}
     id={transcriptScrollId}
-    style:mask-image={maskImage}
     class={flex({
       flexDirection: 'column',
       flexGrow: '1',
@@ -485,6 +468,7 @@
       paddingBottom: '40px',
     })}
     onscroll={onScroll}
+    use:scrollFog={{ orientation: 'vertical' }}
   >
     {#key loading}
       <div bind:this={content} class={contentClass} in:fade={{ ...fadeIn, duration: loading ? 0 : 200 }}>

--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityName.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityName.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
-  import { hoverIntent } from '@typie/ui/actions';
+  import { hoverIntent, scrollFog } from '@typie/ui/actions';
   import { prefersReducedMotion as reducedMotionPreference } from '@typie/ui/state';
   import { onDestroy, onMount } from 'svelte';
   import { advanceEntityNameMotion } from './entity-name-motion';
@@ -12,30 +12,18 @@
 
   let { name, active = false }: Props = $props();
 
-  const FOG_WIDTH = 24;
-  const FOG_TRANSITION_DURATION = 160;
   const HOVER_DELAY = 400;
 
   let viewport = $state<HTMLSpanElement>();
   let viewportWidth = $state(0);
   let contentWidth = $state(0);
-  let overflowLeft = $state(false);
-  let overflowRight = $state(false);
-  let fogTransitionReady = $state(false);
   const prefersReducedMotion = $derived(reducedMotionPreference.current);
   let animationFrame: number | undefined;
-  let fogTransitionFrame: number | undefined;
-  let fogTransitionScheduled = false;
   let hovered = false;
   let hoverReady = $state(false);
   let motionPosition = 0;
   let motionVelocity = 0;
   let previousFrameTime: number | undefined;
-
-  const updateOverflow = () => {
-    overflowLeft = (viewport?.scrollLeft ?? 0) > 1;
-    overflowRight = viewport ? viewport.scrollLeft + viewport.clientWidth < viewport.scrollWidth - 1 : false;
-  };
 
   const cancelAnimation = () => {
     if (animationFrame !== undefined) {
@@ -50,14 +38,12 @@
     cancelAnimation();
     motionPosition = position;
     element.scrollLeft = position;
-    updateOverflow();
   };
 
   const reset = () => {
     cancelAnimation();
     motionPosition = 0;
     if (viewport) viewport.scrollLeft = 0;
-    updateOverflow();
   };
 
   const startMotion = () => {
@@ -89,7 +75,6 @@
       motionPosition = next.position;
       element.scrollLeft = next.position;
       motionVelocity = next.velocity;
-      updateOverflow();
 
       if (next.position < maximum) {
         animationFrame = window.requestAnimationFrame(advance);
@@ -102,8 +87,6 @@
     animationFrame = window.requestAnimationFrame(advance);
   };
 
-  const maskImage = `linear-gradient(to right, rgb(0 0 0 / var(--entity-name-leading-mask-alpha)), black ${FOG_WIDTH}px, black calc(100% - ${FOG_WIDTH}px), rgb(0 0 0 / var(--entity-name-trailing-mask-alpha)))`;
-
   $effect(() => {
     void name;
     reset();
@@ -113,18 +96,7 @@
   $effect(() => {
     void viewportWidth;
     void contentWidth;
-    updateOverflow();
     if (hoverReady) startMotion();
-
-    if (!fogTransitionScheduled && viewportWidth > 0 && contentWidth > 0) {
-      fogTransitionScheduled = true;
-      fogTransitionFrame = window.requestAnimationFrame(() => {
-        fogTransitionFrame = window.requestAnimationFrame(() => {
-          fogTransitionFrame = undefined;
-          fogTransitionReady = true;
-        });
-      });
-    }
   });
 
   $effect(() => {
@@ -151,10 +123,7 @@
           },
         })
       : undefined;
-    updateOverflow();
-
     return () => {
-      if (fogTransitionFrame !== undefined) window.cancelAnimationFrame(fogTransitionFrame);
       hoverIntentAction?.destroy?.();
     };
   });
@@ -164,12 +133,6 @@
 
 <span
   bind:this={viewport}
-  style:mask-image={maskImage}
-  style:--entity-name-leading-mask-alpha={overflowLeft ? 0 : 1}
-  style:--entity-name-trailing-mask-alpha={overflowRight ? 0 : 1}
-  style:transition={fogTransitionReady && !prefersReducedMotion
-    ? `--entity-name-leading-mask-alpha ${FOG_TRANSITION_DURATION}ms ease-in-out, --entity-name-trailing-mask-alpha ${FOG_TRANSITION_DURATION}ms ease-in-out`
-    : 'none'}
   class={css(
     {
       display: 'block',
@@ -186,22 +149,8 @@
     },
     active && { fontWeight: 'bold', color: 'text.default' },
   )}
-  onscroll={updateOverflow}
   bind:clientWidth={viewportWidth}
+  use:scrollFog={{ orientation: 'horizontal' }}
 >
   <span class={css({ display: 'inline-block' })} bind:offsetWidth={contentWidth}>{name}</span>
 </span>
-
-<style>
-  @property --entity-name-leading-mask-alpha {
-    syntax: '<number>';
-    inherits: false;
-    initial-value: 1;
-  }
-
-  @property --entity-name-trailing-mask-alpha {
-    syntax: '<number>';
-    inherits: false;
-    initial-value: 1;
-  }
-</style>

--- a/apps/website/src/routes/website/(dashboard)/@tree/entity-name.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@tree/entity-name.browser.test.ts
@@ -13,8 +13,6 @@ const frames = async (count = 2) => {
 };
 
 const wait = (duration: number) => new Promise<void>((resolve) => setTimeout(resolve, duration));
-const maskAlpha = (element: HTMLElement, edge: 'leading' | 'trailing') =>
-  Number(getComputedStyle(element).getPropertyValue(`--entity-name-${edge}-mask-alpha`));
 
 const reducedMotionPreference = vi.hoisted(() => {
   const eventTarget = new EventTarget();
@@ -107,42 +105,11 @@ describe('entity tree name overflow', () => {
     const { target, viewport } = await mountName('짧은 이름', 320);
 
     expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth);
-    expect(viewport.style.maskImage).toContain('24px');
-    expect(maskAlpha(viewport, 'leading')).toBe(1);
-    expect(maskAlpha(viewport, 'trailing')).toBe(1);
 
     enter(target);
     await wait(400);
 
     expect(viewport.scrollLeft).toBe(0);
-    expect(maskAlpha(viewport, 'leading')).toBe(1);
-    expect(maskAlpha(viewport, 'trailing')).toBe(1);
-  });
-
-  it('waits for the first usable measurement before enabling fog transitions', async () => {
-    mockReducedMotion(false);
-    const target = document.createElement('div');
-    target.className = 'group';
-    target.setAttribute('role', 'treeitem');
-    Object.assign(target.style, { display: 'none', width: '120px' });
-    document.body.append(target);
-
-    component = mount(EntityName, { target, props: { name: '처음 열릴 때부터 긴 폴더 이름' } });
-    await tick();
-    await frames(3);
-
-    const viewport = target.firstElementChild;
-    expect(viewport).toBeInstanceOf(HTMLSpanElement);
-    if (!(viewport instanceof HTMLSpanElement)) throw new Error('EntityName did not render its viewport span');
-
-    expect(viewport.clientWidth).toBe(0);
-    expect(viewport.style.transition).toBe('none');
-
-    target.style.display = 'flex';
-    await vi.waitFor(() => expect(viewport.clientWidth).toBeGreaterThan(0));
-    await frames(3);
-
-    expect(viewport.style.transition).toContain('--entity-name-leading-mask-alpha');
   });
 
   it('scrolls an overflowing name to the end once and resets when the pointer leaves', async () => {
@@ -156,9 +123,6 @@ describe('entity tree name overflow', () => {
     expect(initialMaximumScrollLeft).toBeGreaterThanOrEqual(20);
     expect(initialMaximumScrollLeft).toBeLessThanOrEqual(28);
     expect(viewport.scrollLeft).toBe(0);
-    expect(viewport.style.maskImage).toContain('24px');
-    expect(maskAlpha(viewport, 'leading')).toBe(1);
-    await vi.waitFor(() => expect(maskAlpha(viewport, 'trailing')).toBeCloseTo(0, 1));
 
     enter(target);
     await wait(100);
@@ -172,8 +136,6 @@ describe('entity tree name overflow', () => {
     expect(viewport.scrollLeft).toBe(0);
 
     await vi.waitFor(() => expect(viewport.scrollLeft).toBeCloseTo(maximumScrollLeft, 0), { timeout: 2500 });
-    await vi.waitFor(() => expect(maskAlpha(viewport, 'leading')).toBeCloseTo(0, 1));
-    await vi.waitFor(() => expect(maskAlpha(viewport, 'trailing')).toBeCloseTo(1, 1));
 
     const settledScrollLeft = viewport.scrollLeft;
     await wait(150);
@@ -181,8 +143,6 @@ describe('entity tree name overflow', () => {
 
     leave(target);
     expect(viewport.scrollLeft).toBe(0);
-    await vi.waitFor(() => expect(maskAlpha(viewport, 'leading')).toBeCloseTo(1, 1));
-    await vi.waitFor(() => expect(maskAlpha(viewport, 'trailing')).toBeCloseTo(0, 1));
   });
 
   it('keeps the original hover-intent deadline when its width changes', async () => {
@@ -231,36 +191,6 @@ describe('entity tree name overflow', () => {
     await vi.waitFor(() => expect(viewport.scrollLeft).toBeCloseTo(resizedMaximumScrollLeft, 0), { timeout: 1500 });
   });
 
-  it('transitions the fixed-width fog as content enters and leaves each edge', async () => {
-    mockReducedMotion(false);
-    const { target, viewport, content } = await mountName('Reorder mutation 동기화 구조 검토 및 후속 작업 정리', 360);
-
-    target.style.width = `${content.scrollWidth - 40}px`;
-    await frames();
-    await wait(220);
-
-    expect(maskAlpha(viewport, 'leading')).toBe(1);
-    expect(maskAlpha(viewport, 'trailing')).toBe(0);
-
-    viewport.scrollLeft = 12;
-    viewport.dispatchEvent(new Event('scroll'));
-    await tick();
-    await wait(80);
-    expect(maskAlpha(viewport, 'leading')).toBeGreaterThan(0);
-    expect(maskAlpha(viewport, 'leading')).toBeLessThan(1);
-    await wait(120);
-    expect(maskAlpha(viewport, 'leading')).toBeCloseTo(0, 1);
-
-    viewport.scrollLeft = viewport.scrollWidth - viewport.clientWidth;
-    viewport.dispatchEvent(new Event('scroll'));
-    await tick();
-    await wait(80);
-    expect(maskAlpha(viewport, 'trailing')).toBeGreaterThan(0);
-    expect(maskAlpha(viewport, 'trailing')).toBeLessThan(1);
-    await wait(120);
-    expect(maskAlpha(viewport, 'trailing')).toBeCloseTo(1, 1);
-  });
-
   it('reveals the end directly when reduced motion is requested', async () => {
     mockReducedMotion(true);
     const { target, viewport, content } = await mountName('Reorder mutation 동기화 구조 검토 및 후속 작업 정리', 360);
@@ -269,8 +199,6 @@ describe('entity tree name overflow', () => {
     await frames();
 
     const maximumScrollLeft = viewport.scrollWidth - viewport.clientWidth;
-    expect(viewport.style.transition).toBe('none');
-
     vi.useFakeTimers();
     enter(target);
     await vi.advanceTimersByTimeAsync(199);
@@ -278,8 +206,6 @@ describe('entity tree name overflow', () => {
 
     await vi.advanceTimersByTimeAsync(1);
     expect(viewport.scrollLeft).toBeCloseTo(maximumScrollLeft, 0);
-    expect(maskAlpha(viewport, 'leading')).toBe(0);
-    expect(maskAlpha(viewport, 'trailing')).toBe(1);
   });
 
   it('finishes an active pass immediately when reduced motion is enabled', async () => {
@@ -301,8 +227,5 @@ describe('entity tree name overflow', () => {
     await frames();
 
     expect(viewport.scrollLeft).toBeCloseTo(maximumScrollLeft, 0);
-    expect(viewport.style.transition).toBe('none');
-    expect(maskAlpha(viewport, 'leading')).toBe(0);
-    expect(maskAlpha(viewport, 'trailing')).toBe(1);
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
@@ -2,7 +2,7 @@
   import { createFragment, createMutation } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { center, flex } from '@typie/styled-system/patterns';
-  import { pointerCapture, tooltip } from '@typie/ui/actions';
+  import { pointerCapture, scrollFog, tooltip } from '@typie/ui/actions';
   import { Icon, ProgressRing, Scrollbar } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
   import { clamp } from '@typie/ui/utils';
@@ -261,15 +261,12 @@
   let navigationScrollEl = $state<HTMLDivElement>();
   let navigationIntrinsicHeight = $state(0);
   let navigationMinimumContentHeight = $state(0);
-  let navigationViewportClientHeight = $state(0);
-  let navigationScrollTop = $state(0);
   let navigationClipPreview = $state<number | null>(null);
   const navigationScrollId = 'sidebar-primary-navigation-scroll';
-  const NAVIGATION_SCROLL_FOG_SIZE = 16;
-  const NAVIGATION_MINIMUM_SCROLL_FOG_SIZE = 8;
+  const NAVIGATION_SCROLL_FOG_SIZE = 8;
 
   const navigationMinimumHeight = $derived(
-    Math.min(navigationMinimumContentHeight + NAVIGATION_MINIMUM_SCROLL_FOG_SIZE, navigationIntrinsicHeight),
+    Math.min(navigationMinimumContentHeight + NAVIGATION_SCROLL_FOG_SIZE, navigationIntrinsicHeight),
   );
   const storedNavigationClip = $derived(app.preference.current.sidebarNavigationClip ?? 0);
   const navigationGeometry = $derived(
@@ -279,18 +276,6 @@
   const navigationViewportHeight = $derived(
     navigationIntrinsicHeight > 0 ? `${navigationIntrinsicHeight - currentNavigationClip}px` : undefined,
   );
-  const navigationScrollRange = $derived(Math.max(0, navigationIntrinsicHeight - navigationViewportClientHeight));
-  const effectiveNavigationScrollTop = $derived(clamp(navigationScrollTop, 0, navigationScrollRange));
-  const canScrollNavigationUp = $derived(effectiveNavigationScrollTop > 1);
-  const canScrollNavigationDown = $derived(navigationViewportClientHeight > 0 && effectiveNavigationScrollTop < navigationScrollRange - 1);
-  const navigationMaskImage = $derived.by(() => {
-    const maximallyClippedAtTop = currentNavigationClip >= navigationGeometry.maxClip - 1 && !canScrollNavigationUp;
-    const fogSize = maximallyClippedAtTop ? NAVIGATION_MINIMUM_SCROLL_FOG_SIZE : NAVIGATION_SCROLL_FOG_SIZE;
-    if (!canScrollNavigationUp && !canScrollNavigationDown) return;
-    const top = canScrollNavigationUp ? `transparent, black ${fogSize}px` : `black, black ${fogSize}px`;
-    const bottom = canScrollNavigationDown ? `black calc(100% - ${fogSize}px), transparent` : `black calc(100% - ${fogSize}px), black`;
-    return `linear-gradient(to bottom, ${top}, ${bottom})`;
-  });
 
   const startNavigationResizer = (event: PointerEvent): SidebarNavigationResizeSession | null => {
     if (navigationIntrinsicHeight === 0 || !event.isPrimary || event.button !== 0) return null;
@@ -524,10 +509,8 @@
         <div
           bind:this={navigationScrollEl}
           id={navigationScrollId}
-          style:mask-image={navigationMaskImage}
           class={css({ height: 'full', overflowY: 'auto', overflowX: 'hidden', scrollbar: 'hidden' })}
-          onscroll={(event) => (navigationScrollTop = event.currentTarget.scrollTop)}
-          bind:clientHeight={navigationViewportClientHeight}
+          use:scrollFog={{ orientation: 'vertical', size: NAVIGATION_SCROLL_FOG_SIZE }}
         >
           <!-- 주요 내비게이션 -->
           <div

--- a/packages/ui/src/actions/index.ts
+++ b/packages/ui/src/actions/index.ts
@@ -8,6 +8,7 @@ export * from './infinite-scroll.svelte';
 export * from './outside-click.svelte';
 export * from './pointer-capture.svelte';
 export * from './portal.svelte';
+export * from './scroll-fog.svelte';
 export * from './scroll-lock.svelte';
 export * from './textarea-scrollpadding.svelte';
 export * from './threshold-drag.svelte';

--- a/packages/ui/src/actions/scroll-fog.svelte.ts
+++ b/packages/ui/src/actions/scroll-fog.svelte.ts
@@ -1,0 +1,129 @@
+import { css } from '@typie/styled-system/css';
+import { smootherstep } from '../utils/number';
+import type { Action } from 'svelte/action';
+
+const DEFAULT_SIZE = 24;
+const EDGE_EPSILON = 1;
+const SAMPLES = 6;
+
+const scrollFogClasses = css({
+  transition: '[none]',
+  "&[data-scroll-fog-ready='true']": {
+    transitionProperty: '[--scroll-fog-leading, --scroll-fog-trailing]',
+    transitionDuration: '160ms',
+    transitionTimingFunction: 'ease-out',
+    _motionReduce: { transitionDuration: '0ms' },
+  },
+}).split(' ');
+
+const AXES = {
+  horizontal: {
+    contentExtent: 'scrollWidth',
+    direction: 'right',
+    position: 'scrollLeft',
+    viewportExtent: 'clientWidth',
+  },
+  vertical: {
+    contentExtent: 'scrollHeight',
+    direction: 'bottom',
+    position: 'scrollTop',
+    viewportExtent: 'clientHeight',
+  },
+} as const;
+
+export type ScrollFogOptions = {
+  orientation: keyof typeof AXES;
+  size?: number;
+};
+
+const normalizedSize = (size: number | undefined) => {
+  if (size === undefined || !Number.isFinite(size)) return DEFAULT_SIZE;
+  return Math.max(0, size);
+};
+
+const maskImage = (direction: 'right' | 'bottom', size: number) => {
+  if (size === 0) return `linear-gradient(to ${direction}, black, black)`;
+
+  const leading = Array.from({ length: SAMPLES + 1 }, (_, index) => {
+    const progress = index / SAMPLES;
+    const alpha = smootherstep(progress);
+    return `rgb(0 0 0 / calc(1 - var(--scroll-fog-leading) * ${1 - alpha})) ${progress * size}px`;
+  });
+  const trailing = Array.from({ length: SAMPLES + 1 }, (_, index) => {
+    const progress = index / SAMPLES;
+    const alpha = smootherstep(progress);
+    return `rgb(0 0 0 / calc(1 - var(--scroll-fog-trailing) * ${alpha})) calc(100% - ${size - progress * size}px)`;
+  });
+
+  return `linear-gradient(to ${direction}, ${leading.join(', ')}, black ${size}px, black calc(100% - ${size}px), ${trailing.join(', ')})`;
+};
+
+export const scrollFog: Action<HTMLElement, ScrollFogOptions> = (element, initialOptions) => {
+  let options = initialOptions;
+  let currentMaskKey: string | undefined;
+  let transitionFrame: number | undefined;
+  const previousMaskImage = element.style.maskImage;
+  const addedClasses = scrollFogClasses.filter((className) => !element.classList.contains(className));
+
+  element.classList.add(...addedClasses);
+
+  const sync = () => {
+    const axis = AXES[options.orientation];
+    const viewportExtent = element[axis.viewportExtent];
+    const maximum = Math.max(0, element[axis.contentExtent] - viewportExtent);
+    const position = Math.max(0, element[axis.position]);
+    const effectiveSize = Math.min(normalizedSize(options.size), viewportExtent / 2);
+    const leading = position > EDGE_EPSILON;
+    const trailing = position < maximum - EDGE_EPSILON;
+    const maskKey = `${options.orientation}:${effectiveSize}`;
+
+    element.style.setProperty('--scroll-fog-leading', leading ? '1' : '0');
+    element.style.setProperty('--scroll-fog-trailing', trailing ? '1' : '0');
+    if (maskKey !== currentMaskKey) {
+      currentMaskKey = maskKey;
+      element.style.maskImage = maskImage(axis.direction, effectiveSize);
+    }
+  };
+
+  const resizeObserver = new ResizeObserver(sync);
+  const observeCurrentElements = () => {
+    resizeObserver.disconnect();
+    resizeObserver.observe(element);
+    for (const child of element.children) resizeObserver.observe(child);
+  };
+  const mutationObserver = new MutationObserver(() => {
+    observeCurrentElements();
+    sync();
+  });
+
+  observeCurrentElements();
+  mutationObserver.observe(element, { childList: true });
+  element.addEventListener('scroll', sync);
+  sync();
+  transitionFrame = requestAnimationFrame(() => {
+    sync();
+    transitionFrame = requestAnimationFrame(() => {
+      sync();
+      transitionFrame = undefined;
+      element.dataset.scrollFogReady = 'true';
+    });
+  });
+
+  return {
+    update(nextOptions) {
+      options = nextOptions;
+      sync();
+    },
+    destroy() {
+      element.removeEventListener('scroll', sync);
+      mutationObserver.disconnect();
+      resizeObserver.disconnect();
+      if (transitionFrame !== undefined) cancelAnimationFrame(transitionFrame);
+      delete element.dataset.scrollFogReady;
+      element.classList.remove(...addedClasses);
+      element.style.removeProperty('--scroll-fog-leading');
+      element.style.removeProperty('--scroll-fog-trailing');
+      element.style.maskImage = previousMaskImage;
+    },
+  };
+};

--- a/packages/ui/src/utils/number.ts
+++ b/packages/ui/src/utils/number.ts
@@ -6,6 +6,11 @@ export const clamp = (value: number, min: number, max: number) => {
   return Math.min(Math.max(value, min), max);
 };
 
+export const smootherstep = (value: number) => {
+  const x = clamp(value, 0, 1);
+  return x * x * x * (x * (x * 6 - 15) + 10);
+};
+
 export const closest = (value: number, array: number[]) => {
   if (Number.isNaN(value) || array.length === 0) {
     return null;

--- a/packages/ui/styles/index.css
+++ b/packages/ui/styles/index.css
@@ -1,3 +1,4 @@
 @import url(./prose.css);
+@import url(./scroll-fog.css);
 @import url(./theme.css);
 @import url(./view-transition.css);

--- a/packages/ui/styles/scroll-fog.css
+++ b/packages/ui/styles/scroll-fog.css
@@ -1,0 +1,11 @@
+@property --scroll-fog-leading {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --scroll-fog-trailing {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 0;
+}


### PR DESCRIPTION
- 가로·세로 방향과 포그 크기를 지정할 수 있는 공용 `scrollFog` 액션을 추가했습니다.
- 스크롤 위치와 콘텐츠·뷰포트 크기 변화에 따라 양쪽 포그를 갱신하도록 했습니다.
- smootherstep 기반 마스크와 전환을 공통화하고, reduced-motion 환경에서는 전환을 비활성화했습니다.
- 다음 사용처의 개별 포그 구현을 공용 액션으로 교체했습니다.
  - 에디터 컨텍스트 바 breadcrumb
  - 사이드바 주요 내비게이션
  - 엔티티 이름
  - PRISM transcript 및 도구 호출 목록
- 기존 테스트에서는 포그의 내부 CSS 상태를 고정하던 검증을 제거하고, 각 사용처 고유의 스크롤 동작과 레이아웃 경계만 남겼습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>