### PR TITLE
사이드바 문서 전환 중 이전 항목 스크롤 방지

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@tree/Document.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/Document.svelte
@@ -119,8 +119,10 @@
     void goto(`/${document.data.entity.slug}`, { state: { entityTreeReveal: 'preserve' } });
   };
 
+  const navigationTargetSlug = $derived(navigating.to?.params?.slug ?? page.params.slug);
+
   $effect(() => {
-    if (source === 'tree' && active && page.state.entityTreeReveal !== 'preserve') {
+    if (source === 'tree' && active && document.data.entity.slug === navigationTargetSlug && page.state.entityTreeReveal !== 'preserve') {
       element?.scrollIntoView({ behavior: 'instant', block: 'nearest' });
     }
   });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/+page.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/+page.svelte
@@ -36,6 +36,7 @@
       app.state.current = undefined;
       app.state.ancestors = [];
     } else if (slug) {
+      app.state.ancestors = [];
       app.state.current = slug;
     }
   });


### PR DESCRIPTION
## 문제

문서 전환이 시작된 직후에는 이전 문서가 잠시 active 상태로 남아 있어, 이전 항목과 이동할 항목이 차례로 자동 스크롤되는 경우가 있었습니다.

이 때문에 이미 사이드바 뷰포트 안에 보이는 문서를 눌러도 트리가 이전 위치로 이동했다가 다시 대상 문서로 돌아오는 것처럼 보였습니다.

## 변경 사항

- 문서 전환 중 실제 이동 목적지와 일치하는 트리 항목만 자동 스크롤하도록 변경했습니다.
- route가 바뀌면 이전 문서의 조상 경로를 먼저 비워, 새 문서와 이전 폴더 경로가 잠시 섞이지 않도록 했습니다.
- 최근 문서에서 연 문서는 기존처럼 ‘모두’ 트리를 자동 스크롤하지 않습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>