### PR TITLE
프리즘 세션 배지 쿼리를 user id로 집계

### DIFF
--- a/apps/api/src/graphql/resolvers/prism.ts
+++ b/apps/api/src/graphql/resolvers/prism.ts
@@ -364,16 +364,13 @@ PrismSession.implement({
         const loader = ctx.loader({
           name: 'PrismSession.awaitingWorkflow',
           nullable: true,
-          load: async (sessionIds: string[]) => {
+          load: async () => {
             return await db
               .selectDistinct({ sessionId: PrismWorkflows.sessionId })
               .from(PrismWorkflows)
+              .innerJoin(PrismSessions, eq(PrismSessions.id, PrismWorkflows.sessionId))
               .where(
-                and(
-                  inArray(PrismWorkflows.sessionId, sessionIds),
-                  eq(PrismWorkflows.state, 'RUNNING'),
-                  isNotNull(PrismWorkflows.awaitingUserAt),
-                ),
+                and(eq(PrismSessions.userId, self.userId), eq(PrismWorkflows.state, 'RUNNING'), isNotNull(PrismWorkflows.awaitingUserAt)),
               );
           },
           key: (row) => row?.sessionId,
@@ -388,14 +385,14 @@ PrismSession.implement({
         const loader = ctx.loader({
           name: 'PrismSession.unseenResponses',
           nullable: true,
-          load: async (sessionIds: string[]) => {
+          load: async () => {
             return await db
               .select({ sessionId: PrismRuns.sessionId, count: count(PrismRuns.id) })
               .from(PrismRuns)
               .innerJoin(PrismSessions, eq(PrismSessions.id, PrismRuns.sessionId))
               .where(
                 and(
-                  inArray(PrismRuns.sessionId, sessionIds),
+                  eq(PrismSessions.userId, self.userId),
                   inArray(PrismRuns.state, [PrismRunState.COMPLETED, PrismRunState.FAILED]),
                   isNotNull(PrismRuns.finishedAt),
                   or(isNull(PrismSessions.seenAt), gt(PrismRuns.finishedAt, PrismSessions.seenAt)),
@@ -416,12 +413,13 @@ PrismSession.implement({
         const loader = ctx.loader({
           name: 'PrismSession.completedReviewRounds',
           many: true,
-          load: async (sessionIds: string[]) => {
+          load: async () => {
             return await db
               .select({ sessionId: PrismReviewRounds.sessionId, finishedAt: PrismWorkflows.finishedAt })
               .from(PrismReviewRounds)
+              .innerJoin(PrismSessions, eq(PrismSessions.id, PrismReviewRounds.sessionId))
               .innerJoin(PrismWorkflows, eq(PrismWorkflows.id, PrismReviewRounds.workflowId))
-              .where(and(inArray(PrismReviewRounds.sessionId, sessionIds), eq(PrismWorkflows.state, 'COMPLETED')));
+              .where(and(eq(PrismSessions.userId, self.userId), eq(PrismWorkflows.state, 'COMPLETED')));
           },
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           key: ({ sessionId }) => sessionId!,


### PR DESCRIPTION
세션 목록은 사용자의 전체 세션을 대상으로 하지만, 배지 집계 쿼리는 각 세션 ID를 개별 파라미터로 전달하고 있었습니다. 세션이 많아질수록 SQL과 쿼리 로그가 불필요하게 길어지는 문제가 있어, 실제 조회 범위의 소유자인 사용자 ID를 기준으로 집계하도록 변경했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>