### PR TITLE
에디터 단축키를 포커스된 pane으로 제한

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
@@ -126,14 +126,14 @@
   };
 
   const handleBrowserZoomShortcut = (event: KeyboardEvent): void => {
-    if (!active || !zoomEnabled) {
-      return;
-    }
+    if (!active || !zoomEnabled) return;
+
+    const editorPane = editor.inputEl?.closest<HTMLElement>('[data-pane-id]');
+    const targetPane = event.target instanceof Element ? event.target.closest<HTMLElement>('[data-pane-id]') : null;
+    if (event.target !== editor.inputEl && (!editorPane || targetPane !== editorPane)) return;
 
     const hasZoomModifier = IS_MAC ? event.metaKey : event.ctrlKey;
-    if (!hasZoomModifier || event.altKey) {
-      return;
-    }
+    if (!hasZoomModifier || event.altKey) return;
 
     if (isZoomInShortcut(event)) {
       event.preventDefault();

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -229,7 +229,6 @@ export class EditorContext {
   serverGeneration = $state<number>(0);
   resetKey = $state<number>(0);
   attachmentDropTargetNodeId = $state<string | null>(null);
-  findReplaceOpen = $state(false);
   linkEditorOpen = $state(false);
 }
 

--- a/apps/website/src/routes/website/(dashboard)/Shortcuts.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Shortcuts.svelte
@@ -5,7 +5,6 @@
   import mixpanel from 'mixpanel-browser';
   import { IS_MAC } from '$lib/editor-ffi/constants';
   import { graphql } from '$mearie';
-  import { getPaneGroup } from './[slug]/@pane/context.svelte';
   import type { DashboardLayout_Shortcuts_query$key } from '$mearie';
 
   type Props = {
@@ -15,7 +14,6 @@
   let { query$key }: Props = $props();
 
   const app = getAppContext();
-  const paneGroup = getPaneGroup();
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const query = createFragment(
@@ -54,27 +52,12 @@
       return;
     }
 
-    if ((IS_MAC ? event.metaKey : event.ctrlKey) && event.code === 'KeyF') {
-      if (!app.state.current) return;
-
-      event.preventDefault();
-      if (paneGroup.state.current.focusedPaneId) {
-        paneGroup.findReplaceOpenByPaneId[paneGroup.state.current.focusedPaneId] = true;
-      }
-
-      return;
-    }
-
     if (event.code === 'Escape') {
       if (event.isComposing || event.defaultPrevented) return;
 
       if (runEscapeStack()) {
         event.preventDefault();
         event.stopPropagation();
-        return;
-      }
-
-      if (paneGroup.state.current.focusedPaneId && paneGroup.findReplaceOpenByPaneId[paneGroup.state.current.focusedPaneId]) {
         return;
       }
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/context.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/context.svelte.ts
@@ -60,7 +60,6 @@ export const setupPaneGroup = (initialSiteId: string, options: PaneGroupOptions)
   let resizing = $state(false);
   let activeZone = $state<{ paneId: string; dropZone: DropZone } | null>(null);
   let draggingPaneId = $state<string | null>(null);
-  const findReplaceOpenByPaneId = $state<Record<string, boolean>>({});
   // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperatively read, not reactive state
   const paneRects = new Map<string, Rect>();
 
@@ -165,9 +164,6 @@ export const setupPaneGroup = (initialSiteId: string, options: PaneGroupOptions)
       delete context.state.current.panelTabByPaneId[paneId];
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete context.state.current.toolbarExpandedByPaneId[paneId];
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-      delete findReplaceOpenByPaneId[paneId];
-
       syncUrl();
       return true;
     },
@@ -202,10 +198,6 @@ export const setupPaneGroup = (initialSiteId: string, options: PaneGroupOptions)
 
       syncUrl();
       return true;
-    },
-
-    get findReplaceOpenByPaneId() {
-      return findReplaceOpenByPaneId;
     },
 
     handleNavigation(slug: string, siteId?: string) {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/types.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/types.ts
@@ -64,8 +64,6 @@ export type PaneGroup = {
   removePane: (paneId: string) => boolean;
   replacePane: (paneId: string, pane: PaneInit) => boolean;
 
-  findReplaceOpenByPaneId: Record<string, boolean>;
-
   handleNavigation: (slug: string, siteId?: string) => void;
   switchToSite: (siteId: string, slug?: string) => void;
   focusPane: (paneId: string) => void;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -1017,11 +1017,13 @@
   }
 
   function handleGlobalKeydown(e: KeyboardEvent) {
+    const primaryModifierOnly = IS_MAC
+      ? e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey
+      : e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey;
     const targetPaneId = e.target instanceof Element ? e.target.closest<HTMLElement>('[data-pane-id]')?.dataset.paneId : undefined;
+    const ownsShortcut = e.target === ctx.editor?.inputEl || targetPaneId === pane.id;
 
-    if (!(focused && (IS_MAC ? e.metaKey : e.ctrlKey) && e.code === 'KeyF' && targetPaneId === pane.id)) {
-      return;
-    }
+    if (showFindReplace || !focused || !primaryModifierOnly || !ownsShortcut || e.code !== 'KeyF') return;
 
     e.preventDefault();
     showFindReplace = true;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentFindReplace.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentFindReplace.svelte
@@ -15,6 +15,7 @@
   import { IS_MAC } from '$lib/editor-ffi/constants';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { FocusReturnSession } from '$lib/focus-return-session';
+  import { getPane } from '../@pane/context.svelte';
   import type { Editor } from '$lib/editor-ffi/editor.svelte';
 
   type Props = {
@@ -24,6 +25,7 @@
   let { onclose }: Props = $props();
 
   const ctx = getEditorContext();
+  const pane = getPane();
   const app = getAppContext();
   const editor = $derived(ctx.editor?.terminal ? undefined : ctx.editor);
 
@@ -84,7 +86,13 @@
   const handleKeydown = (e: KeyboardEvent) => {
     if (e.isComposing || e.defaultPrevented) return;
 
-    if ((IS_MAC ? e.metaKey : e.ctrlKey) && e.code === 'KeyF') {
+    const primaryModifierOnly = IS_MAC
+      ? e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey
+      : e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey;
+    const targetPaneId = e.target instanceof Element ? e.target.closest<HTMLElement>('[data-pane-id]')?.dataset.paneId : undefined;
+    const ownsShortcut = e.target === editor?.inputEl || targetPaneId === pane.id;
+
+    if (primaryModifierOnly && ownsShortcut && ctx.paneFocused && e.code === 'KeyF') {
       e.preventDefault();
       tick().then(() => {
         findInputEl?.select();
@@ -153,7 +161,6 @@
   })}
   aria-label="찾기 및 바꾸기"
   onfocusin={handleFocusIn}
-  onkeydown={handleKeydown}
   role="dialog"
   tabindex="-1"
 >


### PR DESCRIPTION
## 문제

찾기/바꾸기와 확대·축소 단축키가 대시보드 전역에서 처리되어, 사이드바나 PRISM 패널에 포커스한 상태에서도 활성 pane의 에디터가 반응했습니다.

macOS에서는 `Ctrl+Cmd+F`도 찾기 단축키로 인식해 전체 화면 전환을 막았습니다.

## 변경

- 찾기/바꾸기는 에디터 입력 또는 포커스된 문서 pane 내부에서만 열리도록 제한했습니다.
- 찾기 UI가 닫힌 상태와 열린 상태의 단축키 처리를 각각 `DocumentEditor`와 `DocumentFindReplace`가 담당하도록 정리했습니다.
- 확대·축소는 이벤트 대상이 활성 에디터와 같은 pane에 있을 때만 브라우저 기본 동작을 가로채도록 수정했습니다.
- 대시보드 전역 단축키 처리와 pane/editor context에 남아 있던 사용되지 않는 찾기 상태를 제거했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>