### PR TITLE
뷰어 본문 브라우저 번역 지원

### DIFF
--- a/apps/website/src/lib/editor-ffi/document-dom-mirror.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/document-dom-mirror.browser.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { initWasm } from '$lib/wasm-ffi.svelte';
+import { createDocumentDomMirror } from './document-dom-mirror';
+import { Editor } from './editor.svelte';
+import type { Modifier, ModifierType, PlainDoc, PlainNode, PlainNodeEntry } from '@typie/editor-ffi/browser';
+
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+
+const entry = (
+  node: PlainNode,
+  children: PlainNodeEntry[] = [],
+  modifiers: Partial<Record<ModifierType, Modifier>> = {},
+): PlainNodeEntry => ({
+  node,
+  children,
+  modifiers: modifiers as Record<ModifierType, Modifier>,
+  carry: [],
+});
+
+const source: PlainDoc = {
+  root: entry({ type: 'root', layout_mode: { type: 'continuous', max_width: 640 } }, [
+    entry({ type: 'paragraph' }, [entry({ type: 'text', text: 'Before' }, [], { bold: { type: 'bold' } }), entry({ type: 'page_break' })]),
+  ]),
+};
+
+describe('document DOM mirror Rust-Web contract', () => {
+  let editor: Editor | undefined;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = undefined;
+  });
+
+  it('projects real editor HTML without duplicating its marker schema in Web fixtures', async () => {
+    await initWasm();
+    editor = await Editor.createFromDoc(source, { width: 640, height: 480, scale_factor: 1 });
+
+    const mirror = createDocumentDomMirror(editor.documentDomProjection());
+    const run = mirror.element.querySelector<HTMLElement>('span');
+    if (!run) throw new Error('expected a text carrier from the Rust document projection');
+    run.textContent = '이후';
+
+    const [paragraph] = mirror.project().doc.root.children;
+    expect(paragraph?.children.map((child) => child.node)).toEqual([{ type: 'text', text: '이후' }, { type: 'page_break' }]);
+    expect(paragraph?.children[0]?.modifiers.bold).toEqual({ type: 'bold' });
+  });
+});

--- a/apps/website/src/lib/editor-ffi/document-dom-mirror.test.ts
+++ b/apps/website/src/lib/editor-ffi/document-dom-mirror.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDocumentDomMirror, startDocumentDomProjection } from './document-dom-mirror';
+import type { DocumentDomProjection, Modifier, ModifierType, PlainDoc, PlainNodeEntry } from '@typie/editor-ffi/browser';
+
+const entry = (
+  node: PlainNodeEntry['node'],
+  children: PlainNodeEntry[] = [],
+  modifiers: Partial<Record<ModifierType, Modifier>> = {},
+): PlainNodeEntry => ({
+  node,
+  children,
+  modifiers: modifiers as Record<ModifierType, Modifier>,
+});
+
+const text = (value: string, modifiers: Partial<Record<ModifierType, Modifier>> = {}) =>
+  entry({ type: 'text', text: value }, [], modifiers);
+
+const doc = (...children: PlainNodeEntry[]): PlainDoc => ({
+  root: entry({ type: 'root', layout_mode: { type: 'continuous', max_width: 640 } }, [entry({ type: 'paragraph' }, children)]),
+});
+
+const inlineChildren = (plain: PlainDoc): PlainNodeEntry[] => {
+  const [paragraph] = plain.root.children;
+  if (!paragraph) throw new Error('expected paragraph');
+  return paragraph.children;
+};
+
+const escapeHtml = (value: string) => value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+
+const defaultInlineHtml = (source: PlainDoc): string =>
+  inlineChildren(source)
+    .map((child, index) => {
+      const path = `0.${index}`;
+      switch (child.node.type) {
+        case 'text': {
+          return `<span data-typie-text="${path}">${escapeHtml(child.node.text)}</span>`;
+        }
+        case 'hard_break': {
+          return `<br data-typie-node="${path}" data-typie-boundary>`;
+        }
+        case 'page_break': {
+          return `<span data-typie-node="${path}" data-typie-boundary></span>`;
+        }
+        default: {
+          throw new Error(`unsupported test fixture node: ${child.node.type}`);
+        }
+      }
+    })
+    .join('');
+
+const projection = (source: PlainDoc, inlineHtml = defaultInlineHtml(source)): DocumentDomProjection => ({
+  source,
+  html: `<article data-typie-node="r"><p data-typie-node="0" data-typie-text-container>${inlineHtml}</p></article>`,
+});
+
+const createMirror = (source: PlainDoc, inlineHtml?: string) => createDocumentDomMirror(projection(source, inlineHtml));
+
+function at<T>(values: T[], index: number): T {
+  const value = values[index];
+  if (value === undefined) throw new Error(`expected value at ${index}`);
+  return value;
+}
+
+const flushFrame = (frames: Map<number, FrameRequestCallback>) => {
+  const callback = frames.values().next().value;
+  if (!callback) throw new Error('expected animation frame');
+  callback(0);
+  frames.clear();
+};
+
+describe('document DOM mirror conversion', () => {
+  it('projects translated run text while preserving source-owned semantic modifiers', () => {
+    const source = doc(
+      text('Important', {
+        bold: { type: 'bold' },
+        link: { type: 'link', href: 'https://example.com/original' },
+        text_color: { type: 'text_color', value: '#c2410c' },
+      }),
+      text(' Tokyo', { ruby: { type: 'ruby', text: 'とうきょう' } }),
+    );
+
+    const mirror = createMirror(source);
+    const runs = [...mirror.element.querySelectorAll<HTMLElement>('[data-typie-text]')];
+
+    runs[0].textContent = '중요한';
+    runs[1].textContent = ' 도쿄';
+
+    const projected = inlineChildren(mirror.project().doc);
+    const sourceChildren = inlineChildren(source);
+
+    expect(projected.map((child) => (child.node.type === 'text' ? child.node.text : ''))).toEqual(['중요한', ' 도쿄']);
+    expect(at(projected, 0).modifiers).toEqual(at(sourceChildren, 0).modifiers);
+    expect(at(projected, 1).modifiers).toEqual(at(sourceChildren, 1).modifiers);
+  });
+
+  it('preserves frozen inline boundary nodes between translated runs', () => {
+    const source = doc(text('Before'), entry({ type: 'hard_break' }), text('After'));
+    const mirror = createMirror(source);
+    const runs = [...mirror.element.querySelectorAll<HTMLElement>('[data-typie-text]')];
+
+    runs[0].textContent = '앞';
+    runs[1].textContent = '뒤';
+
+    expect(inlineChildren(mirror.project().doc).map((child) => child.node)).toEqual([
+      { type: 'text', text: '앞' },
+      { type: 'hard_break' },
+      { type: 'text', text: '뒤' },
+    ]);
+  });
+
+  it('projects translated text from a paragraph that ends with a page break', () => {
+    const source = doc(text('Before'), entry({ type: 'page_break' }));
+    const mirror = createMirror(source);
+    const run = mirror.element.querySelector<HTMLElement>('[data-typie-text]');
+    if (!run) throw new Error('expected text run');
+
+    run.textContent = '앞';
+
+    expect(inlineChildren(mirror.project().doc).map((child) => child.node)).toEqual([{ type: 'text', text: '앞' }, { type: 'page_break' }]);
+  });
+
+  it('uses original identity before attributes and source values before translated attributes', () => {
+    const source = doc(
+      text('Link', {
+        link: { type: 'link', href: 'https://example.com/original' },
+        text_color: { type: 'text_color', value: '#c2410c' },
+      }),
+      text(' Plain'),
+    );
+    const mirror = createMirror(
+      source,
+      '<a href="https://example.com/original"><span data-typie-text="0.0">Link</span></a><span data-typie-text="0.1"> Plain</span>',
+    );
+    const runs = [...mirror.element.querySelectorAll<HTMLElement>('[data-typie-text]')];
+
+    runs[0].dataset.typieText = runs[1].dataset.typieText;
+    runs[0].textContent = '링크';
+    runs[0].style.color = 'rgb(0, 0, 0)';
+    mirror.element.querySelector('a')?.setAttribute('href', 'https://example.com/translated');
+
+    const projected = at(inlineChildren(mirror.project().doc), 0);
+
+    expect(projected.node).toEqual({ type: 'text', text: '링크' });
+    expect(projected.modifiers).toEqual(at(inlineChildren(source), 0).modifiers);
+  });
+
+  it('recovers replaced and unknown-wrapper text without trusting translated markup', () => {
+    const source = doc(text('Known', { italic: { type: 'italic' } }), text(' Tail'));
+    const mirror = createMirror(source);
+    const runs = [...mirror.element.querySelectorAll<HTMLElement>('[data-typie-text]')];
+    const replacement = runs[0].cloneNode(false) as HTMLElement;
+    const unknown = document.createElement('mark');
+
+    replacement.textContent = '알려진';
+    runs[0].replaceWith(replacement);
+    unknown.textContent = ' 이동';
+    runs[1].replaceWith(unknown);
+
+    const projected = inlineChildren(mirror.project().doc);
+
+    expect(projected.map((child) => child.node)).toEqual([
+      { type: 'text', text: '알려진' },
+      { type: 'text', text: ' 이동' },
+    ]);
+    expect(at(projected, 0).modifiers).toEqual(at(inlineChildren(source), 0).modifiers);
+    expect(at(projected, 1).modifiers).toEqual({});
+  });
+
+  it('resolves a browser-replaced inline container through its source path', () => {
+    const mirror = createMirror(doc(text('Original', { bold: { type: 'bold' } })));
+    const paragraph = mirror.element.querySelector('p');
+    if (!paragraph) throw new Error('expected paragraph');
+    const replacement = paragraph.cloneNode(true) as HTMLElement;
+    const run = replacement.querySelector<HTMLElement>('[data-typie-text]');
+    if (!run) throw new Error('expected translated run');
+
+    run.textContent = '교체된 문단';
+    paragraph.replaceWith(replacement);
+
+    expect(inlineChildren(mirror.project().doc).map((child) => child.node)).toEqual([{ type: 'text', text: '교체된 문단' }]);
+  });
+
+  it('excludes ruby annotations and merges adjacent translated runs with equal modifiers', () => {
+    const source = doc(text('Tokyo', { ruby: { type: 'ruby', text: 'とうきょう' } }), text(' is'), text(' large'));
+    const mirror = createMirror(
+      source,
+      '<ruby><span data-typie-text="0.0">Tokyo</span><rt translate="no">とうきょう</rt></ruby><span data-typie-text="0.1"> is</span><span data-typie-text="0.2"> large</span>',
+    );
+    const runs = [...mirror.element.querySelectorAll<HTMLElement>('[data-typie-text]')];
+
+    runs[0].textContent = '도쿄';
+    runs[1].textContent = '는';
+    runs[2].textContent = ' 크다';
+    const annotation = mirror.element.querySelector('rt');
+    if (!annotation) throw new Error('expected ruby annotation');
+    annotation.textContent = '번역되면 안 됨';
+
+    expect(inlineChildren(mirror.project().doc).map((child) => child.node)).toEqual([
+      { type: 'text', text: '도쿄' },
+      { type: 'text', text: '는 크다' },
+    ]);
+  });
+
+  it('changes the full signature when formatting boundaries change without changing prose', () => {
+    const source = doc(text('A', { bold: { type: 'bold' } }), text('B', { italic: { type: 'italic' } }));
+    const mirror = createMirror(source);
+    const runs = [...mirror.element.querySelectorAll<HTMLElement>('[data-typie-text]')];
+
+    runs[0].textContent = 'AB';
+    runs[1].textContent = '';
+
+    const projected = mirror.project();
+
+    expect(inlineChildren(projected.doc).map((child) => child.node)).toEqual([{ type: 'text', text: 'AB' }]);
+    expect(projected.signature).not.toBe(mirror.sourceSignature);
+    expect(mirror.project().signature).toBe(projected.signature);
+  });
+});
+
+describe('document DOM projection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('batches mutations per frame and suppresses duplicate projections', async () => {
+    const frames = new Map<number, FrameRequestCallback>();
+    let nextFrame = 1;
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const id = nextFrame++;
+      frames.set(id, callback);
+      return id;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => frames.delete(id));
+
+    const mirror = createMirror(doc(text('First'), text(' Second')));
+    const runs = [...mirror.element.querySelectorAll<HTMLElement>('[data-typie-text]')];
+    const applied: PlainDoc[] = [];
+    const stop = startDocumentDomProjection({
+      mirror,
+      apply: (projected) => {
+        applied.push(projected);
+      },
+    });
+
+    runs[0].textContent = '첫째';
+    runs[1].textContent = ' 둘째';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(frames.size).toBe(1);
+    flushFrame(frames);
+    expect(applied).toHaveLength(1);
+
+    runs[0].textContent = '첫째';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    flushFrame(frames);
+    expect(applied).toHaveLength(1);
+
+    runs[0].textContent = 'First';
+    runs[1].textContent = ' Second';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    flushFrame(frames);
+    expect(applied).toHaveLength(2);
+    expect(applied[1]).toEqual(doc(text('First Second')));
+
+    stop();
+    runs[0].textContent = '중단 뒤';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(frames.size).toBe(0);
+  });
+
+  it('keeps the last successful signature when projection fails before apply', async () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    const root = document.createElement('div');
+    const apply = vi.fn();
+    const reportError = vi.fn();
+    const stop = startDocumentDomProjection({
+      mirror: {
+        element: root,
+        sourceSignature: 'source',
+        project: () => {
+          throw new Error('invalid translated DOM');
+        },
+      },
+      apply,
+      reportError,
+    });
+
+    root.append('translation');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const frame = frames.shift();
+    if (!frame) throw new Error('expected animation frame');
+    frame(0);
+
+    expect(apply).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledOnce();
+
+    root.append('more translation');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const nextFrame = frames.shift();
+    if (!nextFrame) throw new Error('expected another animation frame');
+    nextFrame(0);
+
+    expect(apply).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledOnce();
+    stop();
+  });
+});

--- a/apps/website/src/lib/editor-ffi/document-dom-mirror.ts
+++ b/apps/website/src/lib/editor-ffi/document-dom-mirror.ts
@@ -1,0 +1,209 @@
+import stringify from 'fast-json-stable-stringify';
+import type { DocumentDomProjection, Modifier, ModifierType, PlainDoc, PlainNodeEntry } from '@typie/editor-ffi/browser';
+
+const NODE_ATTRIBUTE = 'data-typie-node';
+const TEXT_CONTAINER_ATTRIBUTE = 'data-typie-text-container';
+const TEXT_ATTRIBUTE = 'data-typie-text';
+const BOUNDARY_ATTRIBUTE = 'data-typie-boundary';
+
+export type DocumentDomMirror = {
+  element: HTMLElement;
+  sourceSignature: string;
+  project(): { doc: PlainDoc; signature: string };
+};
+
+type DocumentDomProjectionOptions = {
+  mirror: DocumentDomMirror;
+  apply(doc: PlainDoc): void;
+  reportError?(error: unknown): void;
+};
+
+export const startDocumentDomProjection = ({ mirror, apply, reportError = console.error }: DocumentDomProjectionOptions): (() => void) => {
+  let appliedSignature = mirror.sourceSignature;
+  let errorReported = false;
+  let frame: number | undefined;
+
+  const observer = new MutationObserver(() => {
+    if (frame !== undefined) return;
+    frame = requestAnimationFrame(() => {
+      frame = undefined;
+      try {
+        const projected = mirror.project();
+        if (projected.signature === appliedSignature) return;
+        apply(projected.doc);
+        appliedSignature = projected.signature;
+      } catch (err) {
+        if (!errorReported) {
+          errorReported = true;
+          reportError(err);
+        }
+      }
+    });
+  });
+
+  observer.observe(mirror.element, { subtree: true, childList: true, characterData: true });
+
+  return () => {
+    observer.disconnect();
+    if (frame !== undefined) cancelAnimationFrame(frame);
+    frame = undefined;
+  };
+};
+
+type RunRecord = {
+  source: PlainNodeEntry;
+};
+
+function clonePlainValue<T>(value: T): T {
+  return structuredClone(value);
+}
+
+const sameTextShape = (left: PlainNodeEntry, right: PlainNodeEntry) =>
+  stringify(left.modifiers) === stringify(right.modifiers) && stringify(left.carry ?? []) === stringify(right.carry ?? []);
+
+const textEntry = (value: string, source?: PlainNodeEntry): PlainNodeEntry => ({
+  node: { type: 'text', text: value },
+  modifiers: source ? clonePlainValue(source.modifiers) : ({} as Record<ModifierType, Modifier>),
+  ...(source?.carry && { carry: clonePlainValue(source.carry) }),
+  children: [],
+});
+
+const elementsWithAttribute = (root: HTMLElement, attribute: string): HTMLElement[] => {
+  const elements = root.hasAttribute(attribute) ? [root] : [];
+  elements.push(...root.querySelectorAll<HTMLElement>(`[${attribute}]`));
+  return elements;
+};
+
+const parseProjectionHtml = (html: string): HTMLElement => {
+  const template = document.createElement('template');
+  template.innerHTML = html.trim();
+  const element = template.content.firstElementChild;
+  if (template.content.childElementCount !== 1 || !(element instanceof HTMLElement)) {
+    throw new Error('document HTML projection must contain exactly one root element');
+  }
+  return element;
+};
+
+const entryAtPath = (source: PlainDoc, path: string): PlainNodeEntry => {
+  if (path === 'r') return source.root;
+  let entry = source.root;
+  for (const segment of path.split('.')) {
+    if (!/^\d+$/.test(segment)) throw new Error(`invalid document projection path: ${path}`);
+    const child = entry.children[Number(segment)];
+    if (!child) throw new Error(`document projection path is outside its source: ${path}`);
+    entry = child;
+  }
+  return entry;
+};
+
+const pathOf = (element: Element, attribute: string): string => {
+  const path = element.getAttribute(attribute);
+  if (!path) throw new Error(`document projection element is missing ${attribute}`);
+  return path;
+};
+
+export const createDocumentDomMirror = ({ html, source }: DocumentDomProjection): DocumentDomMirror => {
+  const element = parseProjectionHtml(html);
+  const elementByEntry = new Map<PlainNodeEntry, { path: string; element: HTMLElement }>();
+  const containerEntries = new WeakSet<PlainNodeEntry>();
+  const runByElement = new WeakMap<Element, RunRecord>();
+  const runByPath = new Map<string, RunRecord>();
+  const boundaryByElement = new WeakMap<Element, PlainNodeEntry>();
+  const boundaryByPath = new Map<string, PlainNodeEntry>();
+
+  for (const entryElement of elementsWithAttribute(element, NODE_ATTRIBUTE)) {
+    const path = pathOf(entryElement, NODE_ATTRIBUTE);
+    const entry = entryAtPath(source, path);
+    elementByEntry.set(entry, { path, element: entryElement });
+    if (entryElement.hasAttribute(TEXT_CONTAINER_ATTRIBUTE)) containerEntries.add(entry);
+  }
+
+  for (const runElement of elementsWithAttribute(element, TEXT_ATTRIBUTE)) {
+    const path = pathOf(runElement, TEXT_ATTRIBUTE);
+    const sourceRun = entryAtPath(source, path);
+    if (sourceRun.node.type !== 'text') throw new Error(`document projection run does not reference text: ${path}`);
+    const record = { source: sourceRun };
+    runByElement.set(runElement, record);
+    runByPath.set(path, record);
+  }
+
+  for (const boundaryElement of elementsWithAttribute(element, BOUNDARY_ATTRIBUTE)) {
+    const path = pathOf(boundaryElement, NODE_ATTRIBUTE);
+    const boundary = entryAtPath(source, path);
+    boundaryByElement.set(boundaryElement, boundary);
+    boundaryByPath.set(path, boundary);
+  }
+
+  const resolveEntryElement = (entry: PlainNodeEntry, currentByPath: Map<string, HTMLElement>): HTMLElement | undefined => {
+    const record = elementByEntry.get(entry);
+    if (!record) return;
+    if (record.element === element || element.contains(record.element)) return record.element;
+    return currentByPath.get(record.path);
+  };
+
+  const collectCurrentRuns = (container: HTMLElement): PlainNodeEntry[] => {
+    const entries: PlainNodeEntry[] = [];
+
+    const append = (value: string, sourceRun?: PlainNodeEntry) => {
+      if (value.length === 0) return;
+      const next = textEntry(value, sourceRun);
+      const previous = entries.at(-1);
+      if (previous?.node.type === 'text' && sameTextShape(previous, next)) {
+        previous.node.text += value;
+      } else {
+        entries.push(next);
+      }
+    };
+
+    const visit = (node: Node, activeRun?: RunRecord) => {
+      if (node instanceof Text) {
+        append(node.data, activeRun?.source);
+        return;
+      }
+      if (!(node instanceof Element) || node.tagName === 'RT') return;
+
+      const boundaryPath = node.hasAttribute(BOUNDARY_ATTRIBUTE) ? node.getAttribute(NODE_ATTRIBUTE) : undefined;
+      const boundary = boundaryByElement.get(node) ?? (boundaryPath ? boundaryByPath.get(boundaryPath) : undefined);
+      if (boundary) {
+        entries.push(clonePlainValue(boundary));
+        return;
+      }
+
+      const runPath = node.getAttribute(TEXT_ATTRIBUTE);
+      const run = runByElement.get(node) ?? (runPath ? runByPath.get(runPath) : undefined) ?? activeRun;
+      for (const child of node.childNodes) visit(child, run);
+    };
+
+    for (const child of container.childNodes) visit(child);
+    return entries;
+  };
+
+  const project = (): { doc: PlainDoc; signature: string } => {
+    const currentByPath = new Map(
+      elementsWithAttribute(element, NODE_ATTRIBUTE).map((current) => [pathOf(current, NODE_ATTRIBUTE), current]),
+    );
+
+    const projectEntry = (entry: PlainNodeEntry): PlainNodeEntry => {
+      const projected: PlainNodeEntry = {
+        node: clonePlainValue(entry.node),
+        modifiers: clonePlainValue(entry.modifiers),
+        ...(entry.carry && { carry: clonePlainValue(entry.carry) }),
+        children: [],
+      };
+
+      const container = resolveEntryElement(entry, currentByPath);
+      projected.children =
+        container && containerEntries.has(entry) ? collectCurrentRuns(container) : entry.children.map((child) => projectEntry(child));
+      return projected;
+    };
+
+    const doc = { root: projectEntry(source.root) };
+    return { doc, signature: stringify(doc) };
+  };
+
+  return {
+    element,
+    sourceSignature: stringify(source),
+    project,
+  };
+};

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -25,6 +25,7 @@ import type {
   CapturedViewportAnchor,
   ClipboardPayload,
   CursorMetrics,
+  DocumentDomProjection,
   Editor as WasmEditor,
   EditorEvent,
   ExternalElement,
@@ -1185,6 +1186,10 @@ export class Editor {
 
   materializeAt(heads: Uint8Array, sweepTombstones: string[]): PlainDoc {
     return this.#invokeCore((core) => core.materialize_at(heads, sweepTombstones));
+  }
+
+  documentDomProjection(): DocumentDomProjection {
+    return this.#invokeCore((core) => core.document_dom_projection());
   }
 
   enableRecentEdits(): void {

--- a/apps/website/src/routes/usersite/wildcard/[slug]/DocumentDomMirror.svelte
+++ b/apps/website/src/routes/usersite/wildcard/[slug]/DocumentDomMirror.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import * as Sentry from '@sentry/sveltekit';
+  import { css } from '@typie/styled-system/css';
+  import { createDocumentDomMirror, startDocumentDomProjection } from '$lib/editor-ffi/document-dom-mirror';
+  import type { Editor } from '$lib/editor-ffi/editor.svelte';
+
+  type Props = {
+    editor?: Editor;
+    excerpt?: string | null;
+  };
+
+  let { editor, excerpt }: Props = $props();
+  let host = $state<HTMLDivElement>();
+
+  const reportError = (error: unknown, phase: 'initialization' | 'projection') => {
+    console.error(error);
+    try {
+      Sentry.captureException(error, {
+        tags: {
+          feature: 'document-dom-mirror',
+          phase,
+        },
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  $effect(() => {
+    const element = host;
+    if (!element || !editor) return;
+
+    try {
+      const mirror = createDocumentDomMirror(editor.documentDomProjection());
+      element.replaceChildren(mirror.element);
+
+      const stop = startDocumentDomProjection({
+        mirror,
+        apply: (doc) => editor.setDoc(doc),
+        reportError: (error) => reportError(error, 'projection'),
+      });
+
+      return () => {
+        stop();
+        element.replaceChildren();
+      };
+    } catch (err) {
+      reportError(err, 'initialization');
+      element.replaceChildren();
+    }
+  });
+</script>
+
+<div
+  bind:this={host}
+  class={css({
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    overflow: 'hidden',
+    clipPath: 'inset(50%)',
+    whiteSpace: 'nowrap',
+    pointerEvents: 'none',
+    userSelect: 'none',
+  })}
+  aria-hidden="true"
+  inert
+  translate="yes"
+>
+  {#if !editor && excerpt}
+    <p data-typie-dom-mirror-seed>{excerpt}</p>
+  {/if}
+</div>

--- a/apps/website/src/routes/usersite/wildcard/[slug]/DocumentViewV2.svelte
+++ b/apps/website/src/routes/usersite/wildcard/[slug]/DocumentViewV2.svelte
@@ -29,6 +29,7 @@
   import BodyUnavailable from './BodyUnavailable.svelte';
   import ContentNavigation from './ContentNavigation.svelte';
   import DocumentActionMenu from './DocumentActionMenu.svelte';
+  import DocumentDomMirror from './DocumentDomMirror.svelte';
   import DocumentEmojiReaction from './DocumentEmojiReaction.svelte';
   import DocumentViewSkeleton from './DocumentViewSkeleton.svelte';
   import ReadOnlyTouchSelectionSuppress from './ReadOnlyTouchSelectionSuppress.svelte';
@@ -634,6 +635,11 @@
               </EditorComponent>
             {/if}
           </div>
+
+          <DocumentDomMirror
+            editor={editorReady && editorForDocumentId === document.id ? ctx.editor : undefined}
+            excerpt={document.excerpt}
+          />
         {/key}
 
         {#if activeEditorFailure && failureSurface}

--- a/apps/website/src/routes/usersite/wildcard/[slug]/document-dom-mirror.test.ts
+++ b/apps/website/src/routes/usersite/wildcard/[slug]/document-dom-mirror.test.ts
@@ -1,0 +1,45 @@
+import * as Sentry from '@sentry/sveltekit';
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import DocumentDomMirror from './DocumentDomMirror.svelte';
+import type { Editor } from '$lib/editor-ffi/editor.svelte';
+
+vi.mock('@sentry/sveltekit', () => ({ captureException: vi.fn() }));
+
+let component: ReturnType<typeof mount> | undefined;
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.mocked(Sentry.captureException).mockReset();
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => null);
+});
+
+afterEach(async () => {
+  if (component) await unmount(component);
+  component = undefined;
+  consoleError.mockRestore();
+  document.body.replaceChildren();
+});
+
+describe('DocumentDomMirror error reporting', () => {
+  it('reports initialization failures without attaching document content', async () => {
+    const failure = new Error('invalid document projection');
+    const editor = {
+      documentDomProjection: () => {
+        throw failure;
+      },
+    } as unknown as Editor;
+
+    component = mount(DocumentDomMirror, { target: document.body, props: { editor } });
+    await tick();
+
+    expect(consoleError).toHaveBeenCalledWith(failure);
+    expect(Sentry.captureException).toHaveBeenCalledOnce();
+    expect(Sentry.captureException).toHaveBeenCalledWith(failure, {
+      tags: {
+        feature: 'document-dom-mirror',
+        phase: 'initialization',
+      },
+    });
+  });
+});

--- a/crates/editor-clipboard/src/html/dom_projection.rs
+++ b/crates/editor-clipboard/src/html/dom_projection.rs
@@ -1,0 +1,169 @@
+use super::markup::{
+    HtmlTarget, NodeMarkup, dom_projection_style, markup_for_node, write_close_tag,
+    write_dom_projection_text, write_open_tag,
+};
+use editor_model::{PlainDoc, PlainNode, PlainNodeEntry, Schema};
+use editor_resource::Resource;
+
+pub fn serialize(doc: &PlainDoc, resource: &Resource) -> String {
+    let mut out = String::new();
+    serialize_root(&doc.root, resource, &mut out);
+    out
+}
+
+enum SerializeTask<'a> {
+    Node {
+        entry: &'a PlainNodeEntry,
+        path: String,
+    },
+    Close(&'static str),
+}
+
+fn serialize_root(root: &PlainNodeEntry, resource: &Resource, out: &mut String) {
+    let mut tasks = vec![SerializeTask::Node {
+        entry: root,
+        path: "r".to_string(),
+    }];
+
+    while let Some(task) = tasks.pop() {
+        let (entry, path) = match task {
+            SerializeTask::Node { entry, path } => (entry, path),
+            SerializeTask::Close(tag) => {
+                write_close_tag(out, tag);
+                continue;
+            }
+        };
+
+        match markup_for_node(&entry.node, HtmlTarget::DomProjection) {
+            NodeMarkup::Text => {
+                let PlainNode::Text(text) = &entry.node else {
+                    unreachable!()
+                };
+                write_dom_projection_text(
+                    &text.text,
+                    entry.modifiers.values(),
+                    resource,
+                    &path,
+                    out,
+                );
+            }
+            NodeMarkup::Tab => unreachable!("DOM projection tabs use element markup"),
+            NodeMarkup::Children => push_children(&mut tasks, entry, &path),
+            NodeMarkup::Skip => {}
+            NodeMarkup::Element { tag, attrs, void } => {
+                let style = dom_projection_style(entry.modifiers.values(), resource);
+                let inline = Schema::node_spec(entry.node.as_type()).inline;
+                let inline_container = !entry.children.is_empty()
+                    && entry
+                        .children
+                        .iter()
+                        .all(|child| Schema::node_spec(child.node.as_type()).inline);
+                let mut extra_attrs = vec![("data-typie-node", Some(path.as_str()))];
+                if inline_container {
+                    extra_attrs.push(("data-typie-text-container", None));
+                }
+                if inline {
+                    extra_attrs.push(("data-typie-boundary", None));
+                }
+                if matches!(entry.node, PlainNode::Fold(_)) {
+                    extra_attrs.push(("open", None));
+                }
+                if let Some(style) = style.as_deref() {
+                    extra_attrs.push(("style", Some(style)));
+                }
+
+                write_open_tag(out, tag, &attrs, &extra_attrs);
+                if !void {
+                    tasks.push(SerializeTask::Close(tag));
+                    push_children(&mut tasks, entry, &path);
+                }
+            }
+        }
+    }
+}
+
+fn push_children<'a>(tasks: &mut Vec<SerializeTask<'a>>, entry: &'a PlainNodeEntry, path: &str) {
+    for (index, child) in entry.children.iter().enumerate().rev() {
+        let child_path = if path == "r" {
+            index.to_string()
+        } else {
+            format!("{path}.{index}")
+        };
+        tasks.push(SerializeTask::Node {
+            entry: child,
+            path: child_path,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor_macros::state;
+
+    #[test]
+    fn marks_schema_inline_content_for_dom_projection() {
+        let (state, ..) = state! {
+            doc { root { p: paragraph { text("Before") page_break } } }
+            selection: (p, 0)
+        };
+
+        let html = serialize(&state.to_plain(), &Resource::new_test());
+
+        assert!(
+            html.starts_with(r#"<article data-typie-node="r""#),
+            "actual: {html}"
+        );
+        assert!(html.contains(r#"data-typie-text-container"#));
+        assert!(html.contains(r#"data-typie-text="0.0""#));
+        assert!(html.contains(r#"data-typie-node="0.1" data-typie-boundary"#));
+    }
+
+    #[test]
+    fn uses_canonical_html_modifiers_and_theme_colors() {
+        let (state, ..) = state! {
+            doc { root { p: paragraph [line_height(160), paragraph_indent(100), alignment(editor_model::Alignment::Center)] {
+                text("Tokyo") [bold, text_color("red".to_string()), ruby(text: "とうきょう".to_string())]
+            } } }
+            selection: (p, 0)
+        };
+
+        let html = serialize(&state.to_plain(), &Resource::new_test());
+
+        assert!(html.contains("<strong>"));
+        assert!(html.contains("color:#ef4444"));
+        assert!(html.contains("line-height:1.6"));
+        assert!(html.contains("text-indent:16px"));
+        assert!(html.contains("text-align:center"));
+        assert!(html.contains("<ruby>"));
+        assert!(html.contains(r#"<rt translate="no">とうきょう</rt>"#));
+    }
+
+    #[test]
+    fn does_not_treat_modifier_values_as_css_declarations() {
+        let (state, ..) = state! {
+            doc { root { p: paragraph {
+                text("Styled") [
+                    font_family("Injected; background-image:url(https://example.com/font)".to_string()),
+                    text_color("red;background-image:url(https://example.com/color)".to_string())
+                ]
+            } } }
+            selection: (p, 0)
+        };
+
+        let html = serialize(&state.to_plain(), &Resource::new_test());
+        let document = scraper::Html::parse_fragment(&html);
+        let selector = scraper::Selector::parse("[data-typie-text]").unwrap();
+        let style = document
+            .select(&selector)
+            .next()
+            .and_then(|element| element.value().attr("style"))
+            .expect("document text must have a style attribute");
+        let properties = crate::html::parse::stylesheet::parse_inline_style(style)
+            .into_iter()
+            .map(|declaration| declaration.property)
+            .collect::<Vec<_>>();
+
+        assert_eq!(properties, ["font-family"]);
+    }
+}

--- a/crates/editor-clipboard/src/html/markup.rs
+++ b/crates/editor-clipboard/src/html/markup.rs
@@ -1,0 +1,416 @@
+use editor_model::{Modifier, PlainNode};
+use editor_resource::Resource;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum HtmlTarget {
+    Clipboard,
+    DomProjection,
+}
+
+pub(super) enum NodeMarkup {
+    Text,
+    Tab,
+    Children,
+    Skip,
+    Element {
+        tag: &'static str,
+        attrs: String,
+        void: bool,
+    },
+}
+
+fn element(tag: &'static str) -> NodeMarkup {
+    NodeMarkup::Element {
+        tag,
+        attrs: String::new(),
+        void: false,
+    }
+}
+
+fn void_element(tag: &'static str) -> NodeMarkup {
+    NodeMarkup::Element {
+        tag,
+        attrs: String::new(),
+        void: true,
+    }
+}
+
+pub(super) fn markup_for_node(node: &PlainNode, target: HtmlTarget) -> NodeMarkup {
+    match node {
+        PlainNode::Text(_) => NodeMarkup::Text,
+        PlainNode::HardBreak(_) => void_element("br"),
+        PlainNode::Tab(_) if target == HtmlTarget::Clipboard => NodeMarkup::Tab,
+        PlainNode::Tab(_) => element("span"),
+        PlainNode::Paragraph(_) => element("p"),
+        PlainNode::BulletList(_) => element("ul"),
+        PlainNode::OrderedList(_) => element("ol"),
+        PlainNode::ListItem(_) => element("li"),
+        PlainNode::Blockquote(blockquote) => NodeMarkup::Element {
+            tag: "blockquote",
+            attrs: format!(r#"data-variant="{}""#, variant_str(&blockquote.variant)),
+            void: false,
+        },
+        PlainNode::Callout(callout) => NodeMarkup::Element {
+            tag: "aside",
+            attrs: format!(
+                r#"data-callout data-variant="{}""#,
+                variant_str(&callout.variant)
+            ),
+            void: false,
+        },
+        PlainNode::Fold(_) => element("details"),
+        PlainNode::FoldTitle(_) => element("summary"),
+        PlainNode::FoldContent(_) if target == HtmlTarget::Clipboard => NodeMarkup::Children,
+        PlainNode::FoldContent(_) => element("div"),
+        PlainNode::Table(table) => NodeMarkup::Element {
+            tag: "table",
+            attrs: format!(
+                r#"data-border-style="{}" data-proportion="{}""#,
+                variant_str(&table.border_style),
+                table.proportion,
+            ),
+            void: false,
+        },
+        PlainNode::TableRow(_) => element("tr"),
+        PlainNode::TableCell(cell) => NodeMarkup::Element {
+            tag: "td",
+            attrs: cell
+                .col_width
+                .map(|width| format!(r#"data-col-width="{width}""#))
+                .unwrap_or_default(),
+            void: false,
+        },
+        PlainNode::Image(image) if target == HtmlTarget::Clipboard => NodeMarkup::Element {
+            tag: "img",
+            attrs: format!(
+                r#"data-id="{}" data-proportion="{}""#,
+                html_escape(image.id.as_deref().unwrap_or("")),
+                image.proportion,
+            ),
+            void: true,
+        },
+        PlainNode::Image(image) => NodeMarkup::Element {
+            tag: "figure",
+            attrs: format!(
+                r#"data-id="{}" data-proportion="{}""#,
+                html_escape(image.id.as_deref().unwrap_or("")),
+                image.proportion,
+            ),
+            void: false,
+        },
+        PlainNode::Embed(embed) if target == HtmlTarget::Clipboard => NodeMarkup::Element {
+            tag: "a",
+            attrs: format!(
+                r#"data-embed data-id="{}""#,
+                html_escape(embed.id.as_deref().unwrap_or("")),
+            ),
+            void: false,
+        },
+        PlainNode::Embed(embed) => NodeMarkup::Element {
+            tag: "div",
+            attrs: format!(
+                r#"data-embed data-id="{}""#,
+                html_escape(embed.id.as_deref().unwrap_or("")),
+            ),
+            void: false,
+        },
+        PlainNode::File(file) if target == HtmlTarget::Clipboard => NodeMarkup::Element {
+            tag: "a",
+            attrs: format!(
+                r#"data-file data-id="{}""#,
+                html_escape(file.id.as_deref().unwrap_or("")),
+            ),
+            void: false,
+        },
+        PlainNode::File(file) => NodeMarkup::Element {
+            tag: "div",
+            attrs: format!(
+                r#"data-file data-id="{}""#,
+                html_escape(file.id.as_deref().unwrap_or("")),
+            ),
+            void: false,
+        },
+        PlainNode::Archived(_) if target == HtmlTarget::Clipboard => NodeMarkup::Skip,
+        PlainNode::Archived(_) => element("div"),
+        PlainNode::PageBreak(_) if target == HtmlTarget::Clipboard => NodeMarkup::Element {
+            tag: "div",
+            attrs: r#"style="page-break-after:always""#.to_string(),
+            void: false,
+        },
+        PlainNode::PageBreak(_) => NodeMarkup::Element {
+            tag: "span",
+            attrs: r#"style="break-after:page""#.to_string(),
+            void: false,
+        },
+        PlainNode::HorizontalRule(_) => void_element("hr"),
+        PlainNode::Root(_) if target == HtmlTarget::Clipboard => NodeMarkup::Children,
+        PlainNode::Root(_) => element("article"),
+        PlainNode::Unknown if target == HtmlTarget::Clipboard => NodeMarkup::Skip,
+        PlainNode::Unknown => element("div"),
+    }
+}
+
+pub(super) fn write_open_tag(
+    out: &mut String,
+    tag: &str,
+    attrs: &str,
+    extra_attrs: &[(&str, Option<&str>)],
+) {
+    out.push('<');
+    out.push_str(tag);
+    if !attrs.is_empty() {
+        out.push(' ');
+        out.push_str(attrs);
+    }
+    for (name, value) in extra_attrs {
+        out.push(' ');
+        out.push_str(name);
+        if let Some(value) = value {
+            out.push_str(r#"=""#);
+            out.push_str(&html_escape(value));
+            out.push('"');
+        }
+    }
+    out.push('>');
+}
+
+pub(super) fn write_close_tag(out: &mut String, tag: &str) {
+    out.push_str("</");
+    out.push_str(tag);
+    out.push('>');
+}
+
+pub(super) fn write_clipboard_text(
+    text: &str,
+    modifiers: &[Modifier],
+    resource: &Resource,
+    out: &mut String,
+) {
+    let presentation = modifier_presentation(modifiers, resource, HtmlTarget::Clipboard);
+    for structural in &presentation.structural {
+        structural.write_open(out);
+    }
+    let style = joined_style(&presentation);
+    if let Some(style) = style.as_deref() {
+        write_open_tag(out, "span", "", &[("style", Some(style))]);
+    }
+    out.push_str(&html_escape(text));
+    if style.is_some() {
+        write_close_tag(out, "span");
+    }
+    for structural in presentation.structural.iter().rev() {
+        structural.write_close(out);
+    }
+}
+
+pub(super) fn write_dom_projection_text<'m>(
+    text: &str,
+    modifiers: impl IntoIterator<Item = &'m Modifier>,
+    resource: &Resource,
+    path: &str,
+    out: &mut String,
+) {
+    let presentation = modifier_presentation(modifiers, resource, HtmlTarget::DomProjection);
+    if presentation.ruby.is_some() {
+        out.push_str("<ruby>");
+    }
+    for structural in &presentation.structural {
+        structural.write_open(out);
+    }
+
+    let style = joined_style(&presentation);
+    let mut attrs = vec![("data-typie-text", Some(path))];
+    if let Some(style) = style.as_deref() {
+        attrs.push(("style", Some(style)));
+    }
+    write_open_tag(out, "span", "", &attrs);
+    out.push_str(&html_escape(text));
+    write_close_tag(out, "span");
+
+    for structural in presentation.structural.iter().rev() {
+        structural.write_close(out);
+    }
+    if let Some(ruby) = presentation.ruby {
+        out.push_str(r#"<rt translate="no">"#);
+        out.push_str(&html_escape(ruby));
+        out.push_str("</rt></ruby>");
+    }
+}
+
+pub(super) fn dom_projection_style<'m>(
+    modifiers: impl IntoIterator<Item = &'m Modifier>,
+    resource: &Resource,
+) -> Option<String> {
+    joined_style(&modifier_presentation(
+        modifiers,
+        resource,
+        HtmlTarget::DomProjection,
+    ))
+}
+
+enum StructuralMarkup<'a> {
+    Strong,
+    Emphasis,
+    Underline,
+    Strikethrough,
+    Link(&'a str),
+}
+
+impl StructuralMarkup<'_> {
+    fn order(&self) -> u8 {
+        match self {
+            Self::Strong => 0,
+            Self::Emphasis => 1,
+            Self::Underline => 2,
+            Self::Strikethrough => 3,
+            Self::Link(_) => 4,
+        }
+    }
+
+    fn write_open(&self, out: &mut String) {
+        match self {
+            Self::Strong => out.push_str("<strong>"),
+            Self::Emphasis => out.push_str("<em>"),
+            Self::Underline => out.push_str("<u>"),
+            Self::Strikethrough => out.push_str("<s>"),
+            Self::Link(href) => {
+                out.push_str("<a href=\"");
+                out.push_str(&html_escape(href));
+                out.push_str(r#"">"#);
+            }
+        }
+    }
+
+    fn write_close(&self, out: &mut String) {
+        match self {
+            Self::Strong => out.push_str("</strong>"),
+            Self::Emphasis => out.push_str("</em>"),
+            Self::Underline => out.push_str("</u>"),
+            Self::Strikethrough => out.push_str("</s>"),
+            Self::Link(_) => out.push_str("</a>"),
+        }
+    }
+}
+
+struct ModifierPresentation<'a> {
+    structural: Vec<StructuralMarkup<'a>>,
+    style: Vec<String>,
+    ruby: Option<&'a str>,
+}
+
+fn joined_style(presentation: &ModifierPresentation<'_>) -> Option<String> {
+    (!presentation.style.is_empty()).then(|| presentation.style.join(";"))
+}
+
+fn css_color(value: &str, token_prefix: &str, resource: &Resource) -> Option<String> {
+    if value == "none" {
+        return Some("transparent".to_string());
+    }
+    match resource
+        .theme()
+        .try_color(&format!("{token_prefix}.{value}"))
+    {
+        Some(c) => Some(format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b)),
+        None => {
+            let [r, g, b, a] = csscolorparser::parse(value.trim()).ok()?.to_rgba8();
+            Some(if a == u8::MAX {
+                format!("#{r:02x}{g:02x}{b:02x}")
+            } else {
+                format!("#{r:02x}{g:02x}{b:02x}{a:02x}")
+            })
+        }
+    }
+}
+
+fn css_font_family(value: &str) -> Option<String> {
+    if value.is_empty() {
+        return None;
+    }
+    let mut serialized = String::new();
+    cssparser::serialize_string(value, &mut serialized).expect("writing to a String cannot fail");
+    Some(serialized)
+}
+
+fn modifier_presentation<'m>(
+    modifiers: impl IntoIterator<Item = &'m Modifier>,
+    resource: &Resource,
+    target: HtmlTarget,
+) -> ModifierPresentation<'m> {
+    let mut structural = Vec::new();
+    let mut style = Vec::new();
+    let mut ruby = None;
+    for modifier in modifiers {
+        match modifier {
+            Modifier::Bold => structural.push(StructuralMarkup::Strong),
+            Modifier::Italic => structural.push(StructuralMarkup::Emphasis),
+            Modifier::Underline => structural.push(StructuralMarkup::Underline),
+            Modifier::Strikethrough => structural.push(StructuralMarkup::Strikethrough),
+            Modifier::FontSize { value } => {
+                style.push(format!("font-size:{}pt", *value as f32 / 100.0))
+            }
+            Modifier::FontFamily { value } => {
+                if let Some(value) = css_font_family(value) {
+                    style.push(format!("font-family:{value}"));
+                }
+            }
+            Modifier::FontWeight { value } => style.push(format!("font-weight:{value}")),
+            Modifier::TextColor { value } => {
+                if let Some(value) = css_color(value, "text", resource) {
+                    style.push(format!("color:{value}"));
+                }
+            }
+            Modifier::BackgroundColor { value } => {
+                if let Some(value) = css_color(value, "bg", resource) {
+                    style.push(format!("background-color:{value}"));
+                }
+            }
+            Modifier::LetterSpacing { value } => {
+                style.push(format!("letter-spacing:{}em", *value as f32 / 100.0))
+            }
+            Modifier::Link { href } => structural.push(StructuralMarkup::Link(href)),
+            Modifier::Ruby { text } => {
+                if target == HtmlTarget::DomProjection {
+                    ruby = Some(text.as_str());
+                }
+            }
+            Modifier::LineHeight { value } => {
+                if target == HtmlTarget::DomProjection {
+                    style.push(format!("line-height:{}", *value as f32 / 100.0));
+                }
+            }
+            Modifier::BlockGap { .. } => {}
+            Modifier::ParagraphIndent { value } => {
+                if target == HtmlTarget::DomProjection {
+                    style.push(format!("text-indent:{}px", *value as f32 / 100.0 * 16.0));
+                }
+            }
+            Modifier::Alignment { value } => {
+                if target == HtmlTarget::DomProjection {
+                    style.push(format!("text-align:{}", variant_str(value)));
+                }
+            }
+        }
+    }
+    structural.sort_by_key(StructuralMarkup::order);
+    ModifierPresentation {
+        structural,
+        style,
+        ruby,
+    }
+}
+
+// 변형 enum 들은 #[serde(rename_all = "snake_case")] 의 plain string 직렬화를 가정
+fn variant_str<T: serde::Serialize>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(String::from))
+        .unwrap_or_default()
+}
+
+fn html_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}

--- a/crates/editor-clipboard/src/html/mod.rs
+++ b/crates/editor-clipboard/src/html/mod.rs
@@ -1,2 +1,4 @@
+pub mod dom_projection;
+mod markup;
 pub mod parse;
 pub mod serialize;

--- a/crates/editor-clipboard/src/html/serialize.rs
+++ b/crates/editor-clipboard/src/html/serialize.rs
@@ -1,11 +1,14 @@
+use super::markup::{
+    HtmlTarget, NodeMarkup, markup_for_node, write_clipboard_text, write_close_tag, write_open_tag,
+};
 use crate::slice::Slice;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
-use editor_model::{Fragment, Modifier, PlainNode};
+use editor_model::{Fragment, PlainNode};
 use editor_resource::Resource;
 use serde::Serialize;
 
-pub fn to_html(slice: &Slice, resource: &Resource) -> String {
+pub(crate) fn serialize_clipboard_slice(slice: &Slice, resource: &Resource) -> String {
     let mut out = String::new();
     out.push_str(r#"<meta charset="utf-8">"#);
     let mut meta_json = Vec::new();
@@ -35,221 +38,33 @@ fn serialize_forest(fragments: &[Fragment], resource: &Resource, out: &mut Strin
         let fragment = match task {
             SerializeTask::Node(fragment) => fragment,
             SerializeTask::Close(tag) => {
-                out.push_str(tag);
+                write_close_tag(out, tag);
                 continue;
             }
         };
-        match &fragment.node {
-            PlainNode::Text(t) => serialize_text(&t.text, &fragment.modifiers, resource, out),
-            PlainNode::HardBreak(_) => out.push_str("<br>"),
-            PlainNode::Tab(_) => out.push('\t'),
-            PlainNode::Paragraph(_) => open_container("<p>", "</p>", fragment, &mut tasks, out),
-            PlainNode::BulletList(_) => open_container("<ul>", "</ul>", fragment, &mut tasks, out),
-            PlainNode::OrderedList(_) => open_container("<ol>", "</ol>", fragment, &mut tasks, out),
-            PlainNode::ListItem(_) => open_container("<li>", "</li>", fragment, &mut tasks, out),
-            PlainNode::Blockquote(b) => open_container(
-                &format!(r#"<blockquote data-variant="{}">"#, variant_str(&b.variant)),
-                "</blockquote>",
-                fragment,
-                &mut tasks,
-                out,
-            ),
-            PlainNode::Callout(c) => open_container(
-                &format!(
-                    r#"<aside data-callout data-variant="{}">"#,
-                    variant_str(&c.variant)
-                ),
-                "</aside>",
-                fragment,
-                &mut tasks,
-                out,
-            ),
-            PlainNode::Fold(_) => {
-                open_container("<details>", "</details>", fragment, &mut tasks, out)
-            }
-            PlainNode::FoldTitle(_) => {
-                open_container("<summary>", "</summary>", fragment, &mut tasks, out)
-            }
-            PlainNode::FoldContent(_) => push_children(&mut tasks, &fragment.children),
-            PlainNode::Table(t) => open_container(
-                &format!(
-                    r#"<table data-border-style="{}" data-proportion="{}">"#,
-                    variant_str(&t.border_style),
-                    t.proportion,
-                ),
-                "</table>",
-                fragment,
-                &mut tasks,
-                out,
-            ),
-            PlainNode::TableRow(_) => open_container("<tr>", "</tr>", fragment, &mut tasks, out),
-            PlainNode::TableCell(c) => {
-                let open = match c.col_width {
-                    Some(width) => format!(r#"<td data-col-width="{width}">"#),
-                    None => "<td>".to_string(),
+        match markup_for_node(&fragment.node, HtmlTarget::Clipboard) {
+            NodeMarkup::Text => {
+                let PlainNode::Text(text) = &fragment.node else {
+                    unreachable!()
                 };
-                open_container(&open, "</td>", fragment, &mut tasks, out);
+                write_clipboard_text(&text.text, &fragment.modifiers, resource, out);
             }
-            PlainNode::Image(i) => {
-                out.push_str(&format!(
-                    r#"<img data-id="{}" data-proportion="{}">"#,
-                    html_escape(i.id.as_deref().unwrap_or("")),
-                    i.proportion,
-                ));
+            NodeMarkup::Tab => out.push('\t'),
+            NodeMarkup::Children => push_children(&mut tasks, &fragment.children),
+            NodeMarkup::Skip => {}
+            NodeMarkup::Element { tag, attrs, void } => {
+                write_open_tag(out, tag, &attrs, &[]);
+                if !void {
+                    tasks.push(SerializeTask::Close(tag));
+                    push_children(&mut tasks, &fragment.children);
+                }
             }
-            PlainNode::Embed(e) => {
-                out.push_str(&format!(
-                    r#"<a data-embed data-id="{}"></a>"#,
-                    html_escape(e.id.as_deref().unwrap_or("")),
-                ));
-            }
-            PlainNode::File(f) => {
-                out.push_str(&format!(
-                    r#"<a data-file data-id="{}"></a>"#,
-                    html_escape(f.id.as_deref().unwrap_or("")),
-                ));
-            }
-            PlainNode::Archived(_) => {}
-            PlainNode::PageBreak(_) => {
-                out.push_str(r#"<div style="page-break-after:always"></div>"#)
-            }
-            PlainNode::HorizontalRule(_) => out.push_str("<hr>"),
-            PlainNode::Root(_) => push_children(&mut tasks, &fragment.children),
-            PlainNode::Unknown => {}
         }
     }
-}
-
-fn open_container<'a>(
-    open: &str,
-    close: &'static str,
-    fragment: &'a Fragment,
-    tasks: &mut Vec<SerializeTask<'a>>,
-    out: &mut String,
-) {
-    out.push_str(open);
-    tasks.push(SerializeTask::Close(close));
-    push_children(tasks, &fragment.children);
 }
 
 fn push_children<'a>(tasks: &mut Vec<SerializeTask<'a>>, children: &'a [Fragment]) {
     tasks.extend(children.iter().rev().map(SerializeTask::Node));
-}
-
-// 변형 enum 들은 #[serde(rename_all = "snake_case")] 의 plain string 직렬화를 가정
-fn variant_str<T: serde::Serialize>(v: &T) -> String {
-    serde_json::to_value(v)
-        .ok()
-        .and_then(|val| val.as_str().map(String::from))
-        .unwrap_or_default()
-}
-
-fn serialize_text(text: &str, modifiers: &[Modifier], resource: &Resource, out: &mut String) {
-    let escaped = html_escape(text);
-
-    let (structural, style_pairs) = split_modifiers(modifiers, resource);
-    let mut open_tags: Vec<String> = Vec::new();
-    let mut close_tags: Vec<String> = Vec::new();
-
-    for m in &structural {
-        let (open, close) = open_close_for(m);
-        open_tags.push(open);
-        close_tags.push(close);
-    }
-
-    for t in &open_tags {
-        out.push_str(t);
-    }
-    if !style_pairs.is_empty() {
-        out.push_str(&format!(r#"<span style="{}">"#, style_pairs.join(";")));
-    }
-    out.push_str(&escaped);
-    if !style_pairs.is_empty() {
-        out.push_str("</span>");
-    }
-    for t in close_tags.iter().rev() {
-        out.push_str(t);
-    }
-}
-
-fn structural_order(m: &Modifier) -> u8 {
-    match m {
-        Modifier::Bold => 0,
-        Modifier::Italic => 1,
-        Modifier::Underline => 2,
-        Modifier::Strikethrough => 3,
-        Modifier::Link { .. } => 4,
-        _ => u8::MAX,
-    }
-}
-
-fn css_color(value: &str, token_prefix: &str, resource: &Resource) -> String {
-    if value == "none" {
-        return "transparent".to_string();
-    }
-    match resource
-        .theme()
-        .try_color(&format!("{token_prefix}.{value}"))
-    {
-        Some(c) => format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b),
-        None => value.to_string(),
-    }
-}
-
-fn split_modifiers<'m>(
-    mods: &'m [Modifier],
-    resource: &Resource,
-) -> (Vec<&'m Modifier>, Vec<String>) {
-    let mut structural: Vec<&Modifier> = vec![];
-    let mut style: Vec<String> = vec![];
-    for m in mods {
-        match m {
-            Modifier::Bold
-            | Modifier::Italic
-            | Modifier::Underline
-            | Modifier::Strikethrough
-            | Modifier::Link { .. } => structural.push(m),
-            Modifier::FontSize { value } => {
-                style.push(format!("font-size:{}pt", *value as f32 / 100.0))
-            }
-            Modifier::FontFamily { value } => style.push(format!("font-family:{value}")),
-            Modifier::FontWeight { value } => style.push(format!("font-weight:{value}")),
-            Modifier::TextColor { value } => {
-                style.push(format!("color:{}", css_color(value, "text", resource)))
-            }
-            Modifier::BackgroundColor { value } => style.push(format!(
-                "background-color:{}",
-                css_color(value, "bg", resource)
-            )),
-            Modifier::LetterSpacing { value } => {
-                style.push(format!("letter-spacing:{}em", *value as f32 / 100.0))
-            }
-            _ => {}
-        }
-    }
-    structural.sort_by_key(|m| structural_order(m));
-    (structural, style)
-}
-
-fn open_close_for(m: &Modifier) -> (String, String) {
-    match m {
-        Modifier::Bold => ("<strong>".into(), "</strong>".into()),
-        Modifier::Italic => ("<em>".into(), "</em>".into()),
-        Modifier::Underline => ("<u>".into(), "</u>".into()),
-        Modifier::Strikethrough => ("<s>".into(), "</s>".into()),
-        Modifier::Link { href } => (
-            format!(r#"<a href="{}">"#, html_escape(href)),
-            "</a>".into(),
-        ),
-        _ => (String::new(), String::new()),
-    }
-}
-
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
 }
 
 #[cfg(test)]
@@ -267,7 +82,7 @@ mod tests {
     #[test]
     fn serialize_empty_slice_with_meta() {
         let slice = Slice::new(vec![], 0, 0);
-        let html = to_html(&slice, &Resource::new_test());
+        let html = serialize_clipboard_slice(&slice, &Resource::new_test());
         assert!(html.contains("data-slice-v2="));
         assert!(html.contains("data-version=\"1\""));
         assert!(html.contains("<div data-root>"));
@@ -277,7 +92,7 @@ mod tests {
     #[test]
     fn serialize_prepends_charset_meta() {
         let slice = Slice::new(vec![], 0, 0);
-        let html = to_html(&slice, &Resource::new_test());
+        let html = serialize_clipboard_slice(&slice, &Resource::new_test());
         assert!(html.starts_with(r#"<meta charset="utf-8">"#));
     }
 

--- a/crates/editor-clipboard/src/slice.rs
+++ b/crates/editor-clipboard/src/slice.rs
@@ -105,7 +105,7 @@ impl Slice {
     }
 
     pub fn to_html(&self, resource: &Resource) -> String {
-        html_serialize::to_html(self, resource)
+        html_serialize::serialize_clipboard_slice(self, resource)
     }
 
     pub fn from_html(html: &str, resource: &Resource) -> Slice {

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -160,6 +160,11 @@ export interface DecorationStyle {
     underline: Underline | undefined;
 }
 
+export interface DocumentDomProjection {
+    html: string;
+    source: PlainDoc;
+}
+
 export interface ExpansionAffordances {
     word: boolean;
     sentence: boolean;
@@ -781,6 +786,7 @@ declare class Editor {
     cursor_hit_rects(): PageRect[];
     cursor_hit_test(page: number, x: number, y: number): boolean;
     detach_surface(page: number): void;
+    document_dom_projection(): DocumentDomProjection;
     /**
      * `window_ms` is how far back an edit still counts as recent. The host owns that
      * number — it also decides how far back the query that seeds the baseline reaches —

--- a/crates/editor-ffi/src/editor.rs
+++ b/crates/editor-ffi/src/editor.rs
@@ -184,6 +184,14 @@ pub struct CharacterCounts {
     pub selection_without_whitespace_and_punctuation: u32,
 }
 
+#[cfg(feature = "wasm-browser")]
+#[ffi]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DocumentDomProjection {
+    pub html: String,
+    pub source: editor_model::PlainDoc,
+}
+
 #[ffi]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1212,14 +1220,22 @@ impl Editor {
     }
 }
 
-// Separate from the block above: `surface_backend`/`refresh_surface` are browser
-// present-path specific (the `cpu-oversized` report, the visibility-return recovery),
-// so they stay in a wasm-browser-only block rather than the shared uniffi/wasm block
-// above — a `#[cfg]` on an individual method inside a shared uniffi/wasm block isn't
-// honored by uniffi's own codegen.
+// Browser-only APIs stay outside the shared UniFFI/WASM block above: UniFFI codegen
+// does not honor `#[cfg]` on individual methods inside that shared export block.
 #[cfg(feature = "wasm-browser")]
 #[editor_macros::ffi_export(wasm)]
 impl Editor {
+    pub fn document_dom_projection(&self) -> EditorResult<Complex<DocumentDomProjection>> {
+        self.with_inner(|inner| {
+            let source = inner.editor.state().to_plain();
+            let html = {
+                let resource = inner.editor.resource().lock().unwrap();
+                editor_clipboard::html::dom_projection::serialize(&source, &resource)
+            };
+            Ok(DocumentDomProjection { html, source }.into_ffi()?)
+        })
+    }
+
     pub fn surface_backend(&self, page: u32) -> EditorResult<String> {
         self.with_guarded_render(|render| {
             Ok(match render.surfaces.get(&page) {


### PR DESCRIPTION
## 배경

공개 뷰어의 문서 본문은 캔버스로 렌더링되기 때문에 Safari와 Chrome 계열 브라우저의 페이지 번역이 본문을 인식할 수 없었습니다.

## 변경 사항

- 전체 `PlainDoc`을 의미가 보존된 HTML로 투영하는 DOM projection 추가
- 클립보드와 DOM projection이 노드·서식의 HTML 매핑을 공유하도록 직렬화 구조 정리
- HTML과 원본 `PlainDoc`을 동일 시점에 반환하는 브라우저 전용 FFI 추가
- 공개 뷰어에 보이지 않는 DOM 미러를 마운트
- 브라우저가 번역한 DOM 텍스트를 `PlainDoc`으로 복원해 뷰어에 반영
- hard break, page break, ruby 및 원본 modifier 보존
- DOM 변경을 animation frame 단위로 모아 처리
- 초기화 및 projection 오류를 문서 내용 없이 Sentry에 보고

`protectContent` 문서도 번역 대상에 포함됩니다.

## 설계

노드와 modifier의 HTML 표현은 Rust의 공통 markup 계층이 소유합니다.

클립보드 HTML은 기존 slice 구조를 유지하고, 번역용 HTML은 전체 문서 구조와 복원용 marker를 추가합니다. Web에서는 번역된 DOM의 속성이나 스타일을 신뢰하지 않고 원본 `PlainDoc`의 modifier와 경계 노드를 사용해 문서를 재구성합니다.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>