### PR TITLE
사이드바 빈 공간에서 트리 상호작용

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@tree/@selection/SelectedEntitiesBar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/@selection/SelectedEntitiesBar.svelte
@@ -21,7 +21,6 @@
     display: 'flex',
     alignItems: 'center',
     gap: '8px',
-    marginTop: '32px',
     paddingLeft: '16px',
     paddingY: '6px',
     paddingRight: '8px',

--- a/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/EntityTree.svelte
@@ -20,6 +20,7 @@
   import { getPaneGroup } from '../[slug]/@pane/context.svelte';
   import TreeRootMenu from '../@context-menu/TreeRootMenu.svelte';
   import { SubscribeModal } from '../@subscription/subscribe-modal.svelte';
+  import SelectedEntitiesBar from './@selection/SelectedEntitiesBar.svelte';
   import Entity from './Entity.svelte';
   import { getTreeContext } from './state.svelte';
   import { getNextElement, getPreviousElement, maxDepth, resolveEntityTreeDropTarget } from './utils';
@@ -38,9 +39,10 @@
   type Props = {
     site$key: DashboardLayout_EntityTree_site$key;
     scrollContainer: HTMLElement | undefined;
+    open: boolean;
   };
 
-  let { site$key, scrollContainer }: Props = $props();
+  let { site$key, scrollContainer, open }: Props = $props();
 
   const site = createFragment(
     graphql(`
@@ -932,6 +934,9 @@
   const ghostEntityType = $derived.by(() => {
     return ghostEntityName ? dragging?.element.dataset.type : undefined;
   });
+
+  const selectionBarVisible = $derived(treeState.selectedEntityIds.size > 0 && !dragging?.eligible);
+  const shouldOpenTreeRootMenu = () => open;
 </script>
 
 {#snippet treeRootMenuContent()}
@@ -949,18 +954,15 @@
   }}
 />
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<!-- svelte-ignore a11y_interactive_supports_focus -->
 <div
   bind:this={tree}
   class={flex({
     flexDirection: 'column',
     flexGrow: '1',
     flexShrink: '0',
-    paddingX: '12px',
-    paddingY: '4px',
+    minHeight: '0',
     userSelect: 'none',
-    touchAction: 'none',
+    touchAction: open ? 'none' : 'auto',
   })}
   data-entity-tree
   onclick={handleClick}
@@ -970,16 +972,49 @@
   onpointerdowncapture={handlePointerDown}
   onpointermovecapture={handlePointerMove}
   onpointerupcapture={handlePointerUp}
-  role="tree"
-  use:contextMenu={{ content: treeRootMenuContent }}
+  role={open ? 'tree' : undefined}
+  use:contextMenu={{ content: treeRootMenuContent, shouldOpen: shouldOpenTreeRootMenu }}
 >
-  {#each site.data.entities as entity (entity.id)}
-    <Entity entity$key={entity} />
-  {:else}
-    <div class={center({ flexGrow: '1' })}>
-      <p class={css({ fontSize: '14px', fontWeight: 'medium', color: 'text.disabled' })}>아직 문서가 없어요</p>
+  <div
+    class={css({
+      display: 'grid',
+      gridTemplateRows: open ? '1fr' : '0fr',
+      flexShrink: '0',
+      transition: '[grid-template-rows 160ms ease-out]',
+      _motionReduce: { transition: '[none]' },
+    })}
+    aria-hidden={!open}
+    inert={!open}
+  >
+    <div
+      style:opacity={open ? '1' : '0'}
+      class={flex({
+        flexDirection: 'column',
+        minHeight: '0',
+        overflow: 'hidden',
+        transition: '[opacity 120ms ease-out]',
+        _motionReduce: { transition: '[none]' },
+      })}
+    >
+      <div class={flex({ flexDirection: 'column', paddingX: '12px', paddingY: '4px' })}>
+        {#each site.data.entities as entity (entity.id)}
+          <Entity entity$key={entity} />
+        {:else}
+          <div class={center({ flexGrow: '1' })}>
+            <p class={css({ fontSize: '14px', fontWeight: 'medium', color: 'text.disabled' })}>아직 문서가 없어요</p>
+          </div>
+        {/each}
+      </div>
     </div>
-  {/each}
+  </div>
+
+  {#if open || selectionBarVisible}
+    <div class={css({ height: '32px', flexShrink: '0' })}></div>
+
+    {#if selectionBarVisible}
+      <SelectedEntitiesBar />
+    {/if}
+  {/if}
 </div>
 
 {#if dragging?.eligible}

--- a/apps/website/src/routes/website/(dashboard)/@tree/recent-documents.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@tree/recent-documents.browser.test.ts
@@ -31,4 +31,19 @@ describe('recent document tree boundaries', () => {
     expect(resolveEntityTreeDropTarget(tree, recent.querySelector('span'))).toBeNull();
     expect(resolveEntityTreeDropTarget(tree, tree.querySelector('span'))?.dataset.id).toBe('TREE');
   });
+
+  it('resolves blank space in the entity tree surface to the last root entity', () => {
+    const tree = document.createElement('div');
+    tree.dataset.entityTree = 'true';
+    tree.setAttribute('role', 'tree');
+    tree.innerHTML = `
+      <div>
+        <a data-id="FIRST"></a>
+        <a data-id="LAST"></a>
+      </div>
+    `;
+    document.body.append(tree);
+
+    expect(resolveEntityTreeDropTarget(tree, tree)?.dataset.id).toBe('LAST');
+  });
 });

--- a/apps/website/src/routes/website/(dashboard)/@tree/utils.ts
+++ b/apps/website/src/routes/website/(dashboard)/@tree/utils.ts
@@ -65,7 +65,7 @@ export const resolveEntityTreeDropTarget = (root: HTMLElement, hitElement: Eleme
     return null;
   }
 
-  return hitTree.querySelector<HTMLElement>(':scope > [data-id]:last-child');
+  return flatLevel(hitTree, '[data-id]').at(-1) ?? null;
 };
 
 export const getEntityTreeElement = () => document.querySelector<HTMLElement>('[data-entity-tree]') ?? undefined;

--- a/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
@@ -25,7 +25,6 @@
   import PrismBadgeDot from './@prism/PrismBadgeDot.svelte';
   import { SubscribeModal } from './@subscription/subscribe-modal.svelte';
   import TrialWidget from './@subscription/TrialWidget.svelte';
-  import SelectedEntitiesBar from './@tree/@selection/SelectedEntitiesBar.svelte';
   import { createEntityTreeRevealRequest, entityTreeRevealState } from './@tree/entity-reveal.svelte';
   import EntityTree from './@tree/EntityTree.svelte';
   import RecentDocuments from './@tree/RecentDocuments.svelte';
@@ -49,7 +48,7 @@
 
   const app = getAppContext();
   const dayClock = getDayClock();
-  const treeState = setupTreeContext();
+  setupTreeContext();
 
   const user = createFragment(
     graphql(`
@@ -788,34 +787,7 @@
             {/snippet}
           </SidebarSectionHeader>
 
-          <div
-            class={css({
-              display: 'grid',
-              gridTemplateRows: allDocumentsOpen ? '1fr' : '0fr',
-              flexShrink: '0',
-              transition: '[grid-template-rows 160ms ease-out]',
-              _motionReduce: { transition: '[none]' },
-            })}
-            aria-hidden={!allDocumentsOpen}
-            inert={!allDocumentsOpen}
-          >
-            <div
-              style:opacity={allDocumentsOpen ? '1' : '0'}
-              class={flex({
-                flexDirection: 'column',
-                minHeight: '0',
-                overflow: 'hidden',
-                transition: '[opacity 120ms ease-out]',
-                _motionReduce: { transition: '[none]' },
-              })}
-            >
-              <EntityTree scrollContainer={treeScrollEl} site$key={site} />
-            </div>
-          </div>
-
-          {#if treeState.selectedEntityIds.size > 0 && !treeState.dragging}
-            <SelectedEntitiesBar />
-          {/if}
+          <EntityTree open={allDocumentsOpen} scrollContainer={treeScrollEl} site$key={site} />
         </div>
 
         <Scrollbar

--- a/packages/ui/src/actions/context-menu.svelte.ts
+++ b/packages/ui/src/actions/context-menu.svelte.ts
@@ -2,12 +2,16 @@ import { getAllContexts, mount, unmount } from 'svelte';
 import { Menu } from '../components';
 import type { Snippet } from 'svelte';
 
-export function contextMenu(node: HTMLElement, params: { content: Snippet }) {
+export function contextMenu(node: HTMLElement, params: { content: Snippet; shouldOpen?: (event: MouseEvent) => boolean }) {
   $effect(() => {
     let mountedComponent: ReturnType<typeof mount> | null = null;
     const context = getAllContexts();
 
     const handleContextMenu = (e: MouseEvent) => {
+      if (params.shouldOpen?.(e) === false) {
+        return;
+      }
+
       e.preventDefault();
       e.stopPropagation();
 


### PR DESCRIPTION
## 문제

‘최근’ 섹션 도입 후 ‘모두’ 트리의 DOM 영역이 마지막 엔티티에서 끝나면서, 그 아래 사이드바 빈 공간에서 루트 우클릭 메뉴와 트리 드롭이 동작하지 않았습니다. 문서가 사이드바를 가득 채운 경우에는 루트 메뉴를 열 수 있는 여유 공간도 없었습니다.

## 변경 사항

- ‘모두’ 트리가 펼쳐져 있을 때 남은 사이드바 영역을 트리 루트가 차지하도록 구조를 정리했습니다.
- 마지막 엔티티 뒤에 32px의 루트 영역을 보장해, 목록이 가득 찬 경우에도 루트 우클릭 메뉴와 루트 레벨 드롭을 사용할 수 있게 했습니다.
- ‘모두’ 섹션이 접혀 있을 때는 트리 역할과 앱 컨텍스트 메뉴를 비활성화합니다.
- 다중 선택 바를 접히는 문서 목록 바깥의 트리 루트로 옮겨, 섹션의 접힘 여부와 관계없이 기존 간격과 sticky 배치를 유지합니다.
- collapse 래퍼가 있는 DOM에서도 빈 공간 드롭 대상을 마지막 루트 엔티티로 계산하도록 보완했습니다.
- 공용 컨텍스트 메뉴 action에 선택적인 열림 조건을 추가했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>