### PR TITLE
목표와 통계 갱신 개선

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -2240,6 +2240,7 @@ type User implements IUser {
   subscription: Subscription_
   surveys: [String!]!
   textReplacements: [TextReplacementNode!]!
+  todayCharacterCountChange: CharacterCountChange!
   trial: UserTrial
   usableBillingKeyTypes: [BillingKeyType!]!
   usage: UserUsage!

--- a/apps/api/src/graphql/resolvers/document.ts
+++ b/apps/api/src/graphql/resolvers/document.ts
@@ -985,6 +985,7 @@ builder.mutationFields((t) => ({
       }
 
       await db.update(DocumentHeadContributors).set({ excluded: input.excluded }).where(eq(DocumentHeadContributors.id, row.id));
+      pubsub.publish('user:usage:update', ctx.session.userId, null);
 
       return input.headId;
     },

--- a/apps/api/src/graphql/resolvers/user.ts
+++ b/apps/api/src/graphql/resolvers/user.ts
@@ -76,7 +76,7 @@ import { enqueueSearchSyncForEntityIds } from '#/utils/search-index.ts';
 import { hasLiveYearlyBillingKeySubscription } from '#/utils/subscription-billing-key.ts';
 import { lockUserSubscriptionState } from '#/utils/subscription-lock.ts';
 import { getUserUsage } from '#/utils/user.ts';
-import { currentUserGoal, dailyCharacterChanges, dailyGoalHistory } from '#/utils/user-stats.ts';
+import { currentUserGoal, dailyCharacterChanges, dailyGoalHistory, todayCharacterCountChange } from '#/utils/user-stats.ts';
 import { builder } from '../builder.ts';
 import {
   CharacterCountChange,
@@ -348,6 +348,17 @@ User.implement({
       type: [CharacterCountChange],
       resolve: async (self) => {
         return await dailyCharacterChanges(self.id);
+      },
+    }),
+
+    todayCharacterCountChange: t.withAuth({ session: true }).field({
+      type: CharacterCountChange,
+      resolve: async (self, _, ctx) => {
+        if (ctx.session.userId !== self.id) {
+          return { date: dayjs.kst().startOf('day'), additions: 0, deletions: 0 };
+        }
+
+        return await todayCharacterCountChange(self.id);
       },
     }),
 

--- a/apps/api/src/mq/tasks/changeset.ts
+++ b/apps/api/src/mq/tasks/changeset.ts
@@ -75,6 +75,7 @@ export const DocumentChangesetsCollectJob = defineJob('document:changesets:colle
   let shouldConsolidate = false;
   let totalityViolations = 0;
   const isolatedEvents: { headId: string; userId: string; excluded: boolean }[] = [];
+  const usageUpdateUserIds = new Set<string>();
 
   try {
     const collected = await redis.get(collectedKey(documentId));
@@ -323,6 +324,8 @@ export const DocumentChangesetsCollectJob = defineJob('document:changesets:colle
                     deletions: deletions > 0 ? sql`${DocumentCharacterCountChanges.deletions} + ${deletions}` : undefined,
                   },
                 });
+
+              usageUpdateUserIds.add(userId);
             }
 
             if (write.isolatedAuthorId) {
@@ -426,15 +429,18 @@ export const DocumentChangesetsCollectJob = defineJob('document:changesets:colle
     // re-index / preview / recency / usage notifications would be no-ops that a
     // large backfill turns into a job storm.
     if (userVisibleChanged) {
-      const { siteId, entityId, userId } = await db
-        .select({ siteId: Entities.siteId, entityId: Entities.id, userId: Entities.userId })
+      const { siteId, entityId, ownerUserId } = await db
+        .select({ siteId: Entities.siteId, entityId: Entities.id, ownerUserId: Entities.userId })
         .from(Documents)
         .innerJoin(Entities, eq(Documents.entityId, Entities.id))
         .where(eq(Documents.id, documentId))
         .then(firstOrThrow);
 
       pubsub.publish('site:update', siteId, { scope: 'entity', entityId });
-      pubsub.publish('user:usage:update', userId, null);
+      usageUpdateUserIds.add(ownerUserId);
+      for (const userId of usageUpdateUserIds) {
+        pubsub.publish('user:usage:update', userId, null);
+      }
 
       await enqueueJob('search:index:document', documentId, {
         deduplication: { id: `search:index:document:${documentId}`, ttl: 60 * 1000 },

--- a/apps/api/src/utils/user-stats.ts
+++ b/apps/api/src/utils/user-stats.ts
@@ -61,16 +61,14 @@ export const dailyGoalHistory = async (
   return result;
 };
 
-export const dailyCharacterChanges = async (userId: string): Promise<{ date: Dayjs; additions: number; deletions: number }[]> => {
-  const startOfTomorrow = dayjs.kst().startOf('day').add(1, 'day');
-
+const characterChangesInRange = async (
+  userId: string,
+  from: Dayjs,
+  to: Dayjs,
+): Promise<{ date: Dayjs; additions: number; deletions: number }[]> => {
   const documentDate = sql<string>`DATE(${DocumentCharacterCountChanges.bucket} AT TIME ZONE 'Asia/Seoul')`.mapWith(dayjs.kst);
 
-  const excludedByDate = await getExcludedDeltasByDate({
-    userId,
-    from: startOfTomorrow.subtract(365, 'days'),
-    to: startOfTomorrow,
-  });
+  const excludedByDate = await getExcludedDeltasByDate({ userId, from, to });
 
   const rows = await db
     .select({
@@ -82,8 +80,8 @@ export const dailyCharacterChanges = async (userId: string): Promise<{ date: Day
     .where(
       and(
         eq(DocumentCharacterCountChanges.userId, userId),
-        gte(DocumentCharacterCountChanges.bucket, startOfTomorrow.subtract(365, 'days')),
-        lt(DocumentCharacterCountChanges.bucket, startOfTomorrow),
+        gte(DocumentCharacterCountChanges.bucket, from),
+        lt(DocumentCharacterCountChanges.bucket, to),
       ),
     )
     .groupBy(documentDate)
@@ -98,4 +96,15 @@ export const dailyCharacterChanges = async (userId: string): Promise<{ date: Day
       deletions: row.deletions - (excluded?.deletions ?? 0),
     };
   });
+};
+
+export const dailyCharacterChanges = async (userId: string): Promise<{ date: Dayjs; additions: number; deletions: number }[]> => {
+  const startOfTomorrow = dayjs.kst().startOf('day').add(1, 'day');
+  return await characterChangesInRange(userId, startOfTomorrow.subtract(365, 'days'), startOfTomorrow);
+};
+
+export const todayCharacterCountChange = async (userId: string): Promise<{ date: Dayjs; additions: number; deletions: number }> => {
+  const startOfToday = dayjs.kst().startOf('day');
+  const rows = await characterChangesInRange(userId, startOfToday, startOfToday.add(1, 'day'));
+  return rows[0] ?? { date: startOfToday, additions: 0, deletions: 0 };
 };

--- a/apps/website/src/lib/goal.test.ts
+++ b/apps/website/src/lib/goal.test.ts
@@ -10,9 +10,7 @@ import {
   goalColorState,
   pickGoalSource,
   requiredToday,
-  streaks,
   timeFraction,
-  todayProgress,
 } from './goal';
 
 const day = (s: string) => dayjs(s).startOf('day');
@@ -85,41 +83,6 @@ describe('dDayLabel', () => {
   });
 });
 
-describe('todayProgress', () => {
-  const kstToday = dayjs.kst('2026-08-05');
-
-  test('마지막 기록이 KST 오늘이면 그 값을 그대로', () => {
-    const history = [
-      { date: '2026-08-03T15:00:00.000Z', additions: 100, achieved: false },
-      { date: '2026-08-05T05:00:00.000Z', additions: 1200, achieved: true },
-    ];
-
-    expect(todayProgress(history, kstToday)).toEqual({ additions: 1200, achieved: true });
-  });
-
-  test('마지막 기록이 오늘이 아니면 0 · 미달성', () => {
-    const history = [{ date: '2026-08-04T05:00:00.000Z', additions: 1200, achieved: true }];
-
-    expect(todayProgress(history, kstToday)).toEqual({ additions: 0, achieved: false });
-  });
-
-  test('빈 이력이면 0 · 미달성', () => {
-    expect(todayProgress([], kstToday)).toEqual({ additions: 0, achieved: false });
-  });
-
-  test('달성 판정은 서버 achieved를 따르고 클라에서 재계산하지 않는다', () => {
-    const history = [{ date: '2026-08-05T05:00:00.000Z', additions: 1200, achieved: false }];
-
-    expect(todayProgress(history, kstToday)).toEqual({ additions: 1200, achieved: false });
-  });
-
-  test('KST 경계: UTC로는 어제인 시각도 KST 오늘로 취급', () => {
-    const history = [{ date: '2026-08-04T15:30:00.000Z', additions: 300, achieved: false }];
-
-    expect(todayProgress(history, kstToday)).toEqual({ additions: 300, achieved: false });
-  });
-});
-
 describe('dueStatus', () => {
   const today = day('2026-08-05');
 
@@ -180,71 +143,5 @@ describe('pickGoalSource', () => {
     const entity = { id: 'e1', goal: null, ancestors: [{ id: 'a1', goal: null, node: { __typename: 'Folder', characterCount: 500 } }] };
 
     expect(pickGoalSource(entity, 300)).toBeNull();
-  });
-});
-
-describe('streaks', () => {
-  const today = dayjs.kst('2026-08-05');
-  const d = (s: string) => dayjs.kst(s).toISOString();
-
-  test('오늘 달성 포함 연속', () => {
-    const history = [
-      { date: d('2026-08-03'), achieved: true },
-      { date: d('2026-08-04'), achieved: true },
-      { date: d('2026-08-05'), achieved: true },
-    ];
-
-    expect(streaks(history, today)).toEqual({ current: 3, best: 3 });
-  });
-
-  test('오늘 미달성은 어제까지의 연속으로', () => {
-    const history = [
-      { date: d('2026-08-03'), achieved: true },
-      { date: d('2026-08-04'), achieved: true },
-      { date: d('2026-08-05'), achieved: false },
-    ];
-
-    expect(streaks(history, today)).toEqual({ current: 2, best: 2 });
-  });
-
-  test('미달성 하루가 연속을 끊음', () => {
-    const history = [
-      { date: d('2026-08-01'), achieved: true },
-      { date: d('2026-08-02'), achieved: false },
-      { date: d('2026-08-03'), achieved: true },
-      { date: d('2026-08-04'), achieved: true },
-      { date: d('2026-08-05'), achieved: true },
-    ];
-
-    expect(streaks(history, today)).toEqual({ current: 3, best: 3 });
-  });
-
-  test('목표 없던 날(행 없음)도 연속을 끊음', () => {
-    const history = [
-      { date: d('2026-08-01'), achieved: true },
-      { date: d('2026-08-02'), achieved: true },
-      { date: d('2026-08-04'), achieved: true },
-      { date: d('2026-08-05'), achieved: true },
-    ];
-
-    expect(streaks(history, today)).toEqual({ current: 2, best: 2 });
-  });
-
-  test('최고 기록은 과거 구간에서', () => {
-    const history = [
-      { date: d('2026-07-28'), achieved: true },
-      { date: d('2026-07-29'), achieved: true },
-      { date: d('2026-07-30'), achieved: true },
-      { date: d('2026-07-31'), achieved: true },
-      { date: d('2026-08-01'), achieved: false },
-      { date: d('2026-08-04'), achieved: true },
-      { date: d('2026-08-05'), achieved: true },
-    ];
-
-    expect(streaks(history, today)).toEqual({ current: 2, best: 4 });
-  });
-
-  test('빈 이력은 0', () => {
-    expect(streaks([], today)).toEqual({ current: 0, best: 0 });
   });
 });

--- a/apps/website/src/lib/goal.ts
+++ b/apps/website/src/lib/goal.ts
@@ -1,5 +1,4 @@
 import { comma } from '@typie/ui/utils';
-import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 
 export const GOAL_OVER_RATIO = 1.1;
@@ -53,49 +52,6 @@ export const dDayLabel = (dueAt: Dayjs, today: Dayjs): string => {
   }
 
   return diff > 0 ? `D-${diff}` : `D+${-diff}`;
-};
-
-export const todayProgress = (
-  history: readonly { date: string; additions: number; achieved: boolean }[],
-  today: Dayjs,
-): { additions: number; achieved: boolean } => {
-  const last = history.at(-1);
-
-  if (!last || !dayjs(last.date).kst().isSame(today, 'day')) {
-    return { additions: 0, achieved: false };
-  }
-
-  return { additions: last.additions, achieved: last.achieved };
-};
-
-export const streaks = (history: readonly { date: string; achieved: boolean }[], today: Dayjs): { current: number; best: number } => {
-  const days = history.map((h) => ({ day: dayjs(h.date).kst().startOf('day'), achieved: h.achieved }));
-
-  let best = 0;
-  let run = 0;
-  let prevAchievedDay: Dayjs | null = null;
-  for (const { day, achieved } of days) {
-    if (!achieved) {
-      run = 0;
-      prevAchievedDay = null;
-      continue;
-    }
-
-    run = prevAchievedDay && day.diff(prevAchievedDay, 'day') === 1 ? run + 1 : 1;
-    best = Math.max(best, run);
-    prevAchievedDay = day;
-  }
-
-  const achievedByDay = new Map(days.map((d) => [d.day.valueOf(), d.achieved]));
-  const startOfToday = today.startOf('day');
-  let cursor = achievedByDay.get(startOfToday.valueOf()) ? startOfToday : startOfToday.subtract(1, 'day');
-  let current = 0;
-  while (achievedByDay.get(cursor.valueOf())) {
-    current += 1;
-    cursor = cursor.subtract(1, 'day');
-  }
-
-  return { current, best };
 };
 
 export const dueStatus = (

--- a/apps/website/src/lib/user-stats.test.ts
+++ b/apps/website/src/lib/user-stats.test.ts
@@ -1,0 +1,144 @@
+import '@typie/lib/dayjs';
+
+import dayjs from 'dayjs';
+import { describe, expect, test } from 'vitest';
+import { dailyGoalStatus, mergeTodayCharacterCountChanges, mergeTodayGoalHistory, streaks, writingStreaks } from './user-stats';
+
+describe('streaks', () => {
+  const today = dayjs.kst('2026-08-05');
+  const d = (s: string) => dayjs.kst(s).toISOString();
+
+  test('오늘 달성 포함 연속', () => {
+    const history = [
+      { date: d('2026-08-03'), achieved: true },
+      { date: d('2026-08-04'), achieved: true },
+      { date: d('2026-08-05'), achieved: true },
+    ];
+
+    expect(streaks(history, today)).toEqual({ current: 3, best: 3 });
+  });
+
+  test('오늘 미달성은 어제까지의 연속으로', () => {
+    const history = [
+      { date: d('2026-08-03'), achieved: true },
+      { date: d('2026-08-04'), achieved: true },
+      { date: d('2026-08-05'), achieved: false },
+    ];
+
+    expect(streaks(history, today)).toEqual({ current: 2, best: 2 });
+  });
+
+  test('미달성 하루가 연속을 끊음', () => {
+    const history = [
+      { date: d('2026-08-01'), achieved: true },
+      { date: d('2026-08-02'), achieved: false },
+      { date: d('2026-08-03'), achieved: true },
+      { date: d('2026-08-04'), achieved: true },
+      { date: d('2026-08-05'), achieved: true },
+    ];
+
+    expect(streaks(history, today)).toEqual({ current: 3, best: 3 });
+  });
+
+  test('목표 없던 날(행 없음)도 연속을 끊음', () => {
+    const history = [
+      { date: d('2026-08-01'), achieved: true },
+      { date: d('2026-08-02'), achieved: true },
+      { date: d('2026-08-04'), achieved: true },
+      { date: d('2026-08-05'), achieved: true },
+    ];
+
+    expect(streaks(history, today)).toEqual({ current: 2, best: 2 });
+  });
+
+  test('최고 기록은 과거 구간에서', () => {
+    const history = [
+      { date: d('2026-07-28'), achieved: true },
+      { date: d('2026-07-29'), achieved: true },
+      { date: d('2026-07-30'), achieved: true },
+      { date: d('2026-07-31'), achieved: true },
+      { date: d('2026-08-01'), achieved: false },
+      { date: d('2026-08-04'), achieved: true },
+      { date: d('2026-08-05'), achieved: true },
+    ];
+
+    expect(streaks(history, today)).toEqual({ current: 2, best: 4 });
+  });
+
+  test('빈 이력은 0', () => {
+    expect(streaks([], today)).toEqual({ current: 0, best: 0 });
+  });
+});
+
+describe('dailyGoalStatus', () => {
+  const today = dayjs.kst('2026-08-05');
+  const d = (s: string) => dayjs.kst(s).toISOString();
+
+  test('서버의 오늘 통계로 오래된 목표 진행률과 연속일을 덮어쓴다', () => {
+    const history = [
+      { date: d('2026-08-03'), additions: 1000, achieved: true },
+      { date: d('2026-08-04'), additions: 1000, achieved: true },
+      { date: d('2026-08-05'), additions: 0, achieved: false },
+    ];
+
+    expect(dailyGoalStatus(history, 1000, { date: d('2026-08-05'), additions: 1200 }, today)).toEqual({
+      additions: 1200,
+      achieved: true,
+      streak: 3,
+      bestStreak: 3,
+    });
+  });
+});
+
+describe('mergeTodayCharacterCountChanges', () => {
+  const today = dayjs.kst('2026-08-05');
+  const d = (s: string) => dayjs.kst(s).toISOString();
+
+  test('오늘의 오래된 글자 수 행을 서버의 최신 행으로 교체한다', () => {
+    const history = [
+      { date: d('2026-08-03'), additions: 100 },
+      { date: d('2026-08-04'), additions: 100 },
+      { date: d('2026-08-05'), additions: 0 },
+    ];
+    const todayChange = { date: d('2026-08-05'), additions: 50 };
+
+    expect(mergeTodayCharacterCountChanges(history, todayChange, today)).toEqual([
+      { date: d('2026-08-03'), additions: 100 },
+      { date: d('2026-08-04'), additions: 100 },
+      todayChange,
+    ]);
+  });
+});
+
+describe('mergeTodayGoalHistory', () => {
+  const today = dayjs.kst('2026-08-05');
+  const d = (s: string) => dayjs.kst(s).toISOString();
+
+  test('서버의 오늘 글자 수가 감소하면 오래된 달성 기록을 미달성으로 교체한다', () => {
+    const history = [
+      { date: d('2026-08-04'), additions: 1200, achieved: true },
+      { date: d('2026-08-05'), additions: 1200, achieved: true },
+    ];
+
+    expect(mergeTodayGoalHistory(history, 1000, { date: d('2026-08-05'), additions: 0 }, today)).toEqual([
+      { date: d('2026-08-04'), additions: 1200, achieved: true },
+      { date: today.startOf('day').toISOString(), additions: 0, achieved: false },
+    ]);
+  });
+});
+
+describe('writingStreaks', () => {
+  const today = dayjs.kst('2026-08-05');
+  const d = (s: string) => dayjs.kst(s).toISOString();
+
+  test('같은 글자 수 이력에서 현재와 최장 연속 기록을 함께 계산한다', () => {
+    const history = [
+      { date: d('2026-08-01'), additions: 100 },
+      { date: d('2026-08-02'), additions: 100 },
+      { date: d('2026-08-04'), additions: 100 },
+      { date: d('2026-08-05'), additions: 50 },
+    ];
+
+    expect(writingStreaks(history, today)).toEqual({ current: 2, best: 2 });
+  });
+});

--- a/apps/website/src/lib/user-stats.ts
+++ b/apps/website/src/lib/user-stats.ts
@@ -1,0 +1,88 @@
+import dayjs from 'dayjs';
+import type { Dayjs } from 'dayjs';
+
+type CharacterCountChange = { date: string; additions: number };
+type GoalHistoryEntry = CharacterCountChange & { achieved: boolean };
+
+const isSameDay = (date: string, day: Dayjs): boolean => dayjs(date).kst().isSame(day, 'day');
+
+const withoutToday = <T extends { date: string }>(history: readonly T[], today: Dayjs): T[] =>
+  history.filter(({ date }) => !isSameDay(date, today));
+
+export const streaks = (history: readonly { date: string; achieved: boolean }[], today: Dayjs): { current: number; best: number } => {
+  const days = history.map((h) => ({ day: dayjs(h.date).kst().startOf('day'), achieved: h.achieved }));
+
+  let best = 0;
+  let run = 0;
+  let prevAchievedDay: Dayjs | null = null;
+  for (const { day, achieved } of days) {
+    if (!achieved) {
+      run = 0;
+      prevAchievedDay = null;
+      continue;
+    }
+
+    run = prevAchievedDay && day.diff(prevAchievedDay, 'day') === 1 ? run + 1 : 1;
+    best = Math.max(best, run);
+    prevAchievedDay = day;
+  }
+
+  const achievedByDay = new Map(days.map((d) => [d.day.valueOf(), d.achieved]));
+  const startOfToday = today.startOf('day');
+  let cursor = achievedByDay.get(startOfToday.valueOf()) ? startOfToday : startOfToday.subtract(1, 'day');
+  let current = 0;
+  while (achievedByDay.get(cursor.valueOf())) {
+    current += 1;
+    cursor = cursor.subtract(1, 'day');
+  }
+
+  return { current, best };
+};
+
+export const mergeTodayCharacterCountChanges = <T extends CharacterCountChange>(
+  history: readonly T[],
+  todayChange: T,
+  today: Dayjs,
+): T[] => {
+  const startOfToday = today.startOf('day');
+  const pastChanges = withoutToday(history, startOfToday);
+
+  return isSameDay(todayChange.date, startOfToday) ? [...pastChanges, todayChange] : pastChanges;
+};
+
+export const mergeTodayGoalHistory = (
+  history: readonly GoalHistoryEntry[],
+  target: number,
+  todayChange: CharacterCountChange,
+  today: Dayjs,
+): GoalHistoryEntry[] => {
+  const startOfToday = today.startOf('day');
+  const additions = isSameDay(todayChange.date, startOfToday) ? todayChange.additions : 0;
+
+  return [...withoutToday(history, startOfToday), { date: startOfToday.toISOString(), additions, achieved: additions >= target }];
+};
+
+export const dailyGoalStatus = (
+  history: readonly GoalHistoryEntry[],
+  target: number,
+  todayChange: CharacterCountChange,
+  today: Dayjs,
+): { additions: number; achieved: boolean; streak: number; bestStreak: number } => {
+  const additions = isSameDay(todayChange.date, today) ? todayChange.additions : 0;
+  const achieved = additions >= target;
+  const liveHistory = mergeTodayGoalHistory(history, target, todayChange, today);
+  const liveStreaks = streaks(liveHistory, today);
+
+  return {
+    additions,
+    achieved,
+    streak: liveStreaks.current,
+    bestStreak: liveStreaks.best,
+  };
+};
+
+export const writingStreaks = (history: readonly CharacterCountChange[], today: Dayjs): { current: number; best: number } =>
+  streaks(
+    history.map(({ date, additions }) => ({ date, achieved: additions > 0 })),
+    today,
+  );

--- a/apps/website/src/routes/website/(dashboard)/+layout.svelte
+++ b/apps/website/src/routes/website/(dashboard)/+layout.svelte
@@ -52,6 +52,7 @@
   import TrashModal from './@trash/TrashModal.svelte';
   import WidgetGroup from './@widgets/WidgetGroup.svelte';
   import CommandPalette from './CommandPalette.svelte';
+  import { setupDayClock } from './day-clock.svelte';
   import MarketingConsentModal from './MarketingConsentModal.svelte';
   import { setupNoteContext } from './note-context.svelte';
   import ReferralWelcomeModal from './ReferralWelcomeModal.svelte';
@@ -66,6 +67,7 @@
   const query = $derived(hydrateQuery(() => data.query));
 
   const app = setupAppContext(query.data.me.id);
+  setupDayClock();
   let prismPanel = $state<PrismPanel>();
 
   let prismNotifications: ReturnType<typeof createPrismNotifications> | undefined;
@@ -175,6 +177,23 @@
         }
       }
     `),
+  );
+
+  createSubscription(
+    graphql(`
+      subscription DashboardLayout_UserUsageUpdateStream($userId: ID!) {
+        userUsageUpdateStream(userId: $userId) {
+          id
+
+          todayCharacterCountChange {
+            date
+            additions
+            deletions
+          }
+        }
+      }
+    `),
+    () => ({ userId }),
   );
 
   createSubscription(

--- a/apps/website/src/routes/website/(dashboard)/@goal/EntityGoalIndicator.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@goal/EntityGoalIndicator.svelte
@@ -4,6 +4,7 @@
   import { comma } from '@typie/ui/utils';
   import dayjs from 'dayjs';
   import { dueStatus, goalColorState, timeFraction } from '$lib/goal';
+  import { getDayClock } from '../day-clock.svelte';
 
   type Props = {
     current: number;
@@ -14,12 +15,13 @@
   };
 
   let { current, targetCharacterCount, dueAt, goalCreatedAt, onclick }: Props = $props();
+  const dayClock = getDayClock();
 
-  const today = $derived(dayjs.kst().startOf('day'));
+  const today = $derived(dayClock.now.startOf('day'));
   const state = $derived(goalColorState(current, targetCharacterCount));
   const duePassed = $derived(!!dueAt && dayjs(dueAt).kst().startOf('day').isBefore(today));
   const overdue = $derived(duePassed && state === 'under');
-  const pie = $derived(state === 'under' && dueAt ? timeFraction(dayjs(goalCreatedAt).kst(), dayjs(dueAt).kst(), dayjs.kst()) : null);
+  const pie = $derived(state === 'under' && dueAt ? timeFraction(dayjs(goalCreatedAt).kst(), dayjs(dueAt).kst(), dayClock.now) : null);
 
   const percent = $derived(Math.floor((current / targetCharacterCount) * 100));
   const tooltip = $derived.by(() => {

--- a/apps/website/src/routes/website/(dashboard)/@goal/GoalModal.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@goal/GoalModal.svelte
@@ -11,10 +11,12 @@
   import { dDayLabel, goalColorState, requiredToday, timeFraction } from '$lib/goal';
   import { formatCommaInput, parseCommaInput } from '$lib/number-input';
   import { graphql } from '$mearie';
+  import { getDayClock } from '../day-clock.svelte';
   import GoalHistoryTable from './GoalHistoryTable.svelte';
   import GoalTrendChart from './GoalTrendChart.svelte';
 
   const app = getAppContext();
+  const dayClock = getDayClock();
 
   const query = createQuery(
     graphql(`
@@ -316,7 +318,7 @@
         {#if goal && !editing}
           {@const state = goalColorState(currentCount, goal.targetCharacterCount)}
           {@const percent = Math.floor((currentCount / goal.targetCharacterCount) * 100)}
-          {@const today = dayjs.kst()}
+          {@const today = dayClock.now}
           {@const due = goal.dueAt ? dayjs(goal.dueAt).kst() : null}
           {@const overdue = !!due && due.isBefore(today, 'day')}
           {@const overdueUnder = overdue && state === 'under'}

--- a/apps/website/src/routes/website/(dashboard)/@goal/GoalTrendChart.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@goal/GoalTrendChart.svelte
@@ -4,6 +4,7 @@
   import { flex } from '@typie/styled-system/patterns';
   import dayjs from 'dayjs';
   import { graphql } from '$mearie';
+  import { getDayClock } from '../day-clock.svelte';
   import type { DashboardLayout_GoalTrendChart_entity$key } from '$mearie';
 
   type Props = {
@@ -12,6 +13,7 @@
   };
 
   let { entity$key, current }: Props = $props();
+  const dayClock = getDayClock();
 
   const entity = createFragment(
     graphql(`
@@ -43,7 +45,7 @@
   const height = 200;
   const padding = { top: 8, right: 8, bottom: 20, left: 8 };
 
-  const today = $derived(dayjs.kst().startOf('day'));
+  const today = $derived(dayClock.now.startOf('day'));
   const first = $derived(history.length > 0 ? dayjs(history[0].date).kst() : today);
   const last = $derived(dueAt ? dayjs.max(today, dayjs(dueAt).kst().startOf('day')) : today);
   const spanDays = $derived(Math.max(1, last.diff(first, 'day')));

--- a/apps/website/src/routes/website/(dashboard)/@goal/UserGoalDots.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@goal/UserGoalDots.svelte
@@ -5,32 +5,50 @@
   import { Tooltip } from '@typie/ui/components';
   import { comma } from '@typie/ui/utils';
   import dayjs from 'dayjs';
+  import { mergeTodayGoalHistory } from '$lib/user-stats';
   import { graphql } from '$mearie';
+  import { getDayClock } from '../day-clock.svelte';
   import type { DashboardLayout_UserGoalDots_user$key } from '$mearie';
 
   type Props = { user$key: DashboardLayout_UserGoalDots_user$key };
 
   let { user$key }: Props = $props();
+  const dayClock = getDayClock();
 
   const user = createFragment(
     graphql(`
       fragment DashboardLayout_UserGoalDots_user on User {
         id
 
+        goal {
+          id
+          targetCharacterCount
+        }
+
         goalHistory {
           date
           additions
           achieved
+        }
+
+        todayCharacterCountChange {
+          date
+          additions
         }
       }
     `),
     () => user$key,
   );
 
-  const byDate = $derived(new Map(user.data.goalHistory.map((h) => [dayjs(h.date).kst().format('YYYY-MM-DD'), h])));
+  const goalHistory = $derived(
+    user.data.goal
+      ? mergeTodayGoalHistory(user.data.goalHistory, user.data.goal.targetCharacterCount, user.data.todayCharacterCountChange, dayClock.now)
+      : user.data.goalHistory,
+  );
+  const byDate = $derived(new Map(goalHistory.map((h) => [dayjs(h.date).kst().format('YYYY-MM-DD'), h])));
 
   const days = $derived.by(() => {
-    const today = dayjs.kst().startOf('day');
+    const today = dayClock.now;
 
     return Array.from({ length: 112 }, (_, i) => {
       const date = today.subtract(111 - i, 'day');

--- a/apps/website/src/routes/website/(dashboard)/@goal/UserGoalHistoryTable.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@goal/UserGoalHistoryTable.svelte
@@ -4,25 +4,39 @@
   import { flex } from '@typie/styled-system/patterns';
   import { comma } from '@typie/ui/utils';
   import dayjs from 'dayjs';
+  import { mergeTodayCharacterCountChanges, mergeTodayGoalHistory } from '$lib/user-stats';
   import { graphql } from '$mearie';
+  import { getDayClock } from '../day-clock.svelte';
   import type { DashboardLayout_UserGoalHistoryTable_user$key } from '$mearie';
 
   type Props = { user$key: DashboardLayout_UserGoalHistoryTable_user$key };
 
   let { user$key }: Props = $props();
+  const dayClock = getDayClock();
 
   const user = createFragment(
     graphql(`
       fragment DashboardLayout_UserGoalHistoryTable_user on User {
         id
 
+        goal {
+          id
+          targetCharacterCount
+        }
+
         characterCountChanges {
+          date
+          additions
+        }
+
+        todayCharacterCountChange {
           date
           additions
         }
 
         goalHistory {
           date
+          additions
           achieved
         }
       }
@@ -30,13 +44,19 @@
     () => user$key,
   );
 
-  const additionsByDate = $derived(
-    new Map(user.data.characterCountChanges.map((h) => [dayjs(h.date).kst().format('YYYY-MM-DD'), h.additions])),
+  const characterCountChanges = $derived(
+    mergeTodayCharacterCountChanges(user.data.characterCountChanges, user.data.todayCharacterCountChange, dayClock.now),
   );
-  const judgmentByDate = $derived(new Map(user.data.goalHistory.map((h) => [dayjs(h.date).kst().format('YYYY-MM-DD'), h.achieved])));
+  const goalHistory = $derived(
+    user.data.goal
+      ? mergeTodayGoalHistory(user.data.goalHistory, user.data.goal.targetCharacterCount, user.data.todayCharacterCountChange, dayClock.now)
+      : user.data.goalHistory,
+  );
+  const additionsByDate = $derived(new Map(characterCountChanges.map((h) => [dayjs(h.date).kst().format('YYYY-MM-DD'), h.additions])));
+  const judgmentByDate = $derived(new Map(goalHistory.map((h) => [dayjs(h.date).kst().format('YYYY-MM-DD'), h.achieved])));
 
   const rows = $derived.by(() => {
-    const today = dayjs.kst().startOf('day');
+    const today = dayClock.now;
 
     return Array.from({ length: 30 }, (_, i) => {
       const date = today.subtract(i, 'day');

--- a/apps/website/src/routes/website/(dashboard)/@goal/UserGoalModal.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@goal/UserGoalModal.svelte
@@ -6,16 +6,17 @@
   import { getAppContext } from '@typie/ui/context';
   import { Dialog, Toast } from '@typie/ui/notification';
   import { comma } from '@typie/ui/utils';
-  import dayjs from 'dayjs';
   import { untrack } from 'svelte';
-  import { streaks, todayProgress } from '$lib/goal';
   import { formatCommaInput, parseCommaInput } from '$lib/number-input';
+  import { dailyGoalStatus } from '$lib/user-stats';
   import { graphql } from '$mearie';
+  import { getDayClock } from '../day-clock.svelte';
   import UserGoalDots from './UserGoalDots.svelte';
   import UserGoalHistoryTable from './UserGoalHistoryTable.svelte';
   import UserGoalTrendChart from './UserGoalTrendChart.svelte';
 
   const app = getAppContext();
+  const dayClock = getDayClock();
 
   const query = createQuery(
     graphql(`
@@ -33,6 +34,11 @@
             targetCharacterCount
             additions
             achieved
+          }
+
+          todayCharacterCountChange {
+            date
+            additions
           }
 
           ...DashboardLayout_UserGoalDots_user
@@ -215,8 +221,7 @@
         })}
       >
         {#if goal && !editing}
-          {@const progress = todayProgress(me.goalHistory, dayjs.kst())}
-          {@const streak = streaks(me.goalHistory, dayjs.kst())}
+          {@const progress = dailyGoalStatus(me.goalHistory, goal.targetCharacterCount, me.todayCharacterCountChange, dayClock.now)}
 
           <ProgressRing
             progress={progress.additions / goal.targetCharacterCount}
@@ -253,8 +258,8 @@
               backgroundColor: 'surface.muted',
             })}
           >
-            <span class={css({ fontSize: '14px', fontWeight: 'semibold', color: 'text.default' })}>달성 연속 {streak.current}일</span>
-            <span class={css({ fontSize: '12px', color: 'text.faint' })}>최고 기록 {streak.best}일</span>
+            <span class={css({ fontSize: '14px', fontWeight: 'semibold', color: 'text.default' })}>달성 연속 {progress.streak}일</span>
+            <span class={css({ fontSize: '12px', color: 'text.faint' })}>최고 기록 {progress.bestStreak}일</span>
           </div>
 
           <div class={flex({ gap: '6px', width: 'full' })}>

--- a/apps/website/src/routes/website/(dashboard)/@goal/UserGoalTrendChart.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@goal/UserGoalTrendChart.svelte
@@ -4,12 +4,15 @@
   import { flex } from '@typie/styled-system/patterns';
   import { comma } from '@typie/ui/utils';
   import dayjs from 'dayjs';
+  import { mergeTodayCharacterCountChanges } from '$lib/user-stats';
   import { graphql } from '$mearie';
+  import { getDayClock } from '../day-clock.svelte';
   import type { DashboardLayout_UserGoalTrendChart_user$key } from '$mearie';
 
   type Props = { user$key: DashboardLayout_UserGoalTrendChart_user$key };
 
   let { user$key }: Props = $props();
+  const dayClock = getDayClock();
 
   const user = createFragment(
     graphql(`
@@ -25,16 +28,24 @@
           date
           additions
         }
+
+        todayCharacterCountChange {
+          date
+          additions
+        }
       }
     `),
     () => user$key,
   );
 
   const target = $derived(user.data.goal?.targetCharacterCount ?? null);
-  const byDate = $derived(new Map(user.data.characterCountChanges.map((h) => [dayjs(h.date).kst().format('YYYY-MM-DD'), h.additions])));
+  const characterCountChanges = $derived(
+    mergeTodayCharacterCountChanges(user.data.characterCountChanges, user.data.todayCharacterCountChange, dayClock.now),
+  );
+  const byDate = $derived(new Map(characterCountChanges.map((h) => [dayjs(h.date).kst().format('YYYY-MM-DD'), h.additions])));
 
   const days = $derived.by(() => {
-    const today = dayjs.kst().startOf('day');
+    const today = dayClock.now;
 
     return Array.from({ length: 28 }, (_, i) => {
       const date = today.subtract(27 - i, 'day');
@@ -88,7 +99,7 @@
   </div>
 
   <div class={flex({ justifyContent: 'space-between', fontSize: '10px', color: 'text.faint' })}>
-    <span>{dayjs.kst().subtract(27, 'day').format('M월 D일')}</span>
-    <span>{dayjs.kst().format('M월 D일')}{target === null ? '' : ' · ┄ 목표선'}</span>
+    <span>{dayClock.now.subtract(27, 'day').format('M월 D일')}</span>
+    <span>{dayClock.now.format('M월 D일')}{target === null ? '' : ' · ┄ 목표선'}</span>
   </div>
 </div>

--- a/apps/website/src/routes/website/(dashboard)/@stats/ActivityChart.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@stats/ActivityChart.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-  import { createFragment } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { createFloatingActions } from '@typie/ui/actions';
   import { comma } from '@typie/ui/utils';
   import dayjs from 'dayjs';
   import { fade } from 'svelte/transition';
-  import { graphql } from '$mearie';
-  import type { DashboardLayout_Stats_ActivityChart_user$key } from '$mearie';
+  import { mergeTodayCharacterCountChanges } from '$lib/user-stats';
 
   type DayData = {
     date: dayjs.Dayjs;
@@ -17,42 +15,31 @@
   };
 
   type Props = {
-    user$key: DashboardLayout_Stats_ActivityChart_user$key;
+    characterCountChanges: readonly { date: string; additions: number; deletions: number }[];
+    todayCharacterCountChange: { date: string; additions: number; deletions: number };
+    today: dayjs.Dayjs;
   };
 
   const chartHeight = 100;
 
-  const { user$key }: Props = $props();
-
-  const user = createFragment(
-    graphql(`
-      fragment DashboardLayout_Stats_ActivityChart_user on User {
-        id
-
-        characterCountChanges {
-          date
-          additions
-          deletions
-        }
-      }
-    `),
-    () => user$key,
-  );
+  const { characterCountChanges: history, todayCharacterCountChange, today }: Props = $props();
 
   let hoverData = $state<DayData & { element: HTMLElement }>();
   let isHoveringCompressedBar = $state(false);
   let showAdditions = $state(true);
   let showDeletions = $state(true);
 
+  const characterCountChanges = $derived(mergeTodayCharacterCountChanges(history, todayCharacterCountChange, today));
+
   const daysData = $derived.by<DayData[]>(() => {
     const data: DayData[] = [];
-    const endDate = dayjs.kst().startOf('day');
+    const endDate = today.startOf('day');
     const startDate = endDate.subtract(89, 'days');
 
     const changesByDate: Record<string, { additions: number; deletions: number }> = {};
 
-    for (const change of user.data.characterCountChanges) {
-      const date = dayjs(change.date).format('YYYY-MM-DD');
+    for (const change of characterCountChanges) {
+      const date = dayjs(change.date).kst().format('YYYY-MM-DD');
       changesByDate[date] = {
         additions: change.additions,
         deletions: change.deletions,

--- a/apps/website/src/routes/website/(dashboard)/@stats/ActivityGrid.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@stats/ActivityGrid.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-  import { createFragment } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { center, flex, grid } from '@typie/styled-system/patterns';
   import { createFloatingActions } from '@typie/ui/actions';
   import { comma } from '@typie/ui/utils';
   import dayjs from 'dayjs';
   import { fade } from 'svelte/transition';
-  import { graphql } from '$mearie';
-  import type { DashboardLayout_Stats_ActivityGrid_user$key } from '$mearie';
+  import { mergeTodayCharacterCountChanges } from '$lib/user-stats';
 
   type Level = 0 | 1 | 2 | 3 | 4 | 5;
 
@@ -18,34 +16,24 @@
   };
 
   type Props = {
-    user$key: DashboardLayout_Stats_ActivityGrid_user$key;
+    characterCountChanges: readonly { date: string; additions: number }[];
+    todayCharacterCountChange: { date: string; additions: number };
+    today: dayjs.Dayjs;
   };
 
-  const { user$key }: Props = $props();
-
-  const user = createFragment(
-    graphql(`
-      fragment DashboardLayout_Stats_ActivityGrid_user on User {
-        id
-
-        characterCountChanges {
-          date
-          additions
-        }
-      }
-    `),
-    () => user$key,
-  );
+  const { characterCountChanges: history, todayCharacterCountChange, today }: Props = $props();
 
   let hoverActivity = $state<Activity & { element: HTMLElement }>();
 
-  const endDate = dayjs.kst().startOf('day');
-  const startDate = endDate.subtract(364, 'days');
+  const endDate = $derived(today.startOf('day'));
+  const startDate = $derived(endDate.subtract(364, 'days'));
+
+  const characterCountChanges = $derived(mergeTodayCharacterCountChanges(history, todayCharacterCountChange, endDate));
 
   const activities = $derived.by<Activity[]>(() => {
     const activities: Activity[] = [];
 
-    const numbers = user.data.characterCountChanges.map(({ additions }) => additions).filter((n) => n > 0);
+    const numbers = characterCountChanges.map(({ additions }) => additions).filter((n) => n > 0);
 
     let p95 = 0;
     if (numbers.length > 0) {
@@ -54,7 +42,7 @@
       p95 = sorted[Math.min(index, sorted.length - 1)];
     }
 
-    const changes = Object.fromEntries(user.data.characterCountChanges.map((change) => [dayjs(change.date).unix(), change]));
+    const changes = Object.fromEntries(characterCountChanges.map((change) => [dayjs(change.date).unix(), change]));
 
     let currentDate = startDate;
     while (!currentDate.isAfter(endDate)) {

--- a/apps/website/src/routes/website/(dashboard)/@stats/StatsModal.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@stats/StatsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createMutation, createQuery } from '@mearie/svelte';
+  import { createMutation, getClient } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { Button, Icon, Modal, ProgressRing } from '@typie/ui/components';
@@ -10,120 +10,131 @@
   import mixpanel from 'mixpanel-browser';
   import CopyIcon from '~icons/lucide/copy';
   import DownloadIcon from '~icons/lucide/download';
-  import { todayProgress } from '$lib/goal';
+  import { dailyGoalStatus, mergeTodayCharacterCountChanges, writingStreaks } from '$lib/user-stats';
   import { graphql } from '$mearie';
   import ActivityChart from './ActivityChart.svelte';
   import ActivityGrid from './ActivityGrid.svelte';
+  import type { DataOf } from '@mearie/core';
 
   const app = getAppContext();
+  const client = getClient();
 
-  const query = createQuery(
-    graphql(`
-      query DashboardLayout_StatsModal_Query {
-        me @required {
+  const statsQuery = graphql(`
+    query DashboardLayout_StatsModal_Query {
+      me @required {
+        id
+        name
+        documentCount
+
+        characterCountChanges {
+          date
+          additions
+          deletions
+        }
+
+        todayCharacterCountChange {
+          date
+          additions
+          deletions
+        }
+
+        usage {
+          totalCharacterCount
+        }
+
+        goal {
           id
-          name
-          documentCount
+          targetCharacterCount
+        }
 
-          characterCountChanges {
-            date
-            additions
-          }
-
-          usage {
-            totalCharacterCount
-          }
-
-          goal {
-            id
-            targetCharacterCount
-          }
-
-          goalHistory {
-            date
-            targetCharacterCount
-            additions
-            achieved
-          }
-
-          ...DashboardLayout_Stats_ActivityChart_user
-          ...DashboardLayout_Stats_ActivityGrid_user
+        goalHistory {
+          date
+          targetCharacterCount
+          additions
+          achieved
         }
       }
-    `),
-    undefined,
-    () => ({ skip: !app.state.statsOpen }),
-  );
+    }
+  `);
+
+  const createSnapshot = (data: DataOf<typeof statsQuery>, today: dayjs.Dayjs) => ({
+    today,
+    name: data.me.name,
+    documentCount: data.me.documentCount,
+    characterCountChanges: data.me.characterCountChanges.map((change) => ({ ...change })),
+    todayCharacterCountChange: { ...data.me.todayCharacterCountChange },
+    totalCharacterCount: data.me.usage.totalCharacterCount,
+    goal: data.me.goal ? { ...data.me.goal } : null,
+    goalHistory: data.me.goalHistory.map((entry) => ({ ...entry })),
+  });
+
+  let snapshot = $state.raw<ReturnType<typeof createSnapshot>>();
+  let requestId = 0;
+
+  const loadSnapshot = async () => {
+    const id = ++requestId;
+    snapshot = undefined;
+
+    try {
+      const data = await client.query(statsQuery, {}, { fetchPolicy: 'network-only' });
+      if (id !== requestId || !app.state.statsOpen) return;
+
+      snapshot = createSnapshot(data, dayjs.kst());
+    } catch {
+      if (id !== requestId || !app.state.statsOpen) return;
+      app.state.statsOpen = false;
+      Toast.error('통계를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.');
+    }
+  };
+
+  $effect(() => {
+    if (app.state.statsOpen) {
+      void loadSnapshot();
+    } else {
+      requestId++;
+      snapshot = undefined;
+    }
+  });
 
   type StreakData = {
     currentStreak: number;
     longestStreak: number;
     thisMonthDays: number;
     totalDays: number;
-    avgCharactersPerDay: number;
   };
 
-  const calculateStreakData = (characterCountChanges: { date: unknown; additions: number }[], totalCharacterCount: number): StreakData => {
-    const today = dayjs.kst().startOf('day');
-    const activeDates = new Set(
-      characterCountChanges.filter((c) => c.additions > 0).map((c) => dayjs(c.date as string).format('YYYY-MM-DD')),
-    );
+  const calculateStreakData = (characterCountChanges: { date: string; additions: number }[], today: dayjs.Dayjs): StreakData => {
+    const startOfToday = today.startOf('day');
+    const activeDates = new Set(characterCountChanges.filter((c) => c.additions > 0).map((c) => dayjs(c.date).kst().format('YYYY-MM-DD')));
+    const streak = writingStreaks(characterCountChanges, startOfToday);
 
-    let currentStreak = 0;
-    let checkDate = today;
-
-    if (!activeDates.has(today.format('YYYY-MM-DD'))) {
-      checkDate = today.subtract(1, 'day');
-    }
-
-    while (activeDates.has(checkDate.format('YYYY-MM-DD'))) {
-      currentStreak++;
-      checkDate = checkDate.subtract(1, 'day');
-    }
-
-    let longestStreak = 0;
-    let tempStreak = 0;
-    const sortedDates = [...activeDates].toSorted((a, b) => a.localeCompare(b));
-
-    for (let i = 0; i < sortedDates.length; i++) {
-      if (i === 0) {
-        tempStreak = 1;
-      } else {
-        const prevDate = dayjs(sortedDates[i - 1]);
-        const currDate = dayjs(sortedDates[i]);
-        if (currDate.diff(prevDate, 'day') === 1) {
-          tempStreak++;
-        } else {
-          tempStreak = 1;
-        }
-      }
-      longestStreak = Math.max(longestStreak, tempStreak);
-    }
-
-    const monthStart = today.startOf('month');
+    const monthStart = startOfToday.startOf('month');
     let thisMonthDays = 0;
     for (const dateStr of activeDates) {
-      const date = dayjs(dateStr);
+      const date = dayjs.kst(dateStr);
       if (date.isSame(monthStart, 'month')) {
         thisMonthDays++;
       }
     }
 
     const totalDays = activeDates.size;
-    const avgCharactersPerDay = totalDays > 0 ? Math.round(totalCharacterCount / totalDays) : 0;
 
     return {
-      currentStreak,
-      longestStreak,
+      currentStreak: streak.current,
+      longestStreak: streak.best,
       thisMonthDays,
       totalDays,
-      avgCharactersPerDay,
     };
   };
 
+  const characterCountChanges = $derived.by(() => {
+    if (!snapshot) return [];
+    return mergeTodayCharacterCountChanges(snapshot.characterCountChanges, snapshot.todayCharacterCountChange, snapshot.today);
+  });
+
   const streakData = $derived.by(() => {
-    if (!query.data) return null;
-    return calculateStreakData([...query.data.me.characterCountChanges], query.data.me.usage.totalCharacterCount);
+    if (!snapshot) return null;
+    return calculateStreakData(characterCountChanges, snapshot.today);
   });
 
   type WeekdayData = {
@@ -136,7 +147,7 @@
 
   const weekdayLabels = ['일', '월', '화', '수', '목', '금', '토'];
 
-  const calculateWeekdayPattern = (characterCountChanges: { date: unknown; additions: number }[]): WeekdayData[] => {
+  const calculateWeekdayPattern = (characterCountChanges: { date: string; additions: number }[]): WeekdayData[] => {
     const weekdayStats = Array.from({ length: 7 }, (_, i) => ({
       dayIndex: i,
       label: weekdayLabels[i],
@@ -149,7 +160,7 @@
         continue;
       }
 
-      const dayOfWeek = dayjs(change.date as string).day();
+      const dayOfWeek = dayjs(change.date).kst().day();
       weekdayStats[dayOfWeek].totalAdditions += change.additions;
       weekdayStats[dayOfWeek].count++;
     }
@@ -161,8 +172,8 @@
   };
 
   const weekdayData = $derived.by(() => {
-    if (!query.data) return null;
-    return calculateWeekdayPattern([...query.data.me.characterCountChanges]);
+    if (!snapshot) return null;
+    return calculateWeekdayPattern(characterCountChanges);
   });
 
   const maxWeekdayAvg = $derived(weekdayData ? Math.max(...weekdayData.map((d) => d.avgAdditions)) : 0);
@@ -188,7 +199,7 @@
   const downloadActivityImage = async () => {
     const resp = await generateActivityImage();
     const b64 = resp.generateActivityImage;
-    downloadFromBase64(b64, `${query.data?.me.name ?? '타이피'} - 나의 글쓰기 발자취.png`, 'image/png');
+    downloadFromBase64(b64, `${snapshot?.name ?? '타이피'} - 나의 글쓰기 발자취.png`, 'image/png');
 
     Toast.success('이미지가 다운로드되었어요.');
   };
@@ -209,13 +220,13 @@
     padding: '24px',
     backgroundColor: 'surface.subtle',
   })}
-  loading={!query.data}
+  loading={!snapshot}
   onclose={() => {
     app.state.statsOpen = false;
   }}
   open={app.state.statsOpen}
 >
-  {#if query.data && streakData}
+  {#if snapshot && streakData}
     <div class={css({ fontSize: '17px', fontWeight: 'semibold', color: 'text.default' })}>나의 글쓰기 통계</div>
 
     <div class={flex({ flexDirection: 'column', gap: '12px' })}>
@@ -223,14 +234,14 @@
         <div class={css(cardStyle, { flex: '1' })}>
           <div class={css({ fontSize: '12px', fontWeight: 'medium', color: 'text.faint', marginBottom: '8px' })}>총 글자</div>
           <div class={css({ fontSize: '28px', fontWeight: 'bold', color: 'text.default', fontVariantNumeric: 'tabular-nums' })}>
-            {comma(query.data.me.usage.totalCharacterCount)}
+            {comma(snapshot.totalCharacterCount)}
           </div>
         </div>
 
         <div class={css(cardStyle, { flex: '1' })}>
           <div class={css({ fontSize: '12px', fontWeight: 'medium', color: 'text.faint', marginBottom: '8px' })}>총 문서</div>
           <div class={css({ fontSize: '28px', fontWeight: 'bold', color: 'text.default', fontVariantNumeric: 'tabular-nums' })}>
-            {query.data.me.documentCount}
+            {snapshot.documentCount}
           </div>
         </div>
 
@@ -296,9 +307,14 @@
       </div>
 
       <div class={css(cardStyle)}>
-        {#if query.data.me.goal}
-          {@const goal = query.data.me.goal}
-          {@const progress = todayProgress(query.data.me.goalHistory, dayjs.kst())}
+        {#if snapshot.goal}
+          {@const goal = snapshot.goal}
+          {@const progress = dailyGoalStatus(
+            snapshot.goalHistory,
+            goal.targetCharacterCount,
+            snapshot.todayCharacterCountChange,
+            snapshot.today,
+          )}
 
           <div class={flex({ justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '12px' })}>
             <div class={css({ fontSize: '12px', fontWeight: 'medium', color: 'text.faint' })}>일일 목표</div>
@@ -356,11 +372,19 @@
             </Button>
           </div>
         </div>
-        <ActivityGrid user$key={query.data.me} />
+        <ActivityGrid
+          characterCountChanges={snapshot.characterCountChanges}
+          today={snapshot.today}
+          todayCharacterCountChange={snapshot.todayCharacterCountChange}
+        />
       </div>
 
       <div class={css(cardStyle)}>
-        <ActivityChart user$key={query.data.me} />
+        <ActivityChart
+          characterCountChanges={snapshot.characterCountChanges}
+          today={snapshot.today}
+          todayCharacterCountChange={snapshot.todayCharacterCountChange}
+        />
       </div>
     </div>
   {/if}

--- a/apps/website/src/routes/website/(dashboard)/@widgets/widgets/GoalWidget.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/widgets/GoalWidget.svelte
@@ -10,8 +10,10 @@
   import ChevronDownIcon from '~icons/lucide/chevron-down';
   import ChevronUpIcon from '~icons/lucide/chevron-up';
   import TargetIcon from '~icons/lucide/target';
-  import { dueStatus, goalColorState, pickGoalSource, todayProgress } from '$lib/goal';
+  import { dueStatus, goalColorState, pickGoalSource } from '$lib/goal';
+  import { dailyGoalStatus } from '$lib/user-stats';
   import { graphql } from '$mearie';
+  import { getDayClock } from '../../day-clock.svelte';
   import Widget from '../Widget.svelte';
   import { getWidgetContext } from '../widget-context.svelte';
 
@@ -23,6 +25,7 @@
   let { widgetId, data = {} }: Props = $props();
 
   const app = getAppContext();
+  const dayClock = getDayClock();
   const widgetContext = getWidgetContext();
   const { document$key, editor } = $derived(widgetContext.env);
   let isCollapsed = $state((data.isCollapsed as boolean) ?? false);
@@ -89,6 +92,11 @@
             additions
             achieved
           }
+
+          todayCharacterCountChange {
+            date
+            additions
+          }
         }
       }
     `),
@@ -112,7 +120,10 @@
   const userGoal = $derived.by(() => {
     const me = meQuery.data?.me;
     if (!me?.goal) return null;
-    return { target: me.goal.targetCharacterCount, ...todayProgress(me.goalHistory, dayjs.kst()) };
+    return {
+      target: me.goal.targetCharacterCount,
+      ...dailyGoalStatus(me.goalHistory, me.goal.targetCharacterCount, me.todayCharacterCountChange, dayClock.now),
+    };
   });
 
   const collapsedSummary = $derived.by(() => {
@@ -154,7 +165,7 @@
     {#if entityGoal}
       {@const target = entityGoal.goal.targetCharacterCount}
       {@const state = goalColorState(entityGoal.current, target)}
-      {@const today = dayjs.kst()}
+      {@const today = dayClock.now}
       {@const due = entityGoal.goal.dueAt ? dayjs(entityGoal.goal.dueAt).kst() : null}
       <div class={flex({ flexDirection: 'column', gap: '4px' })}>
         <div class={flex({ justifyContent: 'space-between', flexWrap: 'wrap', columnGap: '8px', rowGap: '2px', fontSize: '13px' })}>

--- a/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
@@ -6,7 +6,6 @@
   import { Icon, ProgressRing, Scrollbar } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
   import { clamp } from '@typie/ui/utils';
-  import dayjs from 'dayjs';
   import mixpanel from 'mixpanel-browser';
   import { untrack } from 'svelte';
   import BarChart3Icon from '~icons/lucide/bar-chart-3';
@@ -19,7 +18,7 @@
   import TargetIcon from '~icons/lucide/target';
   import PrismIcon from '~icons/typie/prism';
   import { goto } from '$app/navigation';
-  import { streaks, todayProgress } from '$lib/goal';
+  import { dailyGoalStatus, mergeTodayCharacterCountChanges, writingStreaks } from '$lib/user-stats';
   import { graphql } from '$mearie';
   import { getPaneGroup } from './[slug]/@pane/context.svelte';
   import ChangelogPopover from './@changelog/ChangelogPopover.svelte';
@@ -28,6 +27,7 @@
   import TrialWidget from './@subscription/TrialWidget.svelte';
   import { createEntityTreeRevealRequest, entityTreeRevealState } from './@tree/entity-reveal.svelte';
   import EntityTree from './@tree/EntityTree.svelte';
+  import { getDayClock } from './day-clock.svelte';
   import FeedbackPopover from './FeedbackPopover.svelte';
   import Profile from './Profile.svelte';
   import { resolveSidebarNavigationDrag, resolveSidebarNavigationGeometry } from './sidebar-navigation-resize';
@@ -43,6 +43,7 @@
   let { user$key, changelogSuppressed }: Props = $props();
 
   const app = getAppContext();
+  const dayClock = getDayClock();
 
   const user = createFragment(
     graphql(`
@@ -74,6 +75,11 @@
           additions
         }
 
+        todayCharacterCountChange {
+          date
+          additions
+        }
+
         goal {
           targetCharacterCount
         }
@@ -93,33 +99,20 @@
   );
 
   const currentStreak = $derived.by(() => {
-    const today = dayjs.kst().startOf('day');
-    const activeDates = new Set(
-      user.data.characterCountChanges.filter((c) => c.additions > 0).map((c) => dayjs(c.date as string).format('YYYY-MM-DD')),
+    const today = dayClock.now;
+    const characterCountChanges = mergeTodayCharacterCountChanges(
+      user.data.characterCountChanges,
+      user.data.todayCharacterCountChange,
+      today,
     );
-
-    let streak = 0;
-    let checkDate = today;
-
-    if (!activeDates.has(today.format('YYYY-MM-DD'))) {
-      checkDate = today.subtract(1, 'day');
-    }
-
-    while (activeDates.has(checkDate.format('YYYY-MM-DD'))) {
-      streak++;
-      checkDate = checkDate.subtract(1, 'day');
-    }
-
-    return streak;
+    return writingStreaks(characterCountChanges, today).current;
   });
 
   const dailyGoal = $derived.by(() => {
     if (!user.data.goal) return null;
-    const today = dayjs.kst();
     return {
-      ...todayProgress(user.data.goalHistory, today),
+      ...dailyGoalStatus(user.data.goalHistory, user.data.goal.targetCharacterCount, user.data.todayCharacterCountChange, dayClock.now),
       target: user.data.goal.targetCharacterCount,
-      streak: streaks(user.data.goalHistory, today).current,
     };
   });
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/HomePane.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/HomePane.svelte
@@ -19,11 +19,12 @@
   import { goto } from '$app/navigation';
   import Logo from '$assets/logos/logo.svg?component';
   import EditorBreadcrumb from '$lib/editor-ffi/components/ui/EditorBreadcrumb.svelte';
-  import { todayProgress } from '$lib/goal';
+  import { dailyGoalStatus } from '$lib/user-stats';
   import { graphql } from '$mearie';
   import ActivityGrid from '../../@stats/ActivityGrid.svelte';
   import { SubscribeModal } from '../../@subscription/subscribe-modal.svelte';
   import TrialBanner from '../../@subscription/TrialBanner.svelte';
+  import { getDayClock } from '../../day-clock.svelte';
   import EditorBreadcrumbNavigation from '../v2/@breadcrumb/EditorBreadcrumbNavigation.svelte';
   import CloseButton from './CloseButton.svelte';
   import { getPaneGroup, setupPane } from './context.svelte';
@@ -42,6 +43,7 @@
   let { headerPlacement, pane }: Props = $props();
 
   const app = getAppContext();
+  const dayClock = getDayClock();
 
   const query = createQuery(
     graphql(`
@@ -50,8 +52,12 @@
           id
           name
 
-          ...DashboardLayout_Stats_ActivityGrid_user
           ...HomePane_TrialBanner_user
+
+          characterCountChanges {
+            date
+            additions
+          }
 
           goal {
             id
@@ -63,6 +69,11 @@
             targetCharacterCount
             additions
             achieved
+          }
+
+          todayCharacterCountChange {
+            date
+            additions
           }
 
           sites {
@@ -382,7 +393,12 @@
           <div class={flex({ alignItems: 'center', gap: '12px', width: 'full' })}>
             {#if query.data.me.goal}
               {@const goal = query.data.me.goal}
-              {@const progress = todayProgress(query.data.me.goalHistory, dayjs.kst())}
+              {@const progress = dailyGoalStatus(
+                query.data.me.goalHistory,
+                goal.targetCharacterCount,
+                query.data.me.todayCharacterCountChange,
+                dayClock.now,
+              )}
               <button
                 class={flex({ alignItems: 'center', gap: '8px', cursor: 'pointer' })}
                 onclick={() => {
@@ -416,7 +432,11 @@
 
           <div class={flex({ flexDirection: 'column', gap: '16px', width: 'full' })}>
             <h2 class={css({ fontSize: '18px', fontWeight: 'semibold', color: 'text.default' })}>최근 활동</h2>
-            <ActivityGrid user$key={query.data.me} />
+            <ActivityGrid
+              characterCountChanges={query.data.me.characterCountChanges}
+              today={dayClock.now}
+              todayCharacterCountChange={query.data.me.todayCharacterCountChange}
+            />
           </div>
         </div>
       </div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelGoal.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelGoal.svelte
@@ -9,6 +9,7 @@
   import mixpanel from 'mixpanel-browser';
   import { dueStatus, goalColorState, pickGoalSource } from '$lib/goal';
   import { graphql } from '$mearie';
+  import { getDayClock } from '../../../day-clock.svelte';
   import type { Editor } from '$lib/editor-ffi/editor.svelte';
   import type { DocumentPanelV2_Goal_document$key } from '$mearie';
 
@@ -20,6 +21,7 @@
   let { document$key, editor }: Props = $props();
 
   const app = getAppContext();
+  const dayClock = getDayClock();
 
   const document = createFragment(
     graphql(`
@@ -66,7 +68,7 @@
 
 {#if active}
   {@const state = goalColorState(active.current, active.goal.targetCharacterCount)}
-  {@const today = dayjs.kst()}
+  {@const today = dayClock.now}
   {@const due = active.goal.dueAt ? dayjs(active.goal.dueAt).kst() : null}
 
   <div class={flex({ flexDirection: 'column', gap: '6px' })}>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanelTimeline.svelte
@@ -449,6 +449,7 @@
     cache.invalidate(
       { __typename: 'User', id: app.userId, $field: 'characterCountChanges' },
       { __typename: 'User', id: app.userId, $field: 'goalHistory' },
+      { __typename: 'User', id: app.userId, $field: 'todayCharacterCountChange' },
       { __typename: 'Document', id: document.data.id, $field: 'characterCountChange' },
     );
   };

--- a/apps/website/src/routes/website/(dashboard)/day-clock.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/day-clock.svelte.ts
@@ -1,0 +1,49 @@
+import { createStableContext } from '@typie/ui/context/stable';
+import dayjs from 'dayjs';
+import { onMount } from 'svelte';
+import { delayUntilNextKstDay } from './day-clock';
+import type { Dayjs } from 'dayjs';
+
+type DayClock = {
+  readonly now: Dayjs;
+};
+
+const [getDayClock, setDayClock] = createStableContext<DayClock>('dashboard.DayClock');
+
+export { getDayClock };
+
+export const setupDayClock = (): DayClock => {
+  let dayKey = $state(dayjs.kst().format('YYYY-MM-DD'));
+
+  onMount(() => {
+    let timer: number | undefined;
+
+    const refresh = () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+
+      const now = dayjs.kst();
+      dayKey = now.format('YYYY-MM-DD');
+      timer = window.setTimeout(refresh, delayUntilNextKstDay(now) + 1);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+
+    refresh();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  });
+
+  return setDayClock({
+    get now() {
+      // Keep the current timestamp, but make consumers reactive to KST day changes.
+      void dayKey;
+      return dayjs.kst();
+    },
+  });
+};

--- a/apps/website/src/routes/website/(dashboard)/day-clock.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/day-clock.test.ts
@@ -1,0 +1,19 @@
+import '@typie/lib/dayjs';
+
+import dayjs from 'dayjs';
+import { describe, expect, test } from 'vitest';
+import { delayUntilNextKstDay } from './day-clock';
+
+describe('delayUntilNextKstDay', () => {
+  test('returns the remaining time until the next KST midnight', () => {
+    const now = dayjs('2026-08-31T14:59:59.500Z');
+
+    expect(delayUntilNextKstDay(now)).toBe(500);
+  });
+
+  test('uses KST day boundaries for times in another offset', () => {
+    const now = dayjs('2026-08-31T00:00:00-07:00');
+
+    expect(delayUntilNextKstDay(now)).toBe(8 * 60 * 60 * 1000);
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/day-clock.ts
+++ b/apps/website/src/routes/website/(dashboard)/day-clock.ts
@@ -1,0 +1,6 @@
+import type { Dayjs } from 'dayjs';
+
+export const delayUntilNextKstDay = (now: Dayjs): number => {
+  const kstNow = now.kst();
+  return kstNow.add(1, 'day').startOf('day').diff(kstNow);
+};


### PR DESCRIPTION
## 배경

오늘 글자 수를 포함한 일별 통계와 목표 이력이 대시보드에서 즉시 갱신되지 않아 다음과 같은 문제가 있었습니다.

1. 일일 목표가 1,000자인 상태에서 대시보드를 열었을 때 오늘 글자 수가 700자였고, 이후 400자를 더 작성해 실제로는 1,100자가 되어도 사이드바와 목표 위젯은 계속 700자와 미달성 상태를 표시할 수 있었습니다.
2. 목표를 달성한 뒤 글을 삭제하거나 문서를 통계에서 제외해 실제 글자 수가 다시 목표보다 낮아져도, 기존 달성 상태와 연속 기록이 새로고침 전까지 남을 수 있었습니다.
3. 다른 탭에서 글을 작성한 뒤 통계 모달을 열어도 캐시된 글자 수와 활동 차트가 표시될 수 있었습니다.
4. 대시보드를 자정이 지나도록 열어 두면 목표, 연속 기록, 차트의 ‘오늘’이 새 날짜로 넘어가지 않을 수 있었습니다.

## 변경 사항

- API에서 오늘의 글자 수 변동을 별도로 제공하고, 글자 수 집계나 통계 포함 여부가 바뀌면 대시보드에 갱신을 알립니다.
- 과거 일별 통계의 오늘 항목을 최신 글자 수로 교체해 목표 진행률, 달성 여부, 연속 기록과 활동 차트가 같은 데이터를 사용하도록 했습니다.
- 통계 모달은 열 때 서버에서 최신 데이터를 가져오고, 열려 있는 동안에는 해당 스냅샷을 유지합니다.
- KST 자정과 백그라운드 복귀 시 날짜 기반 UI가 새 날짜를 사용하도록 했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>