### PR TITLE
위젯 그룹이 숨겨졌을 때 포인터를 받지 않도록 함

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@widgets/WidgetGroup.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@widgets/WidgetGroup.svelte
@@ -137,9 +137,10 @@
   let isHidden = $derived.by(() => app.preference.current.widgetHidden);
   let transitioning = $state(false);
   let altPressed = $state(false);
+  const groupVisible = $derived(!isHidden || editMode);
 
   const transformRight = $derived.by(() => {
-    if (!isHidden || editMode) {
+    if (groupVisible) {
       return 'translateX(0)';
     }
 
@@ -819,7 +820,7 @@
       pointerEvents: altPressed ? 'none!' : 'none',
       opacity: altPressed ? '15' : '100',
       '& *': {
-        pointerEvents: transitioning || altPressed ? 'none!' : 'auto',
+        pointerEvents: transitioning || altPressed || !groupVisible ? 'none!' : 'auto',
       },
     }),
   )}


### PR DESCRIPTION
프리즘 패널 리사이저의 가운데 1px이 hit area로 취급되지 않는 문제를 해결함

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>