### PR TITLE
marquee 공용화 및 추가 적용

### DIFF
--- a/apps/website/src/lib/marquee-motion.test.ts
+++ b/apps/website/src/lib/marquee-motion.test.ts
@@ -1,17 +1,17 @@
+import { advanceMarqueeMotion } from '@typie/ui/utils';
 import { describe, expect, it } from 'vitest';
-import { advanceEntityNameMotion } from './entity-name-motion';
 
 const motionAt = (maximum: number, elapsed: number) => {
   let state = { position: 0, velocity: 0 };
 
   for (let time = 0; time < elapsed; time++) {
-    state = advanceEntityNameMotion({ ...state, maximum, elapsed: 1 });
+    state = advanceMarqueeMotion({ ...state, maximum, elapsed: 1 });
   }
 
   return state;
 };
 
-describe('dynamic entity name motion', () => {
+describe('marquee motion', () => {
   it('eases around one fixed spatial rate for a stable endpoint', () => {
     expect(motionAt(48, 100).position).toBeCloseTo(1.2, 1);
     expect(motionAt(48, 200)).toEqual({ position: expect.closeTo(4.8, 1), velocity: expect.closeTo(0.048, 4) });
@@ -32,11 +32,11 @@ describe('dynamic entity name motion', () => {
     let state = { position: 0, velocity: 0 };
 
     for (let elapsed = 0; elapsed < 600; elapsed += 10) {
-      state = advanceEntityNameMotion({ ...state, maximum: 48, elapsed: 10 });
+      state = advanceMarqueeMotion({ ...state, maximum: 48, elapsed: 10 });
     }
 
     const beforeResize = state;
-    state = advanceEntityNameMotion({ ...state, maximum: 72, elapsed: 16 });
+    state = advanceMarqueeMotion({ ...state, maximum: 72, elapsed: 16 });
 
     expect(state.position).toBeGreaterThan(beforeResize.position);
     expect(state.velocity).toBeCloseTo(beforeResize.velocity, 4);
@@ -44,16 +44,16 @@ describe('dynamic entity name motion', () => {
   });
 
   it('clamps only to a nearer endpoint and resumes from a settled position when it grows again', () => {
-    const clamped = advanceEntityNameMotion({ position: 30, velocity: 0.048, maximum: 20, elapsed: 16 });
+    const clamped = advanceMarqueeMotion({ position: 30, velocity: 0.048, maximum: 20, elapsed: 16 });
     expect(clamped).toEqual({ position: 20, velocity: 0 });
 
-    const resumed = advanceEntityNameMotion({ ...clamped, maximum: 35, elapsed: 16 });
+    const resumed = advanceMarqueeMotion({ ...clamped, maximum: 35, elapsed: 16 });
     expect(resumed.position).toBeGreaterThan(20);
     expect(resumed.velocity).toBeGreaterThan(0);
     expect(resumed.velocity).toBeLessThanOrEqual(0.048);
   });
 
   it('does not move for a non-positive endpoint', () => {
-    expect(advanceEntityNameMotion({ position: 0, velocity: 0, maximum: 0, elapsed: 100 })).toEqual({ position: 0, velocity: 0 });
+    expect(advanceMarqueeMotion({ position: 0, velocity: 0, maximum: 0, elapsed: 100 })).toEqual({ position: 0, velocity: 0 });
   });
 });

--- a/apps/website/src/lib/marquee.browser.test.ts
+++ b/apps/website/src/lib/marquee.browser.test.ts
@@ -1,0 +1,119 @@
+import '../app.css';
+
+import { Marquee } from '@typie/ui/components';
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+
+let component: Record<string, unknown> | undefined;
+
+const frame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+const frames = async (count = 2) => {
+  for (let index = 0; index < count; index++) await frame();
+};
+
+const pointer = (element: HTMLElement, type: 'pointerenter' | 'pointerleave') => {
+  element.dispatchEvent(new PointerEvent(type, { pointerType: 'mouse' }));
+};
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  document.body.replaceChildren();
+});
+
+describe('shared marquee', () => {
+  it('reveals overflowing text from keyboard focus or parent hover and resets afterward', async () => {
+    const before = document.createElement('button');
+    const button = document.createElement('button');
+    const after = document.createElement('button');
+    Object.assign(button.style, { display: 'block', padding: '0', width: '240px' });
+    document.body.append(before, button, after);
+
+    component = mount(Marquee, {
+      target: button,
+      props: {
+        getTrigger: (element) => element.parentElement,
+        text: 'Reorder mutation 동기화 구조 검토 및 후속 작업 정리',
+      },
+    });
+    await tick();
+    await document.fonts.ready;
+    await frames();
+
+    const viewport = button.firstElementChild;
+    expect(viewport).toBeInstanceOf(HTMLSpanElement);
+    if (!(viewport instanceof HTMLSpanElement)) return;
+
+    before.focus();
+    await userEvent.keyboard('{Tab}');
+    expect(document.activeElement).toBe(button);
+    expect(button.matches(':focus-visible')).toBe(true);
+    await expect.poll(() => viewport.scrollLeft, { interval: 16, timeout: 350 }).toBeGreaterThan(0);
+
+    await userEvent.keyboard('{Tab}');
+    expect(document.activeElement).toBe(after);
+    expect(viewport.scrollLeft).toBe(0);
+
+    pointer(button, 'pointerenter');
+    await expect.poll(() => viewport.scrollLeft, { timeout: 2500 }).toBeGreaterThan(0);
+
+    pointer(button, 'pointerleave');
+    expect(viewport.scrollLeft).toBe(0);
+  });
+
+  it('bleeds its viewport without moving the resting text', async () => {
+    const button = document.createElement('button');
+    Object.assign(button.style, { border: '0', boxSizing: 'border-box', display: 'flex', padding: '0 8px', width: '240px' });
+    document.body.append(button);
+
+    component = mount(Marquee, {
+      target: button,
+      props: {
+        bleed: { start: 8, end: 4 },
+        text: 'Reorder mutation 동기화 구조 검토 및 후속 작업 정리',
+      },
+    });
+    await tick();
+    await document.fonts.ready;
+    await frames();
+
+    const viewport = button.firstElementChild;
+    const content = viewport?.firstElementChild;
+    expect(viewport).toBeInstanceOf(HTMLSpanElement);
+    expect(content).toBeInstanceOf(HTMLSpanElement);
+    if (!(viewport instanceof HTMLSpanElement) || !(content instanceof HTMLSpanElement)) return;
+
+    const buttonRect = button.getBoundingClientRect();
+    const viewportRect = viewport.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    expect(viewportRect.left).toBeCloseTo(buttonRect.left, 0);
+    expect(viewportRect.right).toBeCloseTo(buttonRect.right - 4, 0);
+    expect(contentRect.left).toBeCloseTo(buttonRect.left + 8, 0);
+  });
+
+  it('clips without rendering a legacy ellipsis', async () => {
+    const style = document.createElement('style');
+    style.textContent = '.legacy-ellipsis { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }';
+    const target = document.createElement('div');
+    target.style.width = '240px';
+    document.body.append(style, target);
+
+    component = mount(Marquee, {
+      target,
+      props: {
+        class: 'legacy-ellipsis',
+        text: 'Reorder mutation 동기화 구조 검토 및 후속 작업 정리',
+      },
+    });
+    await tick();
+    await frames();
+
+    const viewport = target.firstElementChild;
+    expect(viewport).toBeInstanceOf(HTMLSpanElement);
+    if (!(viewport instanceof HTMLSpanElement)) return;
+
+    expect(getComputedStyle(viewport).textOverflow).toBe('clip');
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
@@ -6,7 +6,7 @@
   import { css, cx } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { tooltip } from '@typie/ui/actions';
-  import { Button, Icon, Menu, MenuItem } from '@typie/ui/components';
+  import { Button, Icon, Marquee, Menu, MenuItem } from '@typie/ui/components';
   import { getAppContext, getThemeContext } from '@typie/ui/context';
   import { Dialog, Toast } from '@typie/ui/notification';
   import { prefersReducedMotion } from '@typie/ui/state';
@@ -442,25 +442,7 @@
   let listOpen = $state(false);
   const listToggleLabel = $derived(listOpen ? '대화 목록 닫기' : '대화 목록 열기');
   const currentTitle = $derived(currentSession ? sessionLabel(currentSession) : '새 대화');
-  let currentTitleButton = $state<HTMLButtonElement>();
-  let currentTitleClientWidth = $state(0);
-  let currentTitleTruncated = $state(false);
-
-  $effect(() => {
-    const element = currentTitleButton;
-    void currentTitle;
-    void currentTitleClientWidth;
-    if (!element) return;
-
-    let cancelled = false;
-    void tick().then(() => {
-      if (!cancelled) currentTitleTruncated = element.scrollWidth > element.clientWidth;
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  });
+  const getTitleButton = (element: HTMLElement) => element.parentElement;
 
   export const startNewChat = async (via: 'command_palette' | 'header', nextDraft?: string) => {
     if (selected.current === null) {
@@ -910,12 +892,6 @@
 
 <svelte:document bind:visibilityState />
 
-{#snippet currentTitleTooltip()}
-  <span class={css({ display: 'block', maxWidth: '280px', overflowWrap: 'break-word', textWrap: 'balance', wordBreak: 'keep-all' })}>
-    {currentTitle}
-  </span>
-{/snippet}
-
 <PrismPanelHeader>
   {#snippet children(buttonClass)}
     {#if titleEditing}
@@ -954,29 +930,23 @@
       />
     {:else}
       <button
-        bind:this={currentTitleButton}
         class={css({
           marginLeft: 'auto',
           minWidth: '0',
           maxWidth: '220px',
-          paddingX: '8px',
-          paddingY: '4px',
           borderRadius: '6px',
           fontSize: '12px',
           color: 'text.subtle',
           overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
           backgroundColor: listOpen ? 'surface.muted' : 'transparent',
           _hover: { backgroundColor: 'surface.muted' },
         })}
         aria-label={`${listToggleLabel}: ${currentTitle}`}
         onclick={() => (listOpen = !listOpen)}
         type="button"
-        bind:clientWidth={currentTitleClientWidth}
-        use:tooltip={{ message: currentTitleTruncated ? currentTitleTooltip : listToggleLabel, arrow: !currentTitleTruncated }}
+        use:tooltip={{ message: '대화 목록 열기' }}
       >
-        {currentTitle}
+        <Marquee class={css({ paddingX: '8px', paddingY: '4px' })} fogSize={16} getTrigger={getTitleButton} text={currentTitle} />
       </button>
     {/if}
 

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismSessionList.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismSessionList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
-  import { Icon, Menu, MenuItem, Scrollbar, TimeAgo } from '@typie/ui/components';
+  import { Icon, Marquee, Menu, MenuItem, Scrollbar, TimeAgo } from '@typie/ui/components';
   import dayjs from 'dayjs';
   import { tick } from 'svelte';
   import ArchiveIcon from '~icons/lucide/archive';
@@ -50,6 +50,7 @@
 
   const labelOf = sessionLabel;
   const unread = hasUnread;
+  const getSessionRow = (element: HTMLElement) => element.closest<HTMLElement>('[role="option"]');
 
   const searching = $derived(query.trim().length > 0);
   const matched = $derived(sessions.filter((session) => matchesSessionQuery(session.title, query)));
@@ -155,7 +156,7 @@
     textAlign: 'left',
   });
 
-  const rowTitle = css({ flexGrow: '1', minWidth: '0', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' });
+  const rowTitle = css({ flexGrow: '1', minWidth: '0' });
 
   const rowDot = css({ flexShrink: '0', size: '6px', borderRadius: 'full', backgroundColor: 'accent.info.default' });
 
@@ -350,7 +351,7 @@
       />
     {:else}
       <button class={rowButton} onclick={() => onSelect(session.id)} type="button">
-        <span class={`title ${rowTitle}`}>{labelOf(session)}</span>
+        <Marquee class={`title ${rowTitle}`} bleed={8} fogSize={16} getTrigger={getSessionRow} text={labelOf(session)} />
         {#if unread(session)}
           <span class={rowDot} aria-hidden="true"></span>
           <span class={css({ srOnly: true })}>확인할 항목 있음</span>

--- a/apps/website/src/routes/website/(dashboard)/@prism/cards/PrismDocumentCard.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/cards/PrismDocumentCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createQuery } from '@mearie/svelte';
   import { css } from '@typie/styled-system/css';
-  import { Icon } from '@typie/ui/components';
+  import { Icon, Marquee } from '@typie/ui/components';
   import { z } from 'zod';
   import ChevronRightIcon from '~icons/lucide/chevron-right';
   import FileTextIcon from '~icons/lucide/file-text';
@@ -46,6 +46,7 @@
 
   const doc = $derived(query.data?.documentById ?? null);
   const title = $derived(doc?.nullableTitle ?? '제목 없음');
+  const getCard = (element: HTMLElement) => element.parentElement;
 
   const frameStyle = css.raw({
     display: 'flex',
@@ -100,9 +101,7 @@
     type="button"
   >
     <Icon style={css.raw({ flexShrink: '0', color: 'text.subtle' })} icon={FileTextIcon} size={14} />
-    <span class={css({ minWidth: '0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 'semibold' })}>
-      {title}
-    </span>
+    <Marquee class={css({ minWidth: '0', fontWeight: 'semibold' })} bleed={8} fogSize={16} getTrigger={getCard} text={title} />
     <span
       class={css({
         flexShrink: '0',

--- a/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewConfirmCard.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewConfirmCard.svelte
@@ -5,7 +5,7 @@
   import { ConfirmDecisionSchema, ConfirmHintSchema, quoteReviewCredits } from '@typie/prism';
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
-  import { Button, Icon, Menu, MenuItem, TimeAgo } from '@typie/ui/components';
+  import { Button, Icon, Marquee, Menu, MenuItem, TimeAgo } from '@typie/ui/components';
   import { Toast } from '@typie/ui/notification';
   import dayjs from 'dayjs';
   import mixpanel from 'mixpanel-browser';
@@ -43,6 +43,8 @@
   let pickedTier = $state<PrismReviewTierName | null>(null);
   let pickedLineage = $state<string | 'fresh' | null>(null);
   let busy = $state(false);
+  const getTitleControl = (element: HTMLElement) => element.parentElement;
+  const getMenuItem = (element: HTMLElement) => element.closest<HTMLElement>('[role="menuitem"]');
 
   const selected = $derived(
     documents.find((doc) => doc.documentId === picked) ??
@@ -512,7 +514,13 @@
       )}
       aria-current={decided ? 'true' : undefined}
     >
-      <span class={ellipsisClass}>{chosenTitle || (decided ? '제목 없음' : '—')}</span>
+      <Marquee
+        class={css({ flexGrow: '1' })}
+        bleed={10}
+        fogSize={20}
+        getTrigger={getTitleControl}
+        text={chosenTitle || (decided ? '제목 없음' : '—')}
+      />
     </div>
   {:else if documents.length === 0}
     <div class={css(readonlyOptionStyle, { marginBottom: '12px', color: 'text.faint', borderColor: 'border.subtle' })}>
@@ -527,7 +535,7 @@
       setFullWidth
     >
       {#snippet button({ open: expanded })}
-        <span class={shrinkTitleClass}>{selected?.title || '제목 없음'}</span>
+        <Marquee bleed={{ start: 10, end: 8 }} fogSize={16} getTrigger={getTitleControl} text={selected?.title || '제목 없음'} />
         {#if current !== null}
           <span class={countClass}>원고 {current.characterCount.toLocaleString()}자</span>
         {:else if loading}
@@ -543,9 +551,13 @@
       {#each documents as doc (doc.documentId)}
         <MenuItem onclick={() => (picked = doc.documentId)}>
           <div class={flex({ alignItems: 'center', gap: '8px', flexGrow: '1', minWidth: '0' })}>
-            <span class={css({ flexGrow: '1', minWidth: '0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })}>
-              {doc.title || '제목 없음'}
-            </span>
+            <Marquee
+              class={css({ flexGrow: '1', minWidth: '0' })}
+              bleed={8}
+              fogSize={16}
+              getTrigger={getMenuItem}
+              text={doc.title || '제목 없음'}
+            />
             {#if doc.active}
               <span class={activeTagClass}>활성</span>
             {/if}

--- a/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewPassage.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewPassage.svelte
@@ -3,7 +3,7 @@
   import { ConfirmDecisionSchema, PRISM_REVIEW_TIERS } from '@typie/prism';
   import { css } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
-  import { Button, Icon, Tooltip } from '@typie/ui/components';
+  import { Button, Icon, Marquee, Tooltip } from '@typie/ui/components';
   import { tick, untrack } from 'svelte';
   import { fade } from 'svelte/transition';
   import CheckIcon from '~icons/lucide/check';
@@ -481,9 +481,6 @@
     minWidth: '0',
     fontSize: '13px',
     fontWeight: 'semibold',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
   });
   const metaClass = css({ flexShrink: '0', fontSize: '11px', color: 'text.faint' });
   const rightClass = flex({ alignItems: 'center', gap: '8px', marginLeft: 'auto', flexShrink: '0' });
@@ -497,9 +494,6 @@
     minWidth: '0',
     fontSize: '12px',
     color: 'text.faint',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
   });
   const timeClass = css({ flexShrink: '0', marginLeft: 'auto', fontSize: '11px', color: 'text.disabled' });
   const chevronStyle = css.raw({
@@ -568,6 +562,12 @@
     animation: 'pulse 1.6s ease-in-out infinite',
   });
   const systemClass = css({ marginTop: '10px', fontSize: '[12.5px]', color: 'text.faint' });
+  const getParent = (element: HTMLElement) => element.parentElement;
+  const stageSummaryText = (stage: StageView) => {
+    if (stage.status === 'canceled') return '여기서 중단했어요';
+    if (stage.status === 'failed') return '문제가 생겨 멈췄어요';
+    return `${stage.summary ?? ''}${stage.rounds > 0 ? ` · 점검 ${stage.rounds}회` : ''}`;
+  };
 </script>
 
 {#snippet stageGlyph(status: StageView['status'])}
@@ -696,11 +696,7 @@
     {#if stage.status === 'running'}
       <span class={timeClass}>{stage.elapsedMs === null ? '' : runningLabel(stage.elapsedMs)}</span>
     {:else if stage.status !== 'pending'}
-      <span class={summaryClass}>
-        {#if stage.status === 'canceled'}여기서 중단했어요{:else if stage.status === 'failed'}문제가 생겨 멈췄어요{:else}{stage.summary ??
-            ''}{#if stage.rounds > 0}
-            · 점검 {stage.rounds}회{/if}{/if}
-      </span>
+      <Marquee class={summaryClass} bleed={8} fogSize={16} getTrigger={getParent} text={stageSummaryText(stage)} />
       <span class={timeClass}>{stage.elapsedMs === null ? '' : spentLabel(stage.elapsedMs)}</span>
       {#if toggleable}
         <Icon style={css.raw(chevronStyle, open ? chevronOpenStyle : {})} icon={ChevronDownIcon} size={10} />
@@ -716,7 +712,7 @@
 
 <div>
   <div class={headClass}>
-    <span class={titleClass}>{title}</span>
+    <Marquee class={titleClass} bleed={8} fogSize={16} getTrigger={getParent} text={title} />
     <span class={metaClass}>
       {#if tierLabel !== null}· {tierLabel}{/if}{#if round !== null && round.ordinal > 1}
         · {round.ordinal}회차{/if}

--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityName.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityName.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
-  import { hoverIntent, scrollFog } from '@typie/ui/actions';
-  import { prefersReducedMotion as reducedMotionPreference } from '@typie/ui/state';
-  import { onDestroy, onMount } from 'svelte';
-  import { advanceEntityNameMotion } from './entity-name-motion';
+  import { Marquee } from '@typie/ui/components';
 
   type Props = {
     name: string;
@@ -12,145 +9,21 @@
 
   let { name, active = false }: Props = $props();
 
-  const HOVER_DELAY = 400;
-
-  let viewport = $state<HTMLSpanElement>();
-  let viewportWidth = $state(0);
-  let contentWidth = $state(0);
-  const prefersReducedMotion = $derived(reducedMotionPreference.current);
-  let animationFrame: number | undefined;
-  let hovered = false;
-  let hoverReady = $state(false);
-  let motionPosition = 0;
-  let motionVelocity = 0;
-  let previousFrameTime: number | undefined;
-
-  const cancelAnimation = () => {
-    if (animationFrame !== undefined) {
-      window.cancelAnimationFrame(animationFrame);
-      animationFrame = undefined;
-    }
-    motionVelocity = 0;
-    previousFrameTime = undefined;
-  };
-
-  const settleAt = (element: HTMLSpanElement, position: number) => {
-    cancelAnimation();
-    motionPosition = position;
-    element.scrollLeft = position;
-  };
-
-  const reset = () => {
-    cancelAnimation();
-    motionPosition = 0;
-    if (viewport) viewport.scrollLeft = 0;
-  };
-
-  const startMotion = () => {
-    const element = viewport;
-    if (!hovered || !hoverReady || !element) return;
-
-    const maximumScrollLeft = Math.max(0, element.scrollWidth - element.clientWidth);
-    if (prefersReducedMotion || maximumScrollLeft <= element.scrollLeft) {
-      settleAt(element, maximumScrollLeft);
-      return;
-    }
-
-    if (animationFrame !== undefined) return;
-
-    motionPosition = element.scrollLeft;
-
-    const advance = (time: number) => {
-      animationFrame = undefined;
-      if (!hovered || !hoverReady || viewport !== element) {
-        cancelAnimation();
-        return;
-      }
-
-      const maximum = Math.max(0, element.scrollWidth - element.clientWidth);
-      const elapsed = previousFrameTime === undefined ? 0 : time - previousFrameTime;
-      previousFrameTime = time;
-      const next = advanceEntityNameMotion({ position: motionPosition, velocity: motionVelocity, maximum, elapsed });
-
-      motionPosition = next.position;
-      element.scrollLeft = next.position;
-      motionVelocity = next.velocity;
-
-      if (next.position < maximum) {
-        animationFrame = window.requestAnimationFrame(advance);
-      } else {
-        motionVelocity = 0;
-        previousFrameTime = undefined;
-      }
-    };
-
-    animationFrame = window.requestAnimationFrame(advance);
-  };
-
-  $effect(() => {
-    void name;
-    reset();
-    if (hoverReady) startMotion();
-  });
-
-  $effect(() => {
-    void viewportWidth;
-    void contentWidth;
-    if (hoverReady) startMotion();
-  });
-
-  $effect(() => {
-    if (!prefersReducedMotion || !hoverReady || !viewport) return;
-    settleAt(viewport, Math.max(0, viewport.scrollWidth - viewport.clientWidth));
-  });
-
-  onMount(() => {
-    const hoverTarget = viewport?.closest<HTMLElement>('[role="treeitem"]');
-    const hoverIntentAction = hoverTarget
-      ? hoverIntent(hoverTarget, {
-          delay: HOVER_DELAY,
-          onEnter: () => {
-            hovered = true;
-          },
-          onIntent: () => {
-            hoverReady = true;
-            startMotion();
-          },
-          onLeave: () => {
-            hovered = false;
-            hoverReady = false;
-            reset();
-          },
-        })
-      : undefined;
-    return () => {
-      hoverIntentAction?.destroy?.();
-    };
-  });
-
-  onDestroy(cancelAnimation);
+  const getEntityRow = (element: HTMLElement) => element.closest<HTMLElement>('.group, [role="treeitem"]');
 </script>
 
-<span
-  bind:this={viewport}
+<Marquee
   class={css(
     {
-      display: 'block',
       flexGrow: '1',
-      minWidth: '0',
-      marginX: '-6px',
-      paddingX: '6px',
-      overflowX: 'hidden',
-      whiteSpace: 'nowrap',
-      scrollbarWidth: 'none',
       fontSize: '14px',
       fontWeight: 'medium',
       color: 'text.muted',
     },
     active && { fontWeight: 'bold', color: 'text.default' },
   )}
-  bind:clientWidth={viewportWidth}
-  use:scrollFog={{ orientation: 'horizontal' }}
->
-  <span class={css({ display: 'inline-block' })} bind:offsetWidth={contentWidth}>{name}</span>
-</span>
+  bleed={6}
+  fogSize={12}
+  getTrigger={getEntityRow}
+  text={name}
+/>

--- a/packages/ui/src/components/Marquee.svelte
+++ b/packages/ui/src/components/Marquee.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import { css, cx } from '@typie/styled-system/css';
+  import { onDestroy, untrack } from 'svelte';
+  import { hoverIntent } from '../actions/hover-intent.svelte';
+  import { scrollFog } from '../actions/scroll-fog.svelte';
+  import { prefersReducedMotion as reducedMotionPreference } from '../state/reduced-motion.svelte';
+  import { advanceMarqueeMotion } from '../utils/marquee-motion';
+
+  type Bleed = number | { start?: number; end?: number };
+
+  type Props = {
+    bleed?: Bleed;
+    class?: string;
+    fogSize?: number;
+    getTrigger?: (element: HTMLElement) => HTMLElement | null;
+    text: string;
+  };
+
+  const HOVER_DELAY = 400;
+  const self = (element: HTMLElement) => element;
+  const normalizeBleed = (value: number | undefined) => (value === undefined || !Number.isFinite(value) ? 0 : Math.max(0, value));
+
+  let { bleed, class: className, fogSize, getTrigger = self, text }: Props = $props();
+
+  let viewport = $state<HTMLSpanElement>();
+  let viewportWidth = $state(0);
+  let contentWidth = $state(0);
+  const prefersReducedMotion = $derived(reducedMotionPreference.current);
+  const bleedInsets = $derived.by(() => {
+    if (typeof bleed === 'number') {
+      const inset = normalizeBleed(bleed);
+      return { start: inset, end: inset };
+    }
+    return { start: normalizeBleed(bleed?.start), end: normalizeBleed(bleed?.end) };
+  });
+  let animationFrame: number | undefined;
+  let hovered = false;
+  let hoverReady = false;
+  let keyboardFocused = false;
+  let motionPosition = 0;
+  let motionVelocity = 0;
+  let previousFrameTime: number | undefined;
+
+  const active = () => (hovered && hoverReady) || keyboardFocused;
+
+  const cancelAnimation = () => {
+    if (animationFrame !== undefined) {
+      window.cancelAnimationFrame(animationFrame);
+      animationFrame = undefined;
+    }
+    motionVelocity = 0;
+    previousFrameTime = undefined;
+  };
+
+  const settleAt = (element: HTMLSpanElement, position: number) => {
+    cancelAnimation();
+    motionPosition = position;
+    element.scrollLeft = position;
+  };
+
+  const reset = () => {
+    cancelAnimation();
+    motionPosition = 0;
+    if (viewport) viewport.scrollLeft = 0;
+  };
+
+  const startMotion = () => {
+    const element = viewport;
+    if (!element || !active()) return;
+
+    const maximumScrollLeft = Math.max(0, element.scrollWidth - element.clientWidth);
+    if (prefersReducedMotion || maximumScrollLeft <= element.scrollLeft) {
+      settleAt(element, maximumScrollLeft);
+      return;
+    }
+
+    if (animationFrame !== undefined) return;
+
+    motionPosition = element.scrollLeft;
+
+    const advance = (time: number) => {
+      animationFrame = undefined;
+      if (viewport !== element || !active()) {
+        cancelAnimation();
+        return;
+      }
+
+      const maximum = Math.max(0, element.scrollWidth - element.clientWidth);
+      const elapsed = previousFrameTime === undefined ? 0 : time - previousFrameTime;
+      previousFrameTime = time;
+      const next = advanceMarqueeMotion({ position: motionPosition, velocity: motionVelocity, maximum, elapsed });
+
+      motionPosition = next.position;
+      element.scrollLeft = next.position;
+      motionVelocity = next.velocity;
+
+      if (next.position < maximum) {
+        animationFrame = window.requestAnimationFrame(advance);
+      } else {
+        motionVelocity = 0;
+        previousFrameTime = undefined;
+      }
+    };
+
+    animationFrame = window.requestAnimationFrame(advance);
+  };
+
+  $effect(() => {
+    void text;
+    untrack(() => {
+      reset();
+      if (active()) startMotion();
+    });
+  });
+
+  $effect(() => {
+    void viewportWidth;
+    void contentWidth;
+    untrack(() => {
+      if (active()) startMotion();
+    });
+  });
+
+  $effect(() => {
+    if (!viewport || !prefersReducedMotion || !active()) return;
+    settleAt(viewport, Math.max(0, viewport.scrollWidth - viewport.clientWidth));
+  });
+
+  $effect(() => {
+    const element = viewport;
+    if (!element) return;
+
+    const trigger = getTrigger(element);
+    if (!trigger) return;
+
+    const action = hoverIntent(trigger, {
+      delay: HOVER_DELAY,
+      onEnter: () => {
+        hovered = true;
+      },
+      onIntent: () => {
+        hoverReady = true;
+        startMotion();
+      },
+      onLeave: () => {
+        hovered = false;
+        hoverReady = false;
+        if (!keyboardFocused) reset();
+      },
+    });
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target;
+      keyboardFocused = target instanceof HTMLElement && target.matches(':focus-visible');
+      if (keyboardFocused) startMotion();
+      else if (!hovered || !hoverReady) reset();
+    };
+    const handleFocusOut = (event: FocusEvent) => {
+      const next = event.relatedTarget;
+      if (next instanceof Node && trigger.contains(next)) return;
+      keyboardFocused = false;
+      if (!hovered || !hoverReady) reset();
+    };
+
+    trigger.addEventListener('focusin', handleFocusIn);
+    trigger.addEventListener('focusout', handleFocusOut);
+
+    return () => {
+      action?.destroy?.();
+      trigger.removeEventListener('focusin', handleFocusIn);
+      trigger.removeEventListener('focusout', handleFocusOut);
+    };
+  });
+
+  onDestroy(cancelAnimation);
+</script>
+
+<span
+  bind:this={viewport}
+  style:margin-inline-end={bleedInsets.end > 0 ? `${-bleedInsets.end}px` : undefined}
+  style:margin-inline-start={bleedInsets.start > 0 ? `${-bleedInsets.start}px` : undefined}
+  style:padding-inline-end={bleedInsets.end > 0 ? `${bleedInsets.end}px` : undefined}
+  style:padding-inline-start={bleedInsets.start > 0 ? `${bleedInsets.start}px` : undefined}
+  style:text-overflow="clip"
+  class={cx(
+    css({
+      display: 'block',
+      minWidth: '0',
+      overflowX: 'hidden',
+      whiteSpace: 'nowrap',
+      scrollbarWidth: 'none',
+    }),
+    className,
+  )}
+  bind:clientWidth={viewportWidth}
+  use:scrollFog={{ orientation: 'horizontal', size: fogSize }}
+>
+  <span class={css({ display: 'inline-block' })} bind:offsetWidth={contentWidth}>{text}</span>
+</span>

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -9,6 +9,7 @@ export { default as Helmet } from './Helmet.svelte';
 export { default as HorizontalDivider } from './HorizontalDivider.svelte';
 export { default as Icon } from './Icon.svelte';
 export { default as Img } from './Img.svelte';
+export { default as Marquee } from './Marquee.svelte';
 export { default as Menu } from './Menu.svelte';
 export { default as MenuItem } from './MenuItem.svelte';
 export { default as Modal } from './Modal.svelte';

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './escape-stack';
 export * from './flip-animation';
 export * from './hover-focus';
 export * from './json';
+export * from './marquee-motion';
 export * from './number';
 export * from './ref';
 export * from './remeda';

--- a/packages/ui/src/utils/marquee-motion.ts
+++ b/packages/ui/src/utils/marquee-motion.ts
@@ -3,24 +3,24 @@ const RAMP_DURATION_MS = 200;
 const MAX_FRAME_DURATION_MS = 64;
 const INTEGRATION_STEP_MS = 1;
 
-type AdvanceEntityNameMotionOptions = {
+type AdvanceMarqueeMotionOptions = {
   position: number;
   velocity: number;
   maximum: number;
   elapsed: number;
 };
 
-type EntityNameMotionState = {
+type MarqueeMotionState = {
   position: number;
   velocity: number;
 };
 
-export const advanceEntityNameMotion = ({
+export const advanceMarqueeMotion = ({
   position: currentPosition,
   velocity: currentVelocity,
   maximum: rawMaximum,
   elapsed: rawElapsed,
-}: AdvanceEntityNameMotionOptions): EntityNameMotionState => {
+}: AdvanceMarqueeMotionOptions): MarqueeMotionState => {
   const maximum = Math.max(0, rawMaximum);
   let position = Math.max(0, Math.min(currentPosition, maximum));
   let velocity = Math.max(0, Math.min(currentVelocity, PIXELS_PER_SECOND / 1000));


### PR DESCRIPTION
- 사이드바 엔티티 이름의 marquee 동작을 공용 UI 컴포넌트로 추출했습니다.
- 마우스 hover와 키보드 focus-visible에서 긴 텍스트가 자연스럽게 흐르도록 했습니다.
- 호출부의 패딩과 간격을 활용할 수 있도록 방향별 bleed와 fog 크기 설정을 지원합니다.
- PRISM 대화 제목, 대화 목록, 문서 카드, 리뷰 대상 문서와 리뷰 진행 정보에 적용했습니다.
- PRISM 대화 제목 버튼의 툴팁을 항상 `대화 목록 열기`로 표시합니다.
- 기존 ellipsis 스타일이 marquee와 함께 나타나지 않도록 처리했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>