### PR TITLE
웹 집중 모드 개편

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/Editor.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Editor.svelte
@@ -4,6 +4,7 @@
   import type { SystemStyleObject } from '@typie/styled-system/types';
   import type { Snippet } from 'svelte';
   import type { Editor_document$key } from '$mearie';
+  import type { EditorViewSurfaceLayout } from './editor-view-surface-layout';
 
   type Props = {
     document$key: Editor_document$key;
@@ -11,10 +12,7 @@
     viewer?: boolean;
     useWindowScroll?: boolean;
     style?: SystemStyleObject;
-    contentInsetLeft?: number;
-    contentInsetRight?: number;
-    contentMotion?: { fromX: number; duration: number; easing: string };
-    floatingZoomRightInset?: number;
+    viewSurfaceLayout?: EditorViewSurfaceLayout;
     header?: Snippet;
     footer?: Snippet;
     placeholderAction?: Snippet;
@@ -28,10 +26,7 @@
     viewer = false,
     useWindowScroll = false,
     style,
-    contentInsetLeft = 0,
-    contentInsetRight = 0,
-    contentMotion,
-    floatingZoomRightInset = 0,
+    viewSurfaceLayout,
     header,
     footer,
     placeholderAction,
@@ -54,16 +49,13 @@
   <View
     style={css.raw({ flex: '1' }, style)}
     {active}
-    {contentInsetLeft}
-    {contentInsetRight}
-    {contentMotion}
     {document$key}
-    {floatingZoomRightInset}
     {footer}
     {header}
     {onReady}
     {placeholderAction}
     {useWindowScroll}
+    {viewSurfaceLayout}
     {viewer}
   >
     {#if children}

--- a/apps/website/src/lib/editor-ffi/components/View.svelte
+++ b/apps/website/src/lib/editor-ffi/components/View.svelte
@@ -46,6 +46,7 @@
   import type { Snippet } from 'svelte';
   import type { Editor_document$key } from '$mearie';
   import type { DocumentZoomLayout } from '../zoom';
+  import type { EditorViewSurfaceLayout } from './editor-view-surface-layout';
 
   type Props = {
     document$key: Editor_document$key;
@@ -55,11 +56,8 @@
     useWindowScroll?: boolean;
     style?: SystemStyleObject;
     /** 본문 좌우에 비워 둘 폭. 여백 레이어(프리즘 리뷰)가 레일·카드 컬럼을 놓는 자리다. */
-    contentInsetLeft?: number;
-    contentInsetRight?: number;
-    /** 최종 레이아웃으로 바뀐 본문을 이전 화면 위치에서 합성하는 일회성 모션. */
-    contentMotion?: { fromX: number; duration: number; easing: string };
-    floatingZoomRightInset?: number;
+    /** 에디터 view surface의 좌표계와 그 위에 붙는 UI 배치를 함께 정의한다. */
+    viewSurfaceLayout?: EditorViewSurfaceLayout;
     onReady?: () => void;
     header?: Snippet;
     footer?: Snippet;
@@ -73,16 +71,23 @@
     viewer = false,
     useWindowScroll = false,
     style,
-    contentInsetLeft = 0,
-    contentInsetRight = 0,
-    contentMotion,
-    floatingZoomRightInset = 0,
+    viewSurfaceLayout,
     onReady,
     header,
     footer,
     placeholderAction,
     children,
   }: Props = $props();
+
+  const contentInsetLeft = $derived(viewSurfaceLayout?.contentInset?.left ?? 0);
+  const contentInsetRight = $derived(viewSurfaceLayout?.contentInset?.right ?? 0);
+  const contentInsetTop = $derived(viewSurfaceLayout?.contentInset?.top ?? 0);
+  const visibleAreaTopInset = $derived(viewSurfaceLayout?.visibleAreaTopInset ?? 0);
+  const contentMotion = $derived(viewSurfaceLayout?.contentMotion);
+  const floatingZoomRightInset = $derived(viewSurfaceLayout?.floatingZoom?.rightInset ?? 0);
+  const floatingZoomTopInset = $derived(viewSurfaceLayout?.floatingZoom?.topInset);
+  const floatingZoomLayoutOriginOffset = $derived(viewSurfaceLayout?.floatingZoom?.layoutOriginOffset ?? 0);
+  const floatingZoomChromeAttachment = $derived(viewSurfaceLayout?.floatingZoom?.chromeAttachment);
 
   const ctx = getEditorContext();
   const theme = getThemeContext();
@@ -109,6 +114,10 @@
       surfaceHost = undefined;
       host.destroy();
     };
+  });
+
+  $effect(() => {
+    ctx.scroll?.setTopInset(visibleAreaTopInset);
   });
 
   $effect(() => {
@@ -237,6 +246,7 @@
   let viewportLayoutType: 'continuous' | 'paginated' | undefined;
   let viewportClientWidth: number | undefined;
   let viewportClientHeight: number | undefined;
+  let viewportContentInsetTop: number | undefined;
   let lastViewportScaleFactor: number | undefined;
 
   $effect(() => {
@@ -257,9 +267,12 @@
       const committedLayoutChanged = sameEditor && viewportLayoutType !== layoutMode?.type;
       const physicalViewportChanged =
         sameEditor && (viewportClientWidth !== width || viewportClientHeight !== height || lastViewportScaleFactor !== viewportScaleFactor);
+      const contentOriginShift = sameEditor && viewportContentInsetTop !== undefined ? contentInsetTop - viewportContentInsetTop : 0;
+      if (contentOriginShift !== 0) ctx.scroll?.translateViewportAnchorAttachment(contentOriginShift);
       viewportLayoutType = layoutMode?.type;
       viewportClientWidth = width;
       viewportClientHeight = height;
+      viewportContentInsetTop = contentInsetTop;
       lastViewportScaleFactor = viewportScaleFactor;
       if (sameEditor && !committedLayoutChanged) {
         editor.resizeViewport(effectiveWidth, height, viewportScaleFactor);
@@ -307,6 +320,7 @@
     void windowViewportHeight;
     void contentInsetLeft;
     void contentInsetRight;
+    void contentInsetTop;
     for (const pageEl of Object.values(editor.pageEls)) void pageEl;
     untrack(() => editor.requestPresentationGeometryUpdate());
   });
@@ -358,10 +372,13 @@
     <EditorZoom {active} editor={ctx.editor} {editorViewSurface} layout={zoomLayout} scroll={ctx.scroll} viewportWidth={clientWidth ?? 0}>
       {#snippet zoomControls({ controls })}
         <FloatingEditorZoomControls
+          chromeAttachment={floatingZoomChromeAttachment}
           {controls}
           fixed={useWindowScroll}
+          layoutOriginOffset={floatingZoomLayoutOriginOffset}
           revealOnHover={!useWindowScroll}
           rightInset={floatingZoomRightInset}
+          topInset={floatingZoomTopInset}
         />
       {/snippet}
     </EditorZoom>
@@ -416,6 +433,15 @@
     bind:clientWidth
     bind:clientHeight
   >
+    {#if contentInsetTop > 0}
+      <div
+        style:height={`${contentInsetTop}px`}
+        class={css({ flexShrink: '0', pointerEvents: 'none' })}
+        aria-hidden="true"
+        data-editor-content-top-inset
+      ></div>
+    {/if}
+
     {#if ctx.editor && header}
       <div
         style:--editor-content-from-x={`${contentMotion?.fromX ?? 0}px`}

--- a/apps/website/src/lib/editor-ffi/components/editor-view-surface-layout.ts
+++ b/apps/website/src/lib/editor-ffi/components/editor-view-surface-layout.ts
@@ -1,0 +1,17 @@
+import type { FloatingEditorZoomChromeAttachment } from './ui/FloatingEditorZoomControls.svelte';
+
+export type EditorViewSurfaceLayout = {
+  contentInset?: {
+    left?: number;
+    right?: number;
+    top?: number;
+  };
+  visibleAreaTopInset?: number;
+  contentMotion?: { fromX: number; duration: number; easing: string };
+  floatingZoom?: {
+    rightInset?: number;
+    topInset?: number;
+    layoutOriginOffset?: number;
+    chromeAttachment?: FloatingEditorZoomChromeAttachment;
+  };
+};

--- a/apps/website/src/lib/editor-ffi/components/ui/FloatingEditorZoomControls.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/FloatingEditorZoomControls.svelte
@@ -4,36 +4,121 @@
   import { prefersReducedMotion } from '@typie/ui/state';
   import { CONTEXT_BAR_FADE_IN_MS, CONTEXT_BAR_FADE_OUT_MS, CONTEXT_BAR_TRANSIENT_VISIBLE_MS } from './editor-context-bar.svelte';
   import EditorZoomControls from './EditorZoomControls.svelte';
+  import { setupFloatingOverlayPosition } from './floating-overlay-position.svelte';
   import { TransientVisibilityState } from './transient-visibility.svelte';
   import type { EditorZoomControlsRenderProps } from './EditorZoomControls.svelte';
+
+  export type FloatingEditorZoomChromeAttachment = {
+    hold(event?: PointerEvent): void;
+    release(): void;
+    discoverable(): boolean;
+    attached(): boolean;
+    pointer(): { x: number; y: number } | null;
+  };
 
   type Props = {
     controls: EditorZoomControlsRenderProps;
     fixed?: boolean;
     revealOnHover?: boolean;
     rightInset?: number;
+    topInset?: number;
+    layoutOriginOffset?: number;
+    chromeAttachment?: FloatingEditorZoomChromeAttachment;
   };
 
   const CONTINUOUS_SURFACE = token('colors.surface.default');
   const PAGINATED_SURFACE = token('colors.surface.subtle');
   const TRANSIENT_BASE = `color-mix(in srgb, ${CONTINUOUS_SURFACE} 50%, ${PAGINATED_SURFACE} 50%)`;
-  const TRANSIENT_SURFACE = `color-mix(in srgb, ${TRANSIENT_BASE} 85%, transparent)`;
+  const TRANSIENT_SURFACE = `color-mix(in srgb, ${TRANSIENT_BASE} 75%, transparent)`;
 
-  let { controls, fixed = false, revealOnHover = false, rightInset = 0 }: Props = $props();
+  let {
+    controls,
+    fixed = false,
+    revealOnHover = false,
+    rightInset = 0,
+    topInset,
+    layoutOriginOffset = 0,
+    chromeAttachment,
+  }: Props = $props();
   const visibility = new TransientVisibilityState();
   const visible = $derived(controls.enabled && visibility.visible);
+  const chromeDiscoverable = $derived(chromeAttachment?.discoverable() ?? true);
+  const presented = $derived(visible);
   const engaged = $derived(visibility.engaged);
+  const attached = $derived(chromeAttachment?.attached() ?? false);
+  const interactive = $derived(presented || (chromeDiscoverable && revealOnHover));
+  const top = $derived(
+    fixed
+      ? 'var(--usersite-sticky-header-bottom, 0px)'
+      : topInset === undefined
+        ? 'var(--editor-floating-zoom-top-inset, 0px)'
+        : `${topInset}px`,
+  );
+  const borderRadius = $derived(attached ? '0 0 8px 8px' : '8px');
+  let anchor: HTMLDivElement;
+  let controlsElement: HTMLDivElement;
+  let pointerSyncFrame: number | undefined;
 
-  function handlePointerEnter(): void {
-    if (controls.enabled && (revealOnHover || visible)) visibility.setHovered(true);
+  setupFloatingOverlayPosition({
+    element: () => anchor,
+    layoutTop: () => (fixed || topInset === undefined ? undefined : layoutOriginOffset + topInset),
+    presented: () => presented,
+  });
+
+  function syncPointer(): void {
+    pointerSyncFrame = undefined;
+    const pointer = chromeAttachment?.pointer();
+    if (!controlsElement || !pointer) return;
+    const rect = controlsElement.getBoundingClientRect();
+    const inside = pointer.x >= rect.left && pointer.x <= rect.right && pointer.y >= rect.top && pointer.y <= rect.bottom;
+    if (inside && interactive && (revealOnHover || visible)) {
+      chromeAttachment?.hold();
+      visibility.setHovered(true);
+      return;
+    }
+    if (!inside && visibility.hovered) {
+      visibility.setHovered(false);
+      if (!visibility.focused) chromeAttachment?.release();
+    }
+  }
+
+  function schedulePointerSync(): void {
+    if (!chromeAttachment) return;
+    if (pointerSyncFrame !== undefined) cancelAnimationFrame(pointerSyncFrame);
+    pointerSyncFrame = requestAnimationFrame(syncPointer);
+  }
+
+  $effect(() => {
+    void top;
+    void layoutOriginOffset;
+    void interactive;
+    void presented;
+    if (chromeAttachment && controlsElement) schedulePointerSync();
+  });
+
+  function handlePointerEnter(event: PointerEvent): void {
+    if (!controls.enabled) return;
+    if (!chromeDiscoverable && !attached && !visible) return;
+    if (!revealOnHover && !visible) return;
+    if (chromeDiscoverable || attached) chromeAttachment?.hold(event);
+    visibility.setHovered(true);
   }
 
   function handlePointerLeave(): void {
     if (visibility.hovered) visibility.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
     visibility.setHovered(false);
+    if (!visibility.focused) chromeAttachment?.release();
+  }
+
+  function handlePointerMove(event: PointerEvent): void {
+    if (!chromeAttachment) return;
+    if (!chromeDiscoverable && !attached) return;
+    event.stopPropagation();
+    chromeAttachment.hold(event);
   }
 
   function handleFocusIn(): void {
+    if (chromeDiscoverable || attached) chromeAttachment?.hold();
     visibility.setFocused(true);
   }
 
@@ -41,18 +126,24 @@
     const nextInside = event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget);
     if (!nextInside && visibility.focused) visibility.showTemporarily(CONTEXT_BAR_TRANSIENT_VISIBLE_MS);
     visibility.setFocused(nextInside);
+    if (!nextInside && !visibility.hovered) chromeAttachment?.release();
   }
 
   $effect(() => {
     if (!controls.enabled) visibility.destroy();
   });
 
-  $effect(() => () => visibility.destroy());
+  $effect(() => () => {
+    if (pointerSyncFrame !== undefined) cancelAnimationFrame(pointerSyncFrame);
+    chromeAttachment?.release();
+    visibility.destroy();
+  });
 </script>
 
 <div
+  bind:this={anchor}
   style:position={fixed ? 'fixed' : 'absolute'}
-  style:top={fixed ? 'var(--usersite-sticky-header-bottom, 0px)' : '0'}
+  style:top
   style:right={`${rightInset}px`}
   class={css({
     zIndex: '5',
@@ -66,34 +157,46 @@
   role="presentation"
 >
   <div
+    bind:this={controlsElement}
     style:color={token(engaged ? 'colors.text.default' : 'colors.text.subtle')}
-    style:opacity={visible ? '1' : '0'}
-    style:pointer-events={revealOnHover || visible ? 'auto' : 'none'}
+    style:opacity={presented ? '1' : '0'}
+    style:pointer-events={interactive ? 'auto' : 'none'}
+    style:border-radius={borderRadius}
     style:transition={prefersReducedMotion.current
       ? 'none'
-      : `opacity ${visible ? CONTEXT_BAR_FADE_IN_MS : CONTEXT_BAR_FADE_OUT_MS}ms ease-out, color ${CONTEXT_BAR_FADE_IN_MS}ms ease-out`}
-    class={css({ position: 'relative', isolation: 'isolate', width: '[fit-content]', borderRadius: '8px' })}
+      : `opacity ${presented ? CONTEXT_BAR_FADE_IN_MS : CONTEXT_BAR_FADE_OUT_MS}ms ease-out, color ${CONTEXT_BAR_FADE_IN_MS}ms ease-out`}
+    class={css({ position: 'relative', isolation: 'isolate', width: '[fit-content]' })}
+    data-floating-editor-zoom-attached={attached}
     data-floating-editor-zoom-controls
     data-floating-editor-zoom-hover-reveal={revealOnHover}
+    data-pane-chrome-reveal-exclusion
     onfocusin={handleFocusIn}
     onfocusout={handleFocusOut}
     onpointerenter={handlePointerEnter}
     onpointerleave={handlePointerLeave}
+    onpointermove={handlePointerMove}
     role="presentation"
   >
     <div
-      style:backdrop-filter={`blur(${visible ? 2 : 0}px)`}
+      style:backdrop-filter={`blur(${presented ? 2 : 0}px)`}
+      style:border-radius={borderRadius}
       style:transition={prefersReducedMotion.current ? 'none' : 'backdrop-filter 320ms cubic-bezier(0, 0, 0.2, 1)'}
-      class={css({ position: 'absolute', inset: '0', zIndex: '[-2]', borderRadius: '8px', pointerEvents: 'none' })}
+      class={css({ position: 'absolute', inset: '0', zIndex: '[-2]', pointerEvents: 'none' })}
       aria-hidden="true"
       data-floating-editor-zoom-blur
     ></div>
     <div
       style:background-color={TRANSIENT_SURFACE}
-      class={css({ position: 'absolute', inset: '0', zIndex: '[-1]', borderRadius: '8px', pointerEvents: 'none' })}
+      style:border-radius={borderRadius}
+      class={css({ position: 'absolute', inset: '0', zIndex: '[-1]', pointerEvents: 'none' })}
       aria-hidden="true"
       data-floating-editor-zoom-surface
     ></div>
-    <EditorZoomControls {...controls} keyboardDiscoverableWhenHidden {visibility} {visible} />
+    <EditorZoomControls
+      {...controls}
+      keyboardDiscoverableWhenHidden={!chromeAttachment || chromeDiscoverable || presented}
+      {visibility}
+      visible={presented}
+    />
   </div>
 </div>

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar-test-root.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar-test-root.svelte
@@ -30,7 +30,9 @@
     useAppPinned?: boolean;
     floatingFixed?: boolean;
     floatingRevealOnHover?: boolean;
+    floatingRequiresChrome?: boolean;
     floatingRightInset?: number;
+    floatingTopInset?: number;
   };
 
   let {
@@ -53,7 +55,9 @@
     useAppPinned = false,
     floatingFixed = true,
     floatingRevealOnHover = false,
+    floatingRequiresChrome = false,
     floatingRightInset = 0,
+    floatingTopInset = 0,
   }: Props = $props();
   const app = setupAppContext(preferenceUserId);
   const contextBarPinned = $derived(
@@ -75,6 +79,21 @@
   let currentBreadcrumbWidth = $state(breadcrumbWidth);
   let breadcrumbPathIdentity = $state('folder/document');
   let contextBarTopOcclusion = $state(0);
+  let floatingChromeReady = $state(!floatingRequiresChrome);
+  let floatingChromeAttached = $state(!floatingRequiresChrome);
+  let floatingChromeRequestCount = $state(0);
+  let floatingPointer: { x: number; y: number } | null = null;
+  let currentFloatingTopInset = $state(floatingTopInset);
+  let floatingSurfaceTop = $state(0);
+  let floatingLayoutOriginOffset = $state(0);
+  const noop = () => null;
+  const floatingChromeAttachment = {
+    hold: () => (floatingChromeRequestCount += 1),
+    release: noop,
+    discoverable: () => floatingChromeReady,
+    attached: () => floatingChromeAttached,
+    pointer: () => floatingPointer,
+  };
 
   const toggleTargetLandmark = $derived<DocumentZoomLandmark | null>(
     initialToggleTargetLandmark === undefined ? (landmark === 'unit' ? 'fit-width' : 'unit') : initialToggleTargetLandmark,
@@ -108,10 +127,32 @@
     currentSurfaceWidth = nextWidth;
   }
 
+  export function setFloatingChromeReady(nextReady: boolean) {
+    floatingChromeReady = nextReady;
+    floatingChromeAttached = nextReady;
+  }
+
+  export function setFloatingChromeState(next: { ready: boolean; attached: boolean }) {
+    floatingChromeReady = next.ready;
+    floatingChromeAttached = next.attached;
+  }
+
+  export function setFloatingLayout(next: { surfaceTop: number; topInset: number }) {
+    floatingSurfaceTop = next.surfaceTop;
+    floatingLayoutOriginOffset = next.surfaceTop;
+    currentFloatingTopInset = next.topInset;
+  }
+
   export function setPinned(nextPinned: boolean) {
     (app.preference.current as typeof app.preference.current & { contextBarPinned?: boolean }).contextBarPinned = nextPinned;
   }
 </script>
+
+<svelte:window
+  onpointermove={(event) => {
+    floatingPointer = { x: event.clientX, y: event.clientY };
+  }}
+/>
 
 <svelte:element
   this={withinPane ? 'div' : 'section'}
@@ -119,9 +160,16 @@
   data-pane-id={withinPane ? 'zoom-overlay-test-pane' : undefined}
 >
   <div data-testid="editor-toolbar"></div>
-  <div bind:this={editorViewSurface} style:width={`${currentSurfaceWidth}px`} style="position: relative; height: 120px">
+  <div
+    bind:this={editorViewSurface}
+    style:--editor-floating-zoom-top-inset={`${currentFloatingTopInset}px`}
+    style:top={`${floatingSurfaceTop}px`}
+    style:width={`${currentSurfaceWidth}px`}
+    style="position: relative; height: 120px"
+  >
     {#if mode === 'floating-zoom'}
       <FloatingEditorZoomControls
+        chromeAttachment={floatingRequiresChrome ? floatingChromeAttachment : undefined}
         controls={{
           atMaximum: landmark === 'maximum',
           atMinimum: landmark === 'minimum',
@@ -137,8 +185,10 @@
           toggleTargetLandmark,
         }}
         fixed={floatingFixed}
+        layoutOriginOffset={floatingLayoutOriginOffset}
         revealOnHover={floatingRevealOnHover}
         rightInset={floatingRightInset}
+        topInset={currentFloatingTopInset}
       />
     {/if}
     <button data-testid="context-bar-underlay" type="button">본문</button>
@@ -213,6 +263,8 @@
     {/if}
   </div>
 </svelte:element>
+
+<output data-floating-chrome-request-count>{floatingChromeRequestCount}</output>
 
 {#if mode === 'context-bar' && twoPanes}
   <div bind:this={secondEditorViewSurface} style:width={`${currentSurfaceWidth}px`} style="position: relative; height: 120px">

--- a/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/editor-context-bar.browser.test.ts
@@ -140,11 +140,15 @@ async function mountFloatingOverlay({
   landmark = null,
   fixed = true,
   revealOnHover = false,
+  requiresChrome = false,
   rightInset = 0,
+  topInset = 0,
 }: Partial<Pick<TestProps, 'displayZoom' | 'indicatorZoom' | 'landmark'>> & {
   fixed?: boolean;
   revealOnHover?: boolean;
+  requiresChrome?: boolean;
   rightInset?: number;
+  topInset?: number;
 } = {}) {
   mounted = mount(EditorContextBarTestRoot, {
     target: document.body,
@@ -156,7 +160,9 @@ async function mountFloatingOverlay({
       initialLandmark: landmark,
       floatingFixed: fixed,
       floatingRevealOnHover: revealOnHover,
+      floatingRequiresChrome: requiresChrome,
       floatingRightInset: rightInset,
+      floatingTopInset: topInset,
     },
   });
   await tick();
@@ -804,13 +810,13 @@ describe('public viewer floating zoom controls', () => {
     expect(overlay?.style.opacity).toBe('0');
   });
 
-  it('anchors to the pane surface, shifts for focus-mode exit, and uses a rounded transient surface without an edge fade', async () => {
-    const { anchor, overlay } = await mountFloatingOverlay({ fixed: false, rightInset: 36 });
+  it('anchors below pane chrome, shifts for focus-mode exit, and uses a rounded transient surface without an edge fade', async () => {
+    const { anchor, overlay } = await mountFloatingOverlay({ fixed: false, rightInset: 36, topInset: 78 });
     const blur = document.querySelector<HTMLElement>('[data-floating-editor-zoom-blur]');
     const surface = document.querySelector<HTMLElement>('[data-floating-editor-zoom-surface]');
 
     expect(getComputedStyle(anchor as HTMLElement).position).toBe('absolute');
-    expect(getComputedStyle(anchor as HTMLElement).top).toBe('0px');
+    expect(getComputedStyle(anchor as HTMLElement).top).toBe('78px');
     expect(getComputedStyle(anchor as HTMLElement).right).toBe('36px');
     expect(anchor?.dataset.floatingEditorZoomRightInset).toBe('36');
     expect(getComputedStyle(overlay as HTMLElement).borderRadius).toBe('8px');
@@ -834,6 +840,120 @@ describe('public viewer floating zoom controls', () => {
     enter(overlay as HTMLElement);
     await tick();
     expect(overlay?.style.opacity).toBe('1');
+  });
+
+  it('does not reveal a standalone hidden zoom footprint from unrelated window pointer movement', async () => {
+    const { overlay, pane } = await mountFloatingOverlay({ fixed: false, revealOnHover: true });
+    if (!overlay || !pane) throw new Error('Missing floating zoom fixture');
+    const rect = overlay.getBoundingClientRect();
+
+    move(pane, rect.left + rect.width / 2, rect.top + rect.height / 2);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await tick();
+
+    expect(overlay.style.opacity).toBe('0');
+  });
+
+  it('moves a hidden zoom footprint to the new chrome edge immediately', async () => {
+    const { anchor, overlay, host } = await mountFloatingOverlay({ fixed: false, revealOnHover: true });
+    if (!anchor || !overlay) throw new Error('Missing floating zoom fixture');
+    const initialTop = anchor.getBoundingClientRect().top;
+
+    (host as typeof mounted & { setFloatingLayout(next: { surfaceTop: number; topInset: number }): void }).setFloatingLayout({
+      surfaceTop: 0,
+      topInset: 78,
+    });
+    await tick();
+
+    const rect = anchor.getBoundingClientRect();
+    const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    expect(rect.top).toBeCloseTo(initialTop + 78, 1);
+    expect(overlay.contains(hit)).toBe(true);
+  });
+
+  it('keeps a visible zoom control at its viewport position while the pane layout origin changes', async () => {
+    const { anchor, overlay, host } = await mountFloatingOverlay({ fixed: false, revealOnHover: true });
+    if (!anchor || !overlay) throw new Error('Missing floating zoom fixture');
+    const fixture = host as typeof mounted & {
+      setFloatingLayout(next: { surfaceTop: number; topInset: number }): void;
+      setZoom(displayZoom: number, indicatorZoom: number, landmark: DocumentZoomLandmark | null): void;
+    };
+    fixture.setFloatingLayout({ surfaceTop: 78, topInset: 0 });
+    fixture.setZoom(1.1, 1.1, null);
+    await tick();
+    const initialTop = anchor.getBoundingClientRect().top;
+
+    fixture.setFloatingLayout({ surfaceTop: 0, topInset: 36 });
+    await tick();
+
+    expect(overlay.style.opacity).toBe('1');
+    expect(anchor.getBoundingClientRect().top).toBeCloseTo(initialTop, 1);
+  });
+
+  it('keeps focus-mode zoom unavailable until pane toolbar reveal has finished', async () => {
+    const { overlay, host } = await mountFloatingOverlay({ fixed: false, revealOnHover: true, requiresChrome: true, topInset: 78 });
+
+    expect(overlay?.style.opacity).toBe('0');
+    expect(overlay?.style.pointerEvents).toBe('none');
+    enter(overlay as HTMLElement);
+    await tick();
+    expect(overlay?.style.opacity).toBe('0');
+
+    (host as typeof mounted & { setFloatingChromeReady: (ready: boolean) => void }).setFloatingChromeReady(true);
+    await tick();
+    expect(overlay?.style.pointerEvents).toBe('auto');
+
+    enter(overlay as HTMLElement);
+    await tick();
+    expect(overlay?.style.opacity).toBe('1');
+  });
+
+  it('reveals when the toolbar makes a hidden zoom footprint available under a stationary pointer', async () => {
+    const { overlay, pane, host } = await mountFloatingOverlay({
+      fixed: false,
+      revealOnHover: true,
+      requiresChrome: true,
+      topInset: 78,
+    });
+    if (!overlay || !pane) throw new Error('Missing floating zoom fixture');
+    const rect = overlay.getBoundingClientRect();
+
+    move(pane, rect.left + rect.width / 2, rect.top + rect.height / 2);
+    (host as typeof mounted & { setFloatingChromeReady(ready: boolean): void }).setFloatingChromeReady(true);
+    await tick();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await tick();
+
+    expect(overlay.style.opacity).toBe('1');
+  });
+
+  it('still presents zoom activity independently while focus-mode toolbar is hidden', async () => {
+    const { anchor, overlay, host } = await mountFloatingOverlay({ fixed: false, revealOnHover: true, requiresChrome: true });
+
+    (
+      host as typeof mounted & { setZoom: (displayZoom: number, indicatorZoom: number, landmark: DocumentZoomLandmark | null) => void }
+    ).setZoom(1.1, 1.1, null);
+    await tick();
+
+    expect(overlay?.style.opacity).toBe('1');
+    expect(overlay?.dataset.floatingEditorZoomAttached).toBe('false');
+    expect(getComputedStyle(anchor as HTMLElement).top).toBe('0px');
+  });
+
+  it('hands hover ownership to pane chrome when zoom is attached to header only', async () => {
+    const { overlay, host } = await mountFloatingOverlay({ fixed: false, revealOnHover: true, requiresChrome: true });
+    const fixture = host as typeof mounted & {
+      setFloatingChromeState(next: { ready: boolean; attached: boolean }): void;
+      setZoom(displayZoom: number, indicatorZoom: number, landmark: DocumentZoomLandmark | null): void;
+    };
+    fixture.setFloatingChromeState({ ready: false, attached: true });
+    fixture.setZoom(1.1, 1.1, null);
+    await tick();
+
+    enter(overlay as HTMLElement);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-floating-chrome-request-count]')?.value).toBe('1');
   });
 
   it('remains keyboard discoverable and reveals before a hidden control receives interaction', async () => {

--- a/apps/website/src/lib/editor-ffi/components/ui/floating-overlay-position.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/components/ui/floating-overlay-position.svelte.ts
@@ -1,0 +1,54 @@
+import { prefersReducedMotion } from '@typie/ui/state';
+import { untrack } from 'svelte';
+
+type FloatingOverlayPositionOptions = {
+  element: () => HTMLElement | undefined;
+  layoutTop: () => number | undefined;
+  presented: () => boolean;
+};
+
+const motionDuration = (node: HTMLElement): number => {
+  const value = getComputedStyle(node).getPropertyValue('--editor-pane-overlay-motion-duration').trim() || '280ms';
+  if (value.endsWith('ms')) return Number.parseFloat(value);
+  if (value.endsWith('s')) return Number.parseFloat(value) * 1000;
+  return Number.parseFloat(value);
+};
+
+export const setupFloatingOverlayPosition = ({ element, layoutTop, presented }: FloatingOverlayPositionOptions): void => {
+  let animation: Animation | undefined;
+  let previousLayoutTop: number | undefined;
+
+  $effect(() => {
+    const node = element();
+    const nextLayoutTop = layoutTop();
+    if (!node || nextLayoutTop === undefined) return;
+
+    const previous = previousLayoutTop;
+    previousLayoutTop = nextLayoutTop;
+    if (previous === undefined) return;
+
+    const visualTop = node.getBoundingClientRect().top;
+    animation?.cancel();
+    animation = undefined;
+    const targetTop = node.getBoundingClientRect().top;
+    const offset = visualTop - targetTop + previous - nextLayoutTop;
+    if (!untrack(() => presented() && !prefersReducedMotion.current) || Math.abs(offset) < 0.5) return;
+
+    const styles = getComputedStyle(node);
+    const next = node.animate([{ transform: `translateY(${offset}px)` }, { transform: 'translateY(0)' }], {
+      duration: motionDuration(node),
+      easing: styles.getPropertyValue('--editor-pane-overlay-motion-easing').trim() || 'cubic-bezier(0.22, 1, 0.36, 1)',
+      fill: 'both',
+    });
+    animation = next;
+    next.finished
+      .catch(() => null)
+      .then(() => {
+        if (animation !== next) return;
+        animation = undefined;
+        next.cancel();
+      });
+  });
+
+  $effect(() => () => animation?.cancel());
+};

--- a/apps/website/src/lib/editor-ffi/scroll.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/scroll.svelte.ts
@@ -497,6 +497,10 @@ export class EditorScrollScope {
     this.#viewportAnchor.acceptGeometry(geometry, { left: metrics.scrollLeft, top: target });
   }
 
+  translateViewportAnchorAttachment(deltaY: number): void {
+    this.#viewportAnchor.translateAttachmentY(deltaY);
+  }
+
   resolveScrollTop(
     request: Pick<EditorBringIntoViewRequest, 'target' | 'policy'>,
     metrics: ScrollContainerMetrics & RevealTargetSpan,

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.test.ts
@@ -73,6 +73,19 @@ describe('EditorViewportAnchorState', () => {
     });
   });
 
+  it('translates the attachment when the scroll content origin moves inside the viewport', () => {
+    const state = new EditorViewportAnchorState();
+    state.attach(viewportIdentity, { pointX: 0, pointY: 200 }, { left: 0, top: 100 });
+
+    state.translateAttachmentY(78);
+
+    expect(state.pointAttachmentY).toBe(178);
+    expect(state.publicationScroll({ pointX: 0, pointY: 278 }, { left: 0, top: 100 }, { left: 0, top: 500 })).toEqual({
+      scroll: { left: 0, top: 100 },
+      attachmentAchieved: true,
+    });
+  });
+
   it('retains a directly scrolled anchor inside the cursor guard and rejects it outside', () => {
     const state = new EditorViewportAnchorState();
     const geometry = { pointX: 0, pointY: 200, rect: { top: 190, bottom: 210 } };

--- a/apps/website/src/lib/editor-ffi/viewport-anchor.ts
+++ b/apps/website/src/lib/editor-ffi/viewport-anchor.ts
@@ -90,6 +90,11 @@ export class EditorViewportAnchorState {
     return this.#preferredSelection;
   }
 
+  translateAttachmentY(deltaY: number): void {
+    if (deltaY === 0 || !Number.isFinite(deltaY) || !this.#active) return;
+    this.#active = { ...this.#active, pointAttachmentY: this.#active.pointAttachmentY + deltaY };
+  }
+
   get pendingViewportAttachment(): { identity: ViewportAnchor; focalX: number; focalY: number } | null {
     const attachment = this.viewportAttachment;
     return this.#active?.attachmentPending ? attachment : null;

--- a/apps/website/src/routes/website/(dashboard)/+layout.svelte
+++ b/apps/website/src/routes/website/(dashboard)/+layout.svelte
@@ -62,6 +62,7 @@
   import TrialExpiredModal from './TrialExpiredModal.svelte';
   import { USER_SURVEY_SNOOZE_KEY } from './user-survey';
   import UserSurveyModal from './UserSurveyModal.svelte';
+  import { setupZenMode } from './zen-mode.svelte';
   import type { IntroKind } from './intro';
 
   let { data, children } = $props();
@@ -290,8 +291,26 @@
     },
   });
 
-  setupEditorRegistry();
+  const editorRegistry = setupEditorRegistry();
+  let workbenchFocusTarget = $state<HTMLElement>();
+  const zenMode = setupZenMode({
+    app,
+    paneGroup,
+    editorRegistry,
+    focusWorkbench: () => workbenchFocusTarget?.focus({ preventScroll: true }),
+  });
   setupOpenDocuments();
+
+  onMount(() => {
+    void zenMode.restoreAfterReload();
+  });
+
+  $effect(() => {
+    void paneGroup.currentSiteId;
+    void paneGroup.state.current.panelExpandedByPaneId;
+    void paneGroup.panes.map((pane) => pane.id).join(':');
+    untrack(() => zenMode.syncPanePanels());
+  });
 
   $effect(() => {
     if (!app.preference.current.currentSiteId) {
@@ -645,6 +664,7 @@
         })}
       >
         <div
+          bind:this={workbenchFocusTarget}
           class={cx(
             'main-container',
             flex({
@@ -653,6 +673,7 @@
               overflow: 'auto',
             }),
           )}
+          tabindex="-1"
         >
           {@render children()}
         </div>

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanel.svelte
@@ -631,7 +631,7 @@
   const calloutTextClass = css({ flexGrow: '1', minWidth: '0', fontSize: '12px', lineHeight: '[1.5]', color: 'text.subtle' });
 
   const panelOpen = $derived(app.preference.current.prismPanelOpen);
-  const panelInteractive = $derived(panelOpen && !app.preference.current.zenModeEnabled);
+  const panelInteractive = $derived(panelOpen);
   const welcomeAdmission = $derived(panelInteractive && !listOpen && page.state.shallowRoute == null);
   let visibilityState = $state<DocumentVisibilityState>('hidden');
   const viewingSessionId = $derived(

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelFailure.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelFailure.svelte
@@ -14,7 +14,7 @@
   let { onRetry }: Props = $props();
 
   const app = getAppContext();
-  const panelInteractive = $derived(app.preference.current.prismPanelOpen && !app.preference.current.zenModeEnabled);
+  const panelInteractive = $derived(app.preference.current.prismPanelOpen);
   const titleId = 'prism-panel-failure-title';
   const messageId = 'prism-panel-failure-message';
   let retryButton = $state<HTMLElement>();

--- a/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelShell.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/PrismPanelShell.svelte
@@ -24,7 +24,7 @@
   const PANEL_HIDDEN_SCALE = 0.96;
   const PANEL_HIDDEN_SCRIM_OPACITY = 0.9;
   const panelOpen = $derived(app.preference.current.prismPanelOpen);
-  const panelInteractive = $derived(panelOpen && !app.preference.current.zenModeEnabled);
+  const panelInteractive = $derived(panelOpen);
   const panelMotionDuration = reducedMotion() ? 0 : PRISM_VISIBILITY_MOTION.duration;
   let panel = $state<HTMLElement>();
   let previewWidth = $state<number | null>(null);
@@ -44,16 +44,14 @@
   });
 </script>
 
-{#if !app.preference.current.zenModeEnabled}
-  <div
-    style:width={panelOpen ? `${width}px` : '0px'}
-    style:transition-duration={previewWidth === null ? `${panelMotionDuration}ms` : '0ms'}
-    style:transition-timing-function={PRISM_VISIBILITY_MOTION.easing}
-    class={css({ flexShrink: '0', height: 'full', transitionProperty: '[width]' })}
-    aria-hidden="true"
-    data-prism-panel-spacer
-  ></div>
-{/if}
+<div
+  style:width={panelOpen ? `${width}px` : '0px'}
+  style:transition-duration={previewWidth === null ? `${panelMotionDuration}ms` : '0ms'}
+  style:transition-timing-function={PRISM_VISIBILITY_MOTION.easing}
+  class={css({ flexShrink: '0', height: 'full', transitionProperty: '[width]' })}
+  aria-hidden="true"
+  data-prism-panel-spacer
+></div>
 
 <div
   style:width={`${width}px`}
@@ -72,6 +70,7 @@
     zIndex: 'panel',
   })}
   data-prism-panel-shell
+  data-zen-mode-closing-surface
 >
   <aside
     bind:this={panel}

--- a/apps/website/src/routes/website/(dashboard)/CommandPalette.svelte
+++ b/apps/website/src/routes/website/(dashboard)/CommandPalette.svelte
@@ -26,6 +26,7 @@
   import { graphql } from '$mearie';
   import EntityIcon from './@context-menu/EntityIcon.svelte';
   import { SubscribeModal } from './@subscription/subscribe-modal.svelte';
+  import { getZenMode } from './zen-mode.svelte';
   import type { Component } from 'svelte';
   import type { DashboardLayout_CommandPalette_user$key } from '$mearie';
 
@@ -59,6 +60,7 @@
   );
 
   const app = getAppContext();
+  const zenMode = getZenMode();
   const currentSiteId = $derived((user.data.sites.find((s) => s.id === app.preference.current.currentSiteId) ?? user.data.sites[0]).id);
 
   let debouncedQuery = $state('');
@@ -216,14 +218,7 @@
       name: app.preference.current.zenModeEnabled ? '집중 모드 끄기' : '집중 모드 켜기',
       aliases: ['zen mode'],
       icon: Maximize2Icon,
-      action: () => {
-        app.preference.current.zenModeEnabled = !app.preference.current.zenModeEnabled;
-        if (app.preference.current.zenModeEnabled) {
-          mixpanel.track('zen_mode_enabled', { via: 'command_palette' });
-        } else {
-          mixpanel.track('zen_mode_disabled', { via: 'command_palette' });
-        }
-      },
+      action: () => zenMode.toggle('command_palette'),
     },
     {
       name: prismDraft ? 'PRISM과 새 대화' : app.preference.current.prismPanelOpen ? 'PRISM 닫기' : 'PRISM 열기',

--- a/apps/website/src/routes/website/(dashboard)/Shortcuts.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Shortcuts.svelte
@@ -5,6 +5,7 @@
   import mixpanel from 'mixpanel-browser';
   import { IS_MAC } from '$lib/editor-ffi/constants';
   import { graphql } from '$mearie';
+  import { getZenMode } from './zen-mode.svelte';
   import type { DashboardLayout_Shortcuts_query$key } from '$mearie';
 
   type Props = {
@@ -14,6 +15,7 @@
   let { query$key }: Props = $props();
 
   const app = getAppContext();
+  const zenMode = getZenMode();
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const query = createFragment(
@@ -27,7 +29,7 @@
     () => query$key,
   );
 
-  const handleKeydown = async (event: KeyboardEvent) => {
+  const handleKeydown = (event: KeyboardEvent) => {
     if ((IS_MAC ? event.metaKey : event.ctrlKey) && !event.shiftKey && event.code === 'KeyE') {
       event.preventDefault();
       const next = !app.preference.current.prismPanelOpen;
@@ -37,17 +39,9 @@
     }
 
     if ((IS_MAC ? event.metaKey : event.ctrlKey) && event.shiftKey && event.code === 'KeyM') {
-      if (!app.state.current) return;
-
       event.preventDefault();
 
-      app.preference.current.zenModeEnabled = !app.preference.current.zenModeEnabled;
-
-      if (app.preference.current.zenModeEnabled) {
-        mixpanel.track('zen_mode_enabled', { via: 'shortcut' });
-      } else {
-        mixpanel.track('zen_mode_disabled', { via: 'shortcut' });
-      }
+      void zenMode.toggle('shortcut');
 
       return;
     }
@@ -64,8 +58,7 @@
       if (app.preference.current.zenModeEnabled) {
         event.preventDefault();
 
-        app.preference.current.zenModeEnabled = false;
-        mixpanel.track('zen_mode_disabled', { via: 'esc' });
+        void zenMode.exit('esc');
 
         return;
       }

--- a/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
+++ b/apps/website/src/routes/website/(dashboard)/Sidebar.svelte
@@ -460,6 +460,7 @@
     transitionProperty: '[transform]',
   })}
   aria-label="사이드바"
+  data-zen-mode-closing-surface
   onmouseenter={handleMouseEnter}
   onmouseleave={handleMouseLeave}
   role="navigation"
@@ -812,7 +813,7 @@
       position: 'absolute',
       top: '0',
       right: '-6px',
-      zIndex: app.preference.current.zenModeEnabled ? 'underEditor' : 'sidebar',
+      zIndex: 'sidebar',
       width: '12px',
       height: 'full',
       cursor: 'col-resize',

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/EntityPane.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/EntityPane.svelte
@@ -8,17 +8,20 @@
   import { onDestroy } from 'svelte';
   import { fade } from 'svelte/transition';
   import FileXIcon from '~icons/lucide/file-x';
-  import XIcon from '~icons/lucide/x';
   import { fb } from '$lib/analytics';
   import { getOpenDocuments } from '$lib/prism/open-documents.svelte';
   import { graphql } from '$mearie';
   import { resolveActiveTreeAncestorIds } from '../../@tree/entity-reveal.svelte';
+  import { getZenMode } from '../../zen-mode.svelte';
   import DocumentV2 from '../v2/Document.svelte';
-  import CloseButton from './CloseButton.svelte';
   import { getPaneGroup, setupPane } from './context.svelte';
+  import { setupPaneOverlayLayout } from './pane-overlay-layout.svelte';
   import PaneHeader from './PaneHeader.svelte';
+  import PaneHeaderControls from './PaneHeaderControls.svelte';
   import PaneSkeleton from './PaneSkeleton.svelte';
+  import PaneSplitMenu from './PaneSplitMenu.svelte';
   import TabIcon from './TabIcon.svelte';
+  import { setupZenModePaneChrome } from './zen-mode-pane-chrome.svelte';
   import type { Pane, PaneHeaderPlacement } from './types';
 
   type EntityPane = Extract<Pane, { kind: 'entity' }>;
@@ -166,15 +169,29 @@
   );
 
   setupPane(pane);
+  const zenMode = getZenMode();
+  const paneChrome = setupZenModePaneChrome({
+    active: () => zenMode.active,
+    focused: () => focused,
+  });
+  const overlayLayout = setupPaneOverlayLayout({ active: () => zenMode.active, chrome: paneChrome });
+  const registerPaneChromeRoot = paneChrome.registerRoot;
 </script>
 
 <div
+  style:--editor-pane-header-inset={`${overlayLayout.headerInset}px`}
+  style:--editor-pane-overlay-motion-duration={`${overlayLayout.motionDuration}ms`}
+  style:--editor-pane-overlay-motion-easing="cubic-bezier(0.22, 1, 0.36, 1)"
+  style:--editor-pane-overlay-position-transition={overlayLayout.positionTransition}
+  style:--editor-pane-overlay-top-inset={`${overlayLayout.topInset}px`}
+  style:--editor-floating-zoom-top-inset={`${overlayLayout.topInset}px`}
   class={flex({
     position: 'relative',
     size: 'full',
     backgroundColor: 'surface.default',
     overflow: 'hidden',
   })}
+  data-pane-chrome-phase={zenMode.active ? paneChrome.phase : undefined}
   data-pane-id={pane.id}
   onclick={() => {
     paneGroup.focusPane(pane.id);
@@ -187,8 +204,11 @@
       paneGroup.focusPane(pane.id);
     }
   }}
+  onpointerleave={() => paneChrome.handlePointerLeave()}
+  onpointermove={(event) => paneChrome.handlePointerMove(event)}
   role="tabpanel"
   tabindex={0}
+  use:registerPaneChromeRoot
 >
   {#if query.data && entity}
     {#if entity?.state === EntityState.ACTIVE}
@@ -217,11 +237,9 @@
 
         <PaneHeader placement={headerPlacement}>
           {#snippet fixedActions()}
-            {#if !app.preference.current.zenModeEnabled}
-              <CloseButton>
-                <Icon icon={XIcon} size={16} />
-              </CloseButton>
-            {/if}
+            <PaneHeaderControls>
+              {#snippet menu()}<PaneSplitMenu />{/snippet}
+            </PaneHeaderControls>
           {/snippet}
 
           <div class={flex({ alignItems: 'center', gap: '4px', paddingLeft: '8px', fontSize: '12px', color: 'text.subtle' })}>
@@ -250,16 +268,23 @@
     <div
       class={css({
         position: 'absolute',
-        top: documentHeaderVisible ? '37px' : '0',
+        top: documentHeaderVisible && !app.preference.current.zenModeEnabled ? '37px' : '0',
         right: '0',
         bottom: '0',
         left: '0',
-        zIndex: 'overEditor',
+        zIndex: 'editorOverlay',
         backgroundColor: 'surface.default',
       })}
       out:fade={{ duration: 150 }}
     >
-      <PaneSkeleton {documentId} {documentLayoutMode} {headerPlacement} {pane} showHeader={!documentHeaderVisible} />
+      <PaneSkeleton
+        contentInsetTop={overlayLayout.contentTopInset}
+        {documentId}
+        {documentLayoutMode}
+        {headerPlacement}
+        {pane}
+        showHeader={!documentHeaderVisible}
+      />
     </div>
   {/if}
 </div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/HomePane.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/HomePane.svelte
@@ -15,7 +15,6 @@
   import FileIcon from '~icons/lucide/file';
   import FilePenIcon from '~icons/lucide/file-pen';
   import LayoutTemplateIcon from '~icons/lucide/layout-template';
-  import XIcon from '~icons/lucide/x';
   import { goto } from '$app/navigation';
   import Logo from '$assets/logos/logo.svg?component';
   import EditorBreadcrumb from '$lib/editor-ffi/components/ui/EditorBreadcrumb.svelte';
@@ -25,12 +24,15 @@
   import { SubscribeModal } from '../../@subscription/subscribe-modal.svelte';
   import TrialBanner from '../../@subscription/TrialBanner.svelte';
   import { getDayClock } from '../../day-clock.svelte';
+  import { getZenMode } from '../../zen-mode.svelte';
   import EditorBreadcrumbNavigation from '../v2/@breadcrumb/EditorBreadcrumbNavigation.svelte';
-  import CloseButton from './CloseButton.svelte';
   import { getPaneGroup, setupPane } from './context.svelte';
   import PaneHeader from './PaneHeader.svelte';
+  import PaneHeaderControls from './PaneHeaderControls.svelte';
   import PaneSkeleton from './PaneSkeleton.svelte';
+  import PaneSplitMenu from './PaneSplitMenu.svelte';
   import TabIcon from './TabIcon.svelte';
+  import { setupZenModePaneChrome } from './zen-mode-pane-chrome.svelte';
   import type { Pane, PaneHeaderPlacement } from './types';
 
   type HomePane = Extract<Pane, { kind: 'home' }>;
@@ -214,6 +216,13 @@
   };
 
   setupPane(pane);
+  const zenMode = getZenMode();
+  const paneChrome = setupZenModePaneChrome({
+    active: () => zenMode.active,
+    focused: () => focused,
+  });
+  const registerPaneChromeRoot = paneChrome.registerRoot;
+  const breadcrumbHoldHandle = paneChrome.segmentHandle('identity');
 </script>
 
 <div
@@ -236,16 +245,17 @@
       paneGroup.focusPane(pane.id);
     }
   }}
+  onpointerleave={() => paneChrome.handlePointerLeave()}
+  onpointermove={(event) => paneChrome.handlePointerMove(event)}
   role="tabpanel"
   tabindex={0}
+  use:registerPaneChromeRoot
 >
   <PaneHeader placement={headerPlacement}>
     {#snippet fixedActions()}
-      {#if paneGroup.enabled && !app.preference.current.zenModeEnabled}
-        <CloseButton>
-          <Icon icon={XIcon} size={16} />
-        </CloseButton>
-      {/if}
+      <PaneHeaderControls close={paneGroup.enabled}>
+        {#snippet menu()}<PaneSplitMenu />{/snippet}
+      </PaneHeaderControls>
     {/snippet}
 
     <EditorBreadcrumb pathIdentity="home" viewportId={breadcrumbViewportId}>
@@ -257,6 +267,7 @@
           if (target.kind === 'entity') paneGroup.replacePane(pane.id, { kind: 'entity', slug: target.slug });
         }}
         popupId={`${breadcrumbViewportId}-tree`}
+        segment={breadcrumbHoldHandle}
         siteId={paneGroup.currentSiteId}
       />
     </EditorBreadcrumb>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneHeader.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneHeader.svelte
@@ -2,7 +2,7 @@
   import { css } from '@typie/styled-system/css';
   import { center, flex } from '@typie/styled-system/patterns';
   import { tooltip } from '@typie/ui/actions';
-  import { HorizontalDivider, Icon } from '@typie/ui/components';
+  import { Icon } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
   import mixpanel from 'mixpanel-browser';
   import PanelLeftIcon from '~icons/lucide/panel-left';
@@ -11,6 +11,9 @@
   import PrismBadgeDot from '../../@prism/PrismBadgeDot.svelte';
   import { getPane, getPaneGroup } from './context.svelte';
   import { dragPane } from './dnd';
+  import { getZenModePaneChrome, PANE_CHROME_EXPANSION_EASING, paneChromeExpansionTiming } from './zen-mode-pane-chrome.svelte';
+  import ZenModePaneChromeEffects from './ZenModePaneChromeEffects.svelte';
+  import ZenModePaneChromeSegment from './ZenModePaneChromeSegment.svelte';
   import type { Snippet } from 'svelte';
   import type { PaneHeaderPlacement } from './types';
 
@@ -26,10 +29,11 @@
   const app = getAppContext();
   const pane = getPane();
   const paneGroup = getPaneGroup();
+  const paneChrome = getZenModePaneChrome();
   const dragPaneProps = $derived({ paneGroup, paneId: pane.id });
   const prismPanelOpen = $derived(app.preference.current.prismPanelOpen);
   const sidebarHidden = $derived(app.preference.current.sidebarHidden);
-  const globalControlsVisible = $derived(!app.preference.current.zenModeEnabled);
+  const zenModeEnabled = $derived(app.preference.current.zenModeEnabled);
   const scrollableActionsViewportId = `pane-header-actions-${pane.id}`;
 
   const prismButton = css.raw({
@@ -47,113 +51,208 @@
 
   $effect(() => {
     if (!placement.topLeft) return;
-    if (!globalControlsVisible) {
-      app.state.sidebarPeek = false;
-      return;
-    }
-
     return () => {
       app.state.sidebarPeek = false;
     };
   });
+
+  const expansionTiming = $derived(paneChromeExpansionTiming(paneChrome.phase === 'expanding' ? paneChrome.expansionPace : 'standard'));
+  const registerHeaderLane = paneChrome.registerHeaderLane;
+  const registerIdentity = (node: HTMLElement) => paneChrome.registerSegment('identity', node);
+  const registerActions = (node: HTMLElement) => paneChrome.registerSegment('actions', node);
 </script>
 
 <div
+  style:pointer-events={zenModeEnabled ? 'none' : 'auto'}
   class={flex({
-    alignItems: 'center',
-    gap: '4px',
+    position: zenModeEnabled ? 'absolute' : 'relative',
+    top: zenModeEnabled ? '0' : undefined,
+    left: zenModeEnabled ? '0' : undefined,
+    right: zenModeEnabled ? '0' : undefined,
+    zIndex: zenModeEnabled ? 'overEditor' : undefined,
+    flexDirection: 'column',
     minWidth: '0',
     flexShrink: '0',
-    height: '36px',
-    paddingLeft: globalControlsVisible && placement.topLeft ? '8px' : '4px',
-    paddingRight: '8px',
-    backgroundColor: 'surface.default',
-    borderRadius: '4px',
+    height: '37px',
+    backgroundColor: zenModeEnabled ? 'transparent' : 'surface.default',
     userSelect: 'none',
   })}
+  data-pane-header-adjacent-to-prism={placement.topRight}
+  data-zen-mode-pane-chrome
+  data-zen-pane-chrome-surface-visible={zenModeEnabled && paneChrome.isLaneSurfaceVisible('header')}
   role="region"
   use:dragPane={dragPaneProps}
+  use:registerHeaderLane
 >
-  {#if globalControlsVisible && placement.topLeft}
-    <button
-      class={center({
-        size: '24px',
-        flexShrink: '0',
-        borderRadius: '6px',
-        color: 'text.faint',
-        transition: 'common',
-        _hover: { color: 'text.subtle', backgroundColor: 'surface.muted' },
+  {#if zenModeEnabled}
+    <ZenModePaneChromeEffects lane="header" />
+
+    <div
+      style:--zen-pane-chrome-foreground-radius={`${paneChrome.foregroundRevealRadius('header')}px`}
+      style:clip-path={paneChrome.headerLaneInteractionClip()}
+      style:pointer-events={paneChrome.isHeaderLaneInteractive() ? 'auto' : 'none'}
+      style:transition={`clip-path ${expansionTiming.backgroundExpandMs}ms ${PANE_CHROME_EXPANSION_EASING}, --zen-pane-chrome-foreground-radius ${expansionTiming.backgroundExpandMs}ms ${PANE_CHROME_EXPANSION_EASING}`}
+      class={css({
+        position: 'absolute',
+        top: '0',
+        right: '0',
+        left: '0',
+        height: '36px',
+        cursor: 'grab',
+        _motionReduce: { transitionDuration: '0ms' },
       })}
-      onclick={() => {
-        app.state.sidebarPeek = false;
-        app.preference.current.sidebarHidden = !sidebarHidden;
-        mixpanel.track('toggle_sidebar_auto_hide', { enabled: app.preference.current.sidebarHidden });
-      }}
-      onmouseenter={() => (app.state.sidebarPeek = true)}
-      onmouseleave={() => (app.state.sidebarPeek = false)}
-      type="button"
-      use:tooltip={{ message: sidebarHidden ? '사이드바 고정' : '사이드바 자동 숨김' }}
-    >
-      <Icon icon={PanelLeftIcon} size={14} />
-    </button>
+      aria-hidden="true"
+      data-zen-pane-chrome-header-foreground-hit
+    ></div>
   {/if}
 
-  <div class={flex({ alignItems: 'center', flexBasis: '0', flexGrow: '1', minWidth: '0', height: 'full', overflowX: 'hidden' })}>
-    {@render children()}
+  <div class={flex({ alignItems: 'center', width: 'full', height: '36px', flexShrink: '0' })}>
+    <div
+      class={zenModeEnabled
+        ? flex({
+            alignItems: 'center',
+            flexBasis: '0',
+            flexGrow: '1',
+            flexShrink: '1',
+            minWidth: placement.topLeft ? '[40px]' : '8px',
+            height: 'full',
+          })
+        : css({ display: 'contents' })}
+      data-pane-header-leading-lane
+    >
+      <ZenModePaneChromeSegment
+        class={flex({
+          position: 'relative',
+          alignItems: 'center',
+          gap: '4px',
+          flexBasis: zenModeEnabled ? undefined : '0',
+          flexGrow: zenModeEnabled ? undefined : '1',
+          flexShrink: '1',
+          minWidth: placement.topLeft ? '[32px]' : '0',
+          height: 'full',
+          paddingLeft: placement.topLeft ? '8px' : '4px',
+        })}
+        active={zenModeEnabled}
+        aria-label="문서 위치"
+        contentCursor="grab"
+        register={registerIdentity}
+        segment="identity"
+      >
+        <div class={css({ position: 'relative', display: 'contents' })}>
+          {#if placement.topLeft}
+            <button
+              class={center({
+                size: '24px',
+                flexShrink: '0',
+                borderRadius: '6px',
+                color: 'text.faint',
+                transition: 'common',
+                _hover: { color: 'text.subtle', backgroundColor: 'surface.muted' },
+              })}
+              onclick={() => {
+                app.state.sidebarPeek = false;
+                app.preference.current.sidebarHidden = !sidebarHidden;
+                mixpanel.track('toggle_sidebar_auto_hide', { enabled: app.preference.current.sidebarHidden });
+              }}
+              onmouseenter={() => (app.state.sidebarPeek = true)}
+              onmouseleave={() => (app.state.sidebarPeek = false)}
+              type="button"
+              use:tooltip={{ message: sidebarHidden ? '사이드바 고정' : '사이드바 자동 숨김' }}
+            >
+              <Icon icon={PanelLeftIcon} size={14} />
+            </button>
+          {/if}
+
+          <div class={flex({ alignItems: 'center', minWidth: '0', height: 'full', overflowX: 'hidden' })}>
+            {@render children()}
+          </div>
+        </div>
+      </ZenModePaneChromeSegment>
+
+      <div
+        style:cursor={zenModeEnabled && paneChrome.isHeaderGapInteractive() ? 'grab' : undefined}
+        style:pointer-events={zenModeEnabled ? (paneChrome.isHeaderGapInteractive() ? 'auto' : 'none') : undefined}
+        class={css({ flexGrow: zenModeEnabled ? '1' : undefined, minWidth: zenModeEnabled ? '8px' : '0' })}
+      ></div>
+    </div>
+
+    <ZenModePaneChromeSegment
+      class={flex({
+        position: 'relative',
+        alignItems: 'center',
+        gap: '4px',
+        flexShrink: '1',
+        minWidth: '0',
+        height: 'full',
+        overflowX: 'hidden',
+        paddingRight: '8px',
+      })}
+      active={zenModeEnabled}
+      aria-label="pane 도구"
+      contentCursor="grab"
+      register={registerActions}
+      segment="actions"
+    >
+      <div class={flex({ position: 'relative', alignItems: 'center', gap: '4px', minWidth: '0', height: 'full' })}>
+        {#if scrollableActions}
+          <HorizontalScrollLane
+            alignment="start"
+            contentIdentity={pane.id}
+            label="문서 헤더 도구 가로 스크롤"
+            viewportId={scrollableActionsViewportId}
+            viewportName="pane-header-actions"
+          >
+            <div class={flex({ alignItems: 'center', gap: '4px', minWidth: '[max-content]' })}>
+              {@render scrollableActions()}
+            </div>
+          </HorizontalScrollLane>
+        {/if}
+
+        {#if fixedActions}
+          <div class={flex({ alignItems: 'center', gap: '4px', flexShrink: '0' })}>
+            {@render fixedActions()}
+          </div>
+        {/if}
+
+        {#if placement.topRight}
+          <button
+            class={css(prismButton, prismPanelOpen ? { backgroundColor: 'surface.muted' } : {})}
+            aria-label={app.state.prismBadge ? 'PRISM 열기/닫기, 확인할 항목 있음' : 'PRISM 열기/닫기'}
+            aria-pressed={prismPanelOpen}
+            onclick={() => {
+              const next = !prismPanelOpen;
+              app.preference.current.prismPanelOpen = next;
+              mixpanel.track(next ? 'open_prism_panel' : 'close_prism_panel', { via: 'header' });
+            }}
+            type="button"
+            use:tooltip={{ message: prismPanelOpen ? 'PRISM 닫기' : 'PRISM 열기', keys: ['Mod', 'E'] }}
+          >
+            <span class={css({ position: 'relative', display: 'flex', flexShrink: '0' })}>
+              <Icon style={css.raw({ color: prismPanelOpen ? 'text.default' : 'text.faint' })} icon={PrismIcon} size={14} />
+              {#if app.state.prismBadge}
+                <PrismBadgeDot />
+              {/if}
+            </span>
+            <span
+              class={css({
+                fontSize: '12px',
+                fontWeight: 'semibold',
+                letterSpacing: '[0.04em]',
+                lineHeight: '[1]',
+                color: prismPanelOpen ? 'text.default' : 'text.muted',
+              })}
+            >
+              PRISM
+            </span>
+          </button>
+        {/if}
+      </div>
+    </ZenModePaneChromeSegment>
   </div>
 
-  {#if scrollableActions}
-    <HorizontalScrollLane
-      alignment="start"
-      contentIdentity={pane.id}
-      label="문서 헤더 도구 가로 스크롤"
-      viewportId={scrollableActionsViewportId}
-      viewportName="pane-header-actions"
-    >
-      <div class={flex({ alignItems: 'center', gap: '4px', minWidth: '[max-content]' })}>
-        {@render scrollableActions()}
-      </div>
-    </HorizontalScrollLane>
-  {/if}
-
-  {#if fixedActions}
-    <div class={flex({ alignItems: 'center', gap: '4px', flexShrink: '0' })}>
-      {@render fixedActions()}
-    </div>
-  {/if}
-
-  {#if globalControlsVisible && placement.topRight}
-    <button
-      class={css(prismButton, prismPanelOpen ? { backgroundColor: 'surface.muted' } : {})}
-      aria-label={app.state.prismBadge ? 'PRISM 열기/닫기, 확인할 항목 있음' : 'PRISM 열기/닫기'}
-      aria-pressed={prismPanelOpen}
-      onclick={() => {
-        const next = !prismPanelOpen;
-        app.preference.current.prismPanelOpen = next;
-        mixpanel.track(next ? 'open_prism_panel' : 'close_prism_panel', { via: 'header' });
-      }}
-      type="button"
-      use:tooltip={{ message: prismPanelOpen ? 'PRISM 닫기' : 'PRISM 열기', keys: ['Mod', 'E'] }}
-    >
-      <span class={css({ position: 'relative', display: 'flex', flexShrink: '0' })}>
-        <Icon style={css.raw({ color: prismPanelOpen ? 'text.default' : 'text.faint' })} icon={PrismIcon} size={14} />
-        {#if app.state.prismBadge}
-          <PrismBadgeDot />
-        {/if}
-      </span>
-      <span
-        class={css({
-          fontSize: '12px',
-          fontWeight: 'semibold',
-          letterSpacing: '[0.04em]',
-          lineHeight: '[1]',
-          color: prismPanelOpen ? 'text.default' : 'text.muted',
-        })}
-      >
-        PRISM
-      </span>
-    </button>
-  {/if}
+  <div
+    class={css({ width: 'full', height: '1px', flexShrink: '0', backgroundColor: zenModeEnabled ? 'transparent' : 'surface.muted' })}
+    aria-hidden="true"
+    data-pane-header-boundary
+  ></div>
 </div>
-
-<HorizontalDivider color="secondary" />

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneHeaderControls.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneHeaderControls.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { center } from '@typie/styled-system/patterns';
+  import { tooltip } from '@typie/ui/actions';
+  import { Icon, VerticalDivider } from '@typie/ui/components';
+  import Maximize2Icon from '~icons/lucide/maximize-2';
+  import Minimize2Icon from '~icons/lucide/minimize-2';
+  import XIcon from '~icons/lucide/x';
+  import { getZenMode } from '../../zen-mode.svelte';
+  import CloseButton from './CloseButton.svelte';
+  import { getZenModePaneChrome } from './zen-mode-pane-chrome.svelte';
+  import type { Snippet } from 'svelte';
+
+  type Props = { menu?: Snippet; close?: boolean };
+  let { menu, close = true }: Props = $props();
+
+  const zenMode = getZenMode();
+  const paneChrome = getZenModePaneChrome();
+  const shortcut = $derived(zenMode.active ? (['Esc'] as ['Esc']) : (['Mod', 'Shift', 'M'] as ['Mod', 'Shift', 'M']));
+</script>
+
+<VerticalDivider style={css.raw({ height: '12px' })} />
+
+{#if menu}
+  {@render menu()}
+{/if}
+
+<button
+  class={center({
+    borderRadius: '4px',
+    size: '24px',
+    color: 'text.faint',
+    transition: 'common',
+    _hover: { color: 'text.subtle', backgroundColor: 'surface.muted' },
+  })}
+  aria-label={zenMode.active ? '집중 모드 끄기' : '집중 모드 켜기'}
+  aria-pressed={zenMode.active}
+  data-editor-focus-mode-control
+  onclick={(event) => {
+    paneChrome.prepareEntryReveal('actions', event);
+    void zenMode.toggle('pane_header');
+  }}
+  onpointerdown={(event) => event.preventDefault()}
+  type="button"
+  use:tooltip={{ message: zenMode.active ? '집중 모드 끄기' : '집중 모드 켜기', keys: shortcut }}
+>
+  <Icon icon={zenMode.active ? Minimize2Icon : Maximize2Icon} size={16} />
+</button>
+
+{#if close}
+  <CloseButton>
+    <Icon icon={XIcon} size={16} />
+  </CloseButton>
+{/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneSkeleton.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneSkeleton.svelte
@@ -24,9 +24,10 @@
     documentLayoutMode?: DocumentLayoutMode | null;
     documentId?: string | null;
     showHeader?: boolean;
+    contentInsetTop?: number;
   };
 
-  let { pane, headerPlacement, documentLayoutMode = null, documentId = null, showHeader = true }: Props = $props();
+  let { pane, headerPlacement, documentLayoutMode = null, documentId = null, showHeader = true, contentInsetTop = 0 }: Props = $props();
 
   const app = getAppContext();
   const paneGroup = getPaneGroup();
@@ -150,11 +151,9 @@
           <!-- Focus mode button -->
           <div style:width="24px" style:height="24px" style:border-radius="4px" class={bar} data-pane-skeleton-focus-mode-control></div>
           <div style:width="24px" style:height="24px" style:flex-shrink="0" data-pane-skeleton-close-button>
-            {#if !app.preference.current.zenModeEnabled}
-              <CloseButton>
-                <Icon icon={XIcon} size={16} />
-              </CloseButton>
-            {/if}
+            <CloseButton>
+              <Icon icon={XIcon} size={16} />
+            </CloseButton>
           </div>
         {/snippet}
       </PaneHeader>
@@ -234,14 +233,16 @@
       </div>
     {/snippet}
 
-    {@render toolbarRowSkeleton(primary, true)}
+    {#if !app.preference.current.zenModeEnabled}
+      {@render toolbarRowSkeleton(primary, true)}
 
-    {#if toolbarExpanded}
-      {@render toolbarRowSkeleton(otherToolbarKind(primary), false)}
+      {#if toolbarExpanded}
+        {@render toolbarRowSkeleton(otherToolbarKind(primary), false)}
+      {/if}
     {/if}
 
     <!-- Body: centered content with constrained width -->
-    <div class={flex({ flexGrow: '1', overflow: 'hidden' })}>
+    <div style:padding-top={`${contentInsetTop}px`} class={flex({ flexGrow: '1', overflow: 'hidden' })} data-pane-skeleton-body>
       <div
         style:min-width={bodyMinWidth}
         style:max-width={bodyMaxWidth}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneSplitMenu.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneSplitMenu.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { center } from '@typie/styled-system/patterns';
+  import { Icon, Menu, MenuItem } from '@typie/ui/components';
+  import mixpanel from 'mixpanel-browser';
+  import Columns2Icon from '~icons/lucide/columns-2';
+  import EllipsisIcon from '~icons/lucide/ellipsis';
+  import Rows2Icon from '~icons/lucide/rows-2';
+  import { getPane, getPaneGroup } from './context.svelte';
+
+  const pane = getPane();
+  const paneGroup = getPaneGroup();
+
+  const add = (direction: 'horizontal' | 'vertical') => {
+    const init = pane.kind === 'home' ? ({ kind: 'home' } as const) : ({ kind: 'entity', slug: pane.slug } as const);
+    paneGroup.addPane(init, { paneId: pane.id, side: direction === 'horizontal' ? 'right' : 'bottom' });
+    mixpanel.track('add_pane', { via: 'pane_header', direction });
+  };
+</script>
+
+<Menu placement="bottom-end">
+  {#snippet button({ open })}
+    <button
+      class={center({
+        borderRadius: '4px',
+        size: '24px',
+        color: 'text.faint',
+        transition: 'common',
+        _hover: { color: 'text.subtle', backgroundColor: 'surface.muted' },
+        _pressed: { color: 'text.subtle', backgroundColor: 'surface.muted' },
+      })}
+      aria-label="창 메뉴"
+      aria-pressed={open}
+      type="button"
+    >
+      <Icon icon={EllipsisIcon} size={16} />
+    </button>
+  {/snippet}
+
+  <MenuItem icon={Columns2Icon} onclick={() => add('horizontal')}>오른쪽에 열기</MenuItem>
+  <MenuItem icon={Rows2Icon} onclick={() => add('vertical')}>아래에 열기</MenuItem>
+</Menu>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Panes.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Panes.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
-  import { getAppContext } from '@typie/ui/context';
   import { onDestroy } from 'svelte';
   import { fade } from 'svelte/transition';
   import { getOpenDocuments } from '$lib/prism/open-documents.svelte';
@@ -17,7 +16,6 @@
 
   let { root }: Props = $props();
 
-  const app = getAppContext();
   const context = getPaneGroup();
   const openDocuments = getOpenDocuments();
 
@@ -140,7 +138,6 @@
         style:height="{rect.height}px"
         style:opacity={context.draggingPaneId === pane.id ? '0.4' : undefined}
         style:scale={context.draggingPaneId === pane.id ? '0.99' : undefined}
-        style:z-index={app.preference.current.zenModeEnabled && context.state.current.focusedPaneId === pane.id ? '70' : undefined}
         class={css({
           position: 'absolute',
           overflow: 'hidden',
@@ -166,7 +163,7 @@
     {/each}
   {/if}
 
-  {#if context.enabled && !context.draggingPaneId && !app.preference.current.zenModeEnabled && layout}
+  {#if context.enabled && !context.draggingPaneId && layout}
     {@const focusedRect = layout.panes.get(context.state.current.focusedPaneId ?? '')}
     {#if focusedRect}
       <div

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/ZenModePaneChromeEffects.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/ZenModePaneChromeEffects.svelte
@@ -1,0 +1,376 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { token } from '@typie/styled-system/tokens';
+  import { prefersReducedMotion } from '@typie/ui/state';
+  import { smootherstep } from '@typie/ui/utils';
+  import {
+    getZenModePaneChrome,
+    PANE_CHROME_BOUNDARY,
+    PANE_CHROME_EXPANSION_EASING,
+    PANE_CHROME_FADE_OUT_MS,
+    PANE_CHROME_FADE_WIDTH,
+    PANE_CHROME_FOREGROUND_FADE_IN_MS,
+    PANE_CHROME_SPOT_MASK_INSET,
+    PANE_CHROME_SPOT_RADIUS,
+    paneChromeExpansionTiming,
+    paneChromeRadialMask,
+  } from './zen-mode-pane-chrome.svelte';
+  import type { PaneChromeLane, PaneChromeSegmentGeometry, PaneChromeTone } from './zen-mode-pane-chrome.svelte';
+
+  type Props = { lane: PaneChromeLane; toolbarSeparatorOffsets?: number[] };
+  type HeaderSegment = {
+    id: 'identity' | 'actions';
+    side: 'leading' | 'trailing';
+    geometry: PaneChromeSegmentGeometry | undefined;
+  };
+
+  const SPOT_ENTER_MS = 500;
+  const ENGAGED_SPOT_RADIUS = 52;
+  const ENGAGED_EDGE_SPOT_RADIUS = 80;
+  const ENGAGED_SPOT_STRENGTH = 0.85;
+  const ENGAGED_SEGMENT_STRENGTH = 0.5;
+  const ENGAGED_SPOT_ENTER_DELAY_MS = 500;
+  const MUTED_SURFACE = token('colors.surface.muted');
+  const CONTINUOUS_SURFACE = token('colors.surface.default');
+  const PAGINATED_SURFACE = token('colors.surface.subtle');
+  const TRANSIENT_BASE = `color-mix(in srgb, ${CONTINUOUS_SURFACE} 50%, ${PAGINATED_SURFACE} 50%)`;
+  const ACTIVE_SURFACE = `color-mix(in srgb, ${MUTED_SURFACE} 80%, ${TRANSIENT_BASE} 20%)`;
+  const TRANSIENT_SURFACE = `color-mix(in srgb, ${TRANSIENT_BASE} 75%, transparent)`;
+  const ENGAGED_SEGMENT_SURFACE = `color-mix(in srgb, ${ACTIVE_SURFACE} ${ENGAGED_SEGMENT_STRENGTH * 100}%, transparent)`;
+  const TRANSIENT_EDGE = `color-mix(in srgb, ${TRANSIENT_BASE} 40%, ${token('colors.border.subtle')} 60%)`;
+  const ENGAGED_EDGE_BASE = `color-mix(in srgb, ${ACTIVE_SURFACE} 36%, ${token('colors.border.default')} 64%)`;
+  const ENGAGED_EDGE = `color-mix(in srgb, ${ENGAGED_EDGE_BASE} ${ENGAGED_SEGMENT_STRENGTH * 100}%, transparent)`;
+
+  let { lane, toolbarSeparatorOffsets = [] }: Props = $props();
+  const chrome = getZenModePaneChrome();
+  const expansionTiming = $derived(paneChromeExpansionTiming(chrome.phase === 'expanding' ? chrome.expansionPace : 'standard'));
+  const laneSize = $derived(chrome.laneSize(lane));
+  const pointer = $derived(chrome.pointerInLane(lane));
+  const laneSpot = $derived(chrome.phase === 'expanding' ? chrome.expansionOriginInLane(lane) : chrome.spotInLane(lane));
+  const headerSegments = $derived<HeaderSegment[]>([
+    { id: 'identity', side: 'leading', geometry: chrome.segmentGeometry('identity') },
+    { id: 'actions', side: 'trailing', geometry: chrome.segmentGeometry('actions') },
+  ]);
+  const headerUnified = $derived(chrome.shown.identity && chrome.shown.actions);
+  const expansionApplies = $derived(
+    lane === 'toolbar' ? chrome.expansionTargets.toolbar : chrome.expansionTargets.identity || chrome.expansionTargets.actions,
+  );
+  const spotVisible = $derived(laneSpot !== null && (chrome.phase === 'spot' || (chrome.phase === 'expanding' && expansionApplies)));
+  const spotRadius = $derived(
+    chrome.phase === 'expanding'
+      ? Math.hypot(laneSize.width, laneSize.height) + PANE_CHROME_FADE_WIDTH + PANE_CHROME_SPOT_MASK_INSET
+      : PANE_CHROME_SPOT_RADIUS,
+  );
+  const spotSurfaceStrength = $derived(chrome.phase === 'expanding' ? 1 : spotVisible ? 0.7 : 0);
+  const headerVisible = $derived(
+    chrome.phase !== 'fading' && (spotVisible || chrome.isSurfaceVisible('identity') || chrome.isSurfaceVisible('actions')),
+  );
+  const toolbarVisible = $derived(chrome.phase !== 'fading' && (spotVisible || chrome.isSurfaceVisible('toolbar')));
+  const toolbarSurfaceMask = $derived(
+    spotVisible ? spotMask('--zen-pane-chrome-spot-surface-opacity') : chrome.shown.toolbar ? 'linear-gradient(black, black)' : undefined,
+  );
+  const toolbarBlurMask = $derived(
+    spotVisible ? spotMask('--zen-pane-chrome-spot-opacity') : chrome.shown.toolbar ? 'linear-gradient(black, black)' : undefined,
+  );
+  const headerSurfaceMasks = $derived.by(() => resolveHeaderMasks(true, '--zen-pane-chrome-spot-surface-opacity'));
+  const headerBlurMasks = $derived.by(() => resolveHeaderMasks(true, '--zen-pane-chrome-spot-opacity'));
+  const headerSurfaceMask = $derived(headerSurfaceMasks.join(', '));
+  const headerBlurMask = $derived(headerBlurMasks.join(', '));
+  const hasEngagedHeaderSegment = $derived(
+    (chrome.shown.identity && chrome.tone.identity === 'engaged') || (chrome.shown.actions && chrome.tone.actions === 'engaged'),
+  );
+  const laneShown = $derived(lane === 'header' ? chrome.shown.identity || chrome.shown.actions : chrome.shown.toolbar);
+  const laneVisible = $derived(lane === 'header' ? headerVisible : toolbarVisible);
+  const laneSurfaceMask = $derived(lane === 'header' ? headerSurfaceMask : toolbarSurfaceMask);
+  const laneBlurMask = $derived(lane === 'header' ? headerBlurMask : toolbarBlurMask);
+  const laneEngagedSpotVisible = $derived(
+    pointer !== null && (spotVisible || chrome.phase === 'held' || (lane === 'header' && hasEngagedHeaderSegment)),
+  );
+  const laneEngagedSpotTransition = $derived(
+    pointer === null
+      ? `opacity ${PANE_CHROME_FADE_OUT_MS}ms ease-out`
+      : `opacity ${SPOT_ENTER_MS}ms ease-out ${chrome.phase === 'held' ? 0 : ENGAGED_SPOT_ENTER_DELAY_MS}ms`,
+  );
+  const laneSurfaceTransition = $derived(
+    `opacity ${laneVisible ? 0 : PANE_CHROME_FADE_OUT_MS}ms ease-out${
+      lane === 'header' ? `, mask-image ${chrome.phase === 'expanding' ? expansionTiming.spotSurfaceMs : 0}ms ease-out` : ''
+    }`,
+  );
+  let engagedSpotX = $state(0);
+  let engagedSpotY = $state(0);
+  const toolbarSeparators = $derived.by(() =>
+    toolbarSeparatorOffsets
+      .filter((offset) => Number.isFinite(offset) && offset > 0 && offset < laneSize.height)
+      .toSorted((left, right) => left - right),
+  );
+  const toolbarEngagedRowIndex = $derived.by(() => {
+    let rowIndex = 0;
+    for (const offset of toolbarSeparators) {
+      if (engagedSpotY >= offset) rowIndex += 1;
+    }
+    return rowIndex;
+  });
+  const toolbarEngagedSurfaceClip = $derived.by(() => {
+    if (toolbarSeparators.length === 0) return;
+    const top = toolbarEngagedRowIndex === 0 ? 0 : toolbarSeparators[toolbarEngagedRowIndex - 1];
+    const bottom = toolbarSeparators[toolbarEngagedRowIndex] ?? laneSize.height;
+    return `inset(${top}px 0 ${Math.max(0, laneSize.height - bottom)}px 0)`;
+  });
+
+  $effect(() => {
+    if (!pointer) return;
+    engagedSpotX = pointer.x;
+    engagedSpotY = pointer.y;
+  });
+
+  function toneSurface(tone: PaneChromeTone): string {
+    return tone === 'engaged' ? ENGAGED_SEGMENT_SURFACE : TRANSIENT_SURFACE;
+  }
+
+  function toneEdge(tone: PaneChromeTone): string {
+    return tone === 'engaged' ? ENGAGED_EDGE : TRANSIENT_EDGE;
+  }
+
+  function segmentLaneMask(segment: HeaderSegment, includeEngaged: boolean): string | undefined {
+    const geometry = segment.geometry;
+    if (!geometry || !chrome.shown[segment.id] || (!includeEngaged && chrome.tone[segment.id] === 'engaged')) return;
+    const samples = Array.from({ length: 9 }, (_, index) => {
+      const progress = index / 8;
+      const alpha = segment.side === 'leading' ? 1 - smootherstep(progress) : smootherstep(progress);
+      const position =
+        segment.side === 'leading'
+          ? geometry.right + PANE_CHROME_FADE_WIDTH * progress
+          : geometry.left - PANE_CHROME_FADE_WIDTH * (1 - progress);
+      return `rgb(0 0 0 / ${alpha}) ${position}px`;
+    });
+    if (segment.side === 'leading') samples.push('transparent 100%');
+    else samples.unshift('transparent 0');
+    return `linear-gradient(to right, ${samples.join(', ')})`;
+  }
+
+  function spotMask(opacityVariable: string): string | undefined {
+    if (!spotVisible || !laneSpot) return;
+    return paneChromeRadialMask(laneSpot.x, laneSpot.y, '--zen-pane-chrome-spot-radius', opacityVariable);
+  }
+
+  function resolveHeaderMasks(includeEngaged: boolean, opacityVariable: string): string[] {
+    const spot = spotMask(opacityVariable);
+    if (chrome.phase === 'expanding') {
+      if (headerUnified && !chrome.expansionTargets.identity && !chrome.expansionTargets.actions) {
+        return ['linear-gradient(black, black)'];
+      }
+      return [
+        spot,
+        ...headerSegments
+          .filter((segment) => !chrome.expansionTargets[segment.id])
+          .map((segment) => segmentLaneMask(segment, includeEngaged)),
+      ].filter((mask): mask is string => mask !== undefined);
+    }
+    if (headerUnified) return ['linear-gradient(black, black)'];
+    return [spot, ...headerSegments.map((segment) => segmentLaneMask(segment, includeEngaged))].filter(
+      (mask): mask is string => mask !== undefined,
+    );
+  }
+
+  function edgeMask(side: HeaderSegment['side']): string {
+    const samples = Array.from({ length: 9 }, (_, index) => {
+      const progress = index / 8;
+      const alpha = side === 'leading' ? 1 - smootherstep(progress) : smootherstep(progress);
+      const position =
+        side === 'leading' ? `calc(100% - ${PANE_CHROME_FADE_WIDTH * (1 - progress)}px)` : `${PANE_CHROME_FADE_WIDTH * progress}px`;
+      return `rgb(0 0 0 / ${alpha}) ${position}`;
+    });
+    if (side === 'leading') samples.unshift('black 0', `black calc(100% - ${PANE_CHROME_FADE_WIDTH}px)`);
+    else samples.push(`black ${PANE_CHROME_FADE_WIDTH}px`, 'black 100%');
+    return `linear-gradient(to right, ${samples.join(', ')})`;
+  }
+
+  function engagedPointerMask(radius: number, strength: number): string {
+    const stops = Array.from({ length: 9 }, (_, index) => {
+      const progress = index / 8;
+      return `rgb(0 0 0 / ${strength * (1 - smootherstep(progress))}) ${radius * progress}px`;
+    });
+    return `radial-gradient(circle at ${engagedSpotX}px ${engagedSpotY}px, ${stops.join(', ')})`;
+  }
+
+  function engagedSpotMask(): string {
+    return engagedPointerMask(ENGAGED_SPOT_RADIUS, ENGAGED_SPOT_STRENGTH);
+  }
+
+  function engagedEdgeSpotMask(): string {
+    return engagedPointerMask(ENGAGED_EDGE_SPOT_RADIUS, 1);
+  }
+</script>
+
+<div
+  style:--zen-pane-chrome-spot-opacity={spotVisible ? 1 : 0}
+  style:--zen-pane-chrome-spot-radius={`${spotRadius}px`}
+  style:--zen-pane-chrome-spot-surface-opacity={spotSurfaceStrength}
+  style:transition={prefersReducedMotion.current
+    ? 'none'
+    : `--zen-pane-chrome-spot-opacity ${chrome.phase === 'expanding' ? expansionTiming.spotEnterMs : SPOT_ENTER_MS}ms ease-out, --zen-pane-chrome-spot-surface-opacity ${chrome.phase === 'expanding' ? expansionTiming.spotSurfaceMs : SPOT_ENTER_MS}ms ease-out, --zen-pane-chrome-spot-radius ${expansionTiming.backgroundExpandMs}ms ${PANE_CHROME_EXPANSION_EASING}`}
+  class={css({ position: 'absolute', inset: '0', isolation: 'isolate', pointerEvents: 'none' })}
+  data-zen-pane-chrome-header-effects={lane === 'header' ? '' : undefined}
+  data-zen-pane-chrome-phase={chrome.phase}
+  data-zen-pane-chrome-toolbar-effects={lane === 'toolbar' ? '' : undefined}
+  role="presentation"
+>
+  <div
+    style:backdrop-filter={`blur(${laneVisible ? (spotVisible && !laneShown ? 1.5 : 2) : 0}px)`}
+    style:mask-image={laneBlurMask || 'linear-gradient(transparent, transparent)'}
+    style:mask-composite={lane === 'header' ? 'add' : undefined}
+    style:transition={prefersReducedMotion.current
+      ? 'none'
+      : `backdrop-filter ${chrome.phase === 'expanding' ? expansionTiming.backgroundExpandMs : 320}ms ${
+          chrome.phase === 'expanding' ? PANE_CHROME_EXPANSION_EASING : 'ease-out'
+        }`}
+    class={css({ position: 'absolute', inset: '0', zIndex: '[-2]', pointerEvents: 'none' })}
+    aria-hidden="true"
+    data-zen-pane-chrome-header-blur={lane === 'header' ? '' : undefined}
+    data-zen-pane-chrome-toolbar-blur={lane === 'toolbar' ? '' : undefined}
+  ></div>
+
+  <div
+    style:background={TRANSIENT_SURFACE}
+    style:mask-image={laneSurfaceMask || 'linear-gradient(transparent, transparent)'}
+    style:mask-composite={lane === 'header' ? 'add' : undefined}
+    style:opacity={laneVisible ? '1' : '0'}
+    style:transition={prefersReducedMotion.current ? 'none' : laneSurfaceTransition}
+    class={css({ position: 'absolute', inset: '0', zIndex: '[-1]', pointerEvents: 'none' })}
+    aria-hidden="true"
+    data-zen-pane-chrome-header-full-lane={lane === 'header' ? headerUnified : undefined}
+    data-zen-pane-chrome-header-lane-surface={lane === 'header' ? '' : undefined}
+    data-zen-pane-chrome-spot-strength={spotSurfaceStrength}
+    data-zen-pane-chrome-spot-x={laneSpot?.x}
+    data-zen-pane-chrome-spot-y={laneSpot?.y}
+    data-zen-pane-chrome-toolbar-surface={lane === 'toolbar' ? '' : undefined}
+  >
+    {#if lane === 'toolbar'}
+      {#each toolbarSeparators as offset (offset)}
+        <div
+          style:background={TRANSIENT_EDGE}
+          style:top={`${offset}px`}
+          style:height={`${PANE_CHROME_BOUNDARY}px`}
+          class={css({ position: 'absolute', right: '0', left: '0' })}
+          data-zen-pane-chrome-toolbar-edge-boundary="separator"
+        ></div>
+      {/each}
+    {/if}
+    <div style:background={TRANSIENT_EDGE} class={css({ position: 'absolute', right: '0', bottom: '0', left: '0', height: '1px' })}></div>
+  </div>
+
+  <div
+    style:background={ACTIVE_SURFACE}
+    style:clip-path={lane === 'toolbar' ? toolbarEngagedSurfaceClip : undefined}
+    style:mask-image={engagedSpotMask()}
+    style:opacity={laneEngagedSpotVisible ? '1' : '0'}
+    style:transition={prefersReducedMotion.current ? 'none' : laneEngagedSpotTransition}
+    class={css({ position: 'absolute', inset: '0', zIndex: '[-1]', pointerEvents: 'none' })}
+    aria-hidden="true"
+    data-zen-pane-chrome-header-engaged-spot={lane === 'header' ? '' : undefined}
+    data-zen-pane-chrome-toolbar-engaged-spot={lane === 'toolbar' ? '' : undefined}
+  ></div>
+
+  <div
+    style:mask-image={engagedEdgeSpotMask()}
+    style:opacity={laneEngagedSpotVisible ? '1' : '0'}
+    style:transition={prefersReducedMotion.current ? 'none' : laneEngagedSpotTransition}
+    class={css({ position: 'absolute', inset: '0', zIndex: '[-1]', pointerEvents: 'none' })}
+    aria-hidden="true"
+    data-zen-pane-chrome-engaged-edge-radius={ENGAGED_EDGE_SPOT_RADIUS}
+    data-zen-pane-chrome-header-engaged-edge={lane === 'header' ? '' : undefined}
+    data-zen-pane-chrome-toolbar-engaged-edge={lane === 'toolbar' ? '' : undefined}
+  >
+    {#if lane === 'header'}
+      <div style:background={ENGAGED_EDGE} class={css({ position: 'absolute', right: '0', bottom: '0', left: '0', height: '1px' })}></div>
+    {:else}
+      {#if toolbarEngagedRowIndex === 0}
+        <div
+          style:background={ENGAGED_EDGE}
+          style:height={`${PANE_CHROME_BOUNDARY}px`}
+          class={css({ position: 'absolute', top: '[-1px]', right: '0', left: '0' })}
+          data-zen-pane-chrome-toolbar-engaged-edge-boundary="top"
+        ></div>
+      {/if}
+      {#each toolbarSeparators as offset, index (offset)}
+        {#if toolbarEngagedRowIndex === index || toolbarEngagedRowIndex === index + 1}
+          <div
+            style:background={ENGAGED_EDGE}
+            style:top={`${offset}px`}
+            style:height={`${PANE_CHROME_BOUNDARY}px`}
+            class={css({ position: 'absolute', right: '0', left: '0' })}
+            data-zen-pane-chrome-toolbar-engaged-edge-boundary="separator"
+          ></div>
+        {/if}
+      {/each}
+      {#if toolbarEngagedRowIndex === toolbarSeparators.length}
+        <div
+          style:background={ENGAGED_EDGE}
+          style:height={`${PANE_CHROME_BOUNDARY}px`}
+          class={css({ position: 'absolute', right: '0', bottom: '0', left: '0' })}
+          data-zen-pane-chrome-toolbar-engaged-edge-boundary="bottom"
+        ></div>
+      {/if}
+    {/if}
+  </div>
+
+  {#if lane === 'header'}
+    {#each headerSegments as segment (segment.id)}
+      {#if segment.geometry}
+        {@const leading = segment.side === 'leading'}
+        {@const visible = chrome.isSurfaceVisible(segment.id) && chrome.tone[segment.id] === 'engaged'}
+        <div
+          style:left={leading ? '0' : undefined}
+          style:right={leading ? undefined : '0'}
+          style:width={`${segment.geometry.width + PANE_CHROME_FADE_WIDTH}px`}
+          style:opacity={visible ? '1' : '0'}
+          style:background-color={toneSurface(chrome.tone[segment.id])}
+          style:mask-image={edgeMask(segment.side)}
+          style:transition={prefersReducedMotion.current
+            ? 'none'
+            : `opacity ${visible ? PANE_CHROME_FOREGROUND_FADE_IN_MS : PANE_CHROME_FADE_OUT_MS}ms ease-out, background-color ${PANE_CHROME_FOREGROUND_FADE_IN_MS}ms ease-out`}
+          class={css({ position: 'absolute', top: '0', bottom: '0', zIndex: '[-1]', pointerEvents: 'none' })}
+          aria-hidden="true"
+          data-zen-pane-chrome-header-surface={segment.id}
+        >
+          <div
+            style:background-color={toneEdge(chrome.tone[segment.id])}
+            class={css({ position: 'absolute', right: '0', bottom: '0', left: '0', height: '1px' })}
+          ></div>
+        </div>
+      {/if}
+    {/each}
+  {/if}
+</div>
+
+<style>
+  @property --zen-pane-chrome-spot-radius {
+    syntax: '<length>';
+    inherits: true;
+    initial-value: 88px;
+  }
+
+  @property --zen-pane-chrome-spot-opacity {
+    syntax: '<number>';
+    inherits: true;
+    initial-value: 0;
+  }
+
+  @property --zen-pane-chrome-spot-surface-opacity {
+    syntax: '<number>';
+    inherits: true;
+    initial-value: 0;
+  }
+
+  @property --zen-pane-chrome-foreground-radius {
+    syntax: '<length>';
+    inherits: true;
+    initial-value: 88px;
+  }
+
+  @property --zen-pane-chrome-foreground-opacity {
+    syntax: '<number>';
+    inherits: true;
+    initial-value: 0;
+  }
+</style>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/ZenModePaneChromeSegment.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/ZenModePaneChromeSegment.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { onDestroy } from 'svelte';
+  import {
+    getZenModePaneChrome,
+    PANE_CHROME_EXPANSION_EASING,
+    PANE_CHROME_FADE_OUT_MS,
+    PANE_CHROME_FOREGROUND_FADE_IN_MS,
+    paneChromeExpansionTiming,
+  } from './zen-mode-pane-chrome.svelte';
+  import type { Snippet } from 'svelte';
+  import type { ActionReturn } from 'svelte/action';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { PaneChromeSegment } from './zen-mode-pane-chrome.svelte';
+
+  type Props = Omit<HTMLAttributes<HTMLDivElement>, 'children'> & {
+    active: boolean;
+    children: Snippet;
+    contentCursor?: string;
+    register?: (node: HTMLElement) => ActionReturn;
+    segment: PaneChromeSegment;
+  };
+
+  let { active, children, class: className, contentCursor, register, segment, style, ...attributes }: Props = $props();
+
+  const chrome = getZenModePaneChrome();
+  const interactive = $derived(chrome.isInteractive(segment));
+  const expansionTiming = $derived(paneChromeExpansionTiming(chrome.phase === 'expanding' ? chrome.expansionPace : 'standard'));
+  const registerNode = (node: HTMLElement): ActionReturn => register?.(node) ?? {};
+  let hoverHeld = false;
+  let focusHeld = false;
+
+  function handleFocusIn(event: FocusEvent): void {
+    if (
+      event.relatedTarget instanceof Node &&
+      event.currentTarget instanceof HTMLElement &&
+      event.currentTarget.contains(event.relatedTarget)
+    )
+      return;
+    if (!focusHeld) chrome.hold(segment, 'focus');
+    focusHeld = true;
+  }
+
+  function handleFocusOut(event: FocusEvent): void {
+    if (
+      event.relatedTarget instanceof Node &&
+      event.currentTarget instanceof HTMLElement &&
+      event.currentTarget.contains(event.relatedTarget)
+    )
+      return;
+    if (focusHeld) chrome.release(segment, 'focus');
+    focusHeld = false;
+  }
+
+  function handlePointerEnter(): void {
+    if (!hoverHeld) chrome.hold(segment, 'hover');
+    hoverHeld = true;
+  }
+
+  function handlePointerLeave(): void {
+    if (hoverHeld) chrome.release(segment, 'hover');
+    hoverHeld = false;
+  }
+
+  onDestroy(() => {
+    if (hoverHeld) chrome.release(segment, 'hover');
+    if (focusHeld) chrome.release(segment, 'focus');
+  });
+</script>
+
+<div
+  {...attributes}
+  {style}
+  style:--zen-pane-chrome-foreground-opacity={chrome.isForegroundRevealStarted(segment) ? 1 : 0}
+  style:--zen-pane-chrome-foreground-radius={`${chrome.foregroundRevealRadius(segment === 'toolbar' ? 'toolbar' : 'header')}px`}
+  style:clip-path={active ? chrome.foregroundClip(segment) : undefined}
+  style:cursor={active && interactive ? contentCursor : undefined}
+  style:mask-image={active ? chrome.foregroundMask(segment) : undefined}
+  style:opacity={chrome.isForegroundVisible(segment) ? '1' : '0'}
+  style:pointer-events={interactive ? 'auto' : 'none'}
+  style:transition={active
+    ? `opacity ${chrome.phase === 'fading' ? PANE_CHROME_FADE_OUT_MS : PANE_CHROME_FOREGROUND_FADE_IN_MS}ms ease-out, clip-path ${expansionTiming.backgroundExpandMs}ms ${PANE_CHROME_EXPANSION_EASING}, --zen-pane-chrome-foreground-radius ${expansionTiming.backgroundExpandMs}ms ${PANE_CHROME_EXPANSION_EASING}`
+    : undefined}
+  class={`${css({ position: 'relative', _motionReduce: { transitionDuration: '0ms' } })} ${className ?? ''}`}
+  data-pane-chrome-segment={segment}
+  inert={!interactive}
+  onfocusin={handleFocusIn}
+  onfocusout={handleFocusOut}
+  onpointerenter={handlePointerEnter}
+  onpointerleave={handlePointerLeave}
+  role="group"
+  use:registerNode
+>
+  {@render children()}
+</div>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/context.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/context.svelte.ts
@@ -1,5 +1,6 @@
 import { createStableContext } from '@typie/ui/context/stable';
 import { LocalStore } from '@typie/ui/state';
+import { safeJsonParse } from '@typie/ui/utils';
 import { nanoid } from 'nanoid';
 import { getContext, setContext } from 'svelte';
 import { browser } from '$app/environment';
@@ -33,6 +34,20 @@ const defaultPaneGroupState: PaneGroupState = {
   panelExpandedByPaneId: {},
   panelTabByPaneId: {},
   toolbarExpandedByPaneId: {},
+};
+
+const paneGroupStorageKey = (siteId: string) => `typie:panegroup:${siteId}`;
+
+const readStoredPaneGroupState = (siteId: string): PaneGroupState => {
+  if (!browser) return defaultPaneGroupState;
+  const saved = safeJsonParse<Partial<PaneGroupState>>(localStorage.getItem(paneGroupStorageKey(siteId)), {});
+  return {
+    ...defaultPaneGroupState,
+    ...saved,
+    panelExpandedByPaneId: { ...defaultPaneGroupState.panelExpandedByPaneId, ...saved.panelExpandedByPaneId },
+    panelTabByPaneId: { ...defaultPaneGroupState.panelTabByPaneId, ...saved.panelTabByPaneId },
+    toolbarExpandedByPaneId: { ...defaultPaneGroupState.toolbarExpandedByPaneId, ...saved.toolbarExpandedByPaneId },
+  };
 };
 
 type PaneGroupOptions = {
@@ -198,6 +213,27 @@ export const setupPaneGroup = (initialSiteId: string, options: PaneGroupOptions)
 
       syncUrl();
       return true;
+    },
+    readPanelExpandedByPaneId: (siteId) => {
+      if (siteId === currentSiteId) return { ...state.current.panelExpandedByPaneId };
+      return { ...readStoredPaneGroupState(siteId).panelExpandedByPaneId };
+    },
+    restorePanelExpandedByPaneId: (siteId, entry) => {
+      const stored = siteId === currentSiteId ? state.current : readStoredPaneGroupState(siteId);
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local membership index for one restore transaction
+      const paneIds = new Set(collectPanes(stored.root).map((pane) => pane.id));
+      const next = { ...stored.panelExpandedByPaneId };
+
+      for (const [paneId, entryVisible] of Object.entries(entry)) {
+        if (!paneIds.has(paneId)) continue;
+        next[paneId] = entryVisible || (next[paneId] ?? false);
+      }
+
+      if (siteId === currentSiteId) {
+        state.current.panelExpandedByPaneId = next;
+      } else if (browser) {
+        localStorage.setItem(paneGroupStorageKey(siteId), JSON.stringify({ ...stored, panelExpandedByPaneId: next }));
+      }
     },
 
     handleNavigation(slug: string, siteId?: string) {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-chrome-attachment.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-chrome-attachment.ts
@@ -1,0 +1,48 @@
+import type { ActionReturn } from 'svelte/action';
+import type { PaneChromeAttachmentHandle } from './zen-mode-pane-chrome.svelte';
+
+export const paneChromeAttachment = (node: HTMLElement, handle: PaneChromeAttachmentHandle): ActionReturn<PaneChromeAttachmentHandle> => {
+  let current = handle;
+  let hovered = false;
+  let focused = false;
+
+  const enter = (event: PointerEvent) => {
+    hovered = true;
+    current.hold(event);
+  };
+  const leave = () => {
+    hovered = false;
+    if (!focused) current.release();
+  };
+  const focusIn = (event: FocusEvent) => {
+    if (event.relatedTarget instanceof Node && node.contains(event.relatedTarget)) return;
+    focused = true;
+    current.hold();
+  };
+  const focusOut = (event: FocusEvent) => {
+    if (event.relatedTarget instanceof Node && node.contains(event.relatedTarget)) return;
+    focused = false;
+    if (!hovered) current.release();
+  };
+
+  node.addEventListener('pointerenter', enter);
+  node.addEventListener('pointerleave', leave);
+  node.addEventListener('focusin', focusIn);
+  node.addEventListener('focusout', focusOut);
+
+  return {
+    update(next) {
+      if (next === current) return;
+      current.release();
+      current = next;
+      if (hovered || focused) current.hold();
+    },
+    destroy() {
+      node.removeEventListener('pointerenter', enter);
+      node.removeEventListener('pointerleave', leave);
+      node.removeEventListener('focusin', focusIn);
+      node.removeEventListener('focusout', focusOut);
+      current.release();
+    },
+  };
+};

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-header-test-root.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-header-test-root.svelte
@@ -4,11 +4,16 @@
   import { setupPane, setupPaneGroup } from './context.svelte';
   import PaneHeader from './PaneHeader.svelte';
   import PaneSkeleton from './PaneSkeleton.svelte';
+  import { setupZenModePaneChrome } from './zen-mode-pane-chrome.svelte';
   import type { Pane } from './types';
+
+  type Props = { headerWidth?: number; zenModeEnabled?: boolean };
+
+  let { headerWidth = 420, zenModeEnabled = false }: Props = $props();
 
   const app = setupAppContext('pane-header-priority-test');
   app.preference.current.sidebarHidden = false;
-  app.preference.current.zenModeEnabled = false;
+  app.preference.current.zenModeEnabled = zenModeEnabled;
   app.preference.current.prismPanelOpen = false;
 
   const pane: Pane = { id: 'pane-header-test', type: 'pane', kind: 'entity', slug: 'pane-header-test' };
@@ -24,9 +29,10 @@
   paneGroup.state.current.root = pane;
   paneGroup.state.current.focusedPaneId = pane.id;
   setupPane(pane);
+  setupZenModePaneChrome({ active: () => zenModeEnabled, focused: () => true });
 </script>
 
-<div style="width: 420px" data-pane-header-test-host>
+<div style:width={`${headerWidth}px`} style="position: relative; height: 37px" data-pane-header-test-host>
   <PaneHeader placement={{ topLeft: true, topRight: true }}>
     <EditorBreadcrumb pathIdentity="folder/document" viewportId="pane-header-breadcrumb-test">
       <div style="width: 260px">Folder / Document with a long title</div>
@@ -62,7 +68,7 @@
   <PaneHeader placement={{ topLeft: true, topRight: true }}>
     <span>Loaded document</span>
   </PaneHeader>
-  <PaneSkeleton headerPlacement={{ topLeft: true, topRight: true }} {pane} showHeader={false} />
+  <PaneSkeleton contentInsetTop={78} headerPlacement={{ topLeft: true, topRight: true }} {pane} showHeader={false} />
 </div>
 
 <output data-sidebar-peek>{String(app.state.sidebarPeek)}</output>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-header.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-header.browser.test.ts
@@ -69,7 +69,46 @@ describe('PaneHeader priority lanes', () => {
     await expect.poll(() => scrollViewport.scrollWidth).toBeGreaterThan(scrollViewport.clientWidth);
     const scrollbar = document.querySelector<HTMLElement>('[role="scrollbar"][aria-label="문서 헤더 도구 가로 스크롤"]');
     expect(scrollbar?.getAttribute('aria-controls')).toBe(scrollViewport.id);
-    expect(scrollbar?.getBoundingClientRect().bottom).toBeCloseTo(bounds.bottom, 1);
+    expect(scrollbar?.getBoundingClientRect().bottom).toBeCloseTo(bounds.bottom - 1, 1);
+  });
+
+  it('keeps fixed actions visible after the breadcrumb compresses in focus mode', async () => {
+    component = mount(PaneHeaderTestRoot, {
+      target: document.body,
+      props: { headerWidth: 220, zenModeEnabled: true },
+    });
+    await tick();
+
+    const host = document.querySelector<HTMLElement>('[data-pane-header-test-host]');
+    const region = host?.querySelector<HTMLElement>('[role="region"]');
+    const identity = region?.querySelector<HTMLElement>('[data-pane-chrome-segment="identity"]');
+    const actions = region?.querySelector<HTMLElement>('[data-pane-chrome-segment="actions"]');
+    const sidebar = region?.querySelector<HTMLButtonElement>('button');
+    const prism = region?.querySelector<HTMLButtonElement>('[aria-label^="PRISM"]');
+    const fixedActions = [...(region?.querySelectorAll<HTMLElement>('[data-pane-header-fixed-action]') ?? [])];
+    const breadcrumbViewport = document.querySelector<HTMLElement>('#pane-header-breadcrumb-test');
+    const scrollViewport = document.querySelector<HTMLElement>('#pane-header-actions-pane-header-test');
+
+    if (!region || !identity || !actions || !sidebar || !prism || !breadcrumbViewport || !scrollViewport) {
+      throw new Error('Missing focus-mode PaneHeader test fixture');
+    }
+
+    const bounds = region.getBoundingClientRect();
+    const identityBounds = identity.getBoundingClientRect();
+    const actionsBounds = actions.getBoundingClientRect();
+    for (const control of [sidebar, ...fixedActions, prism]) {
+      const rect = control.getBoundingClientRect();
+      expect(rect.left).toBeGreaterThanOrEqual(bounds.left);
+      expect(rect.right).toBeLessThanOrEqual(bounds.right);
+    }
+    for (const control of [...fixedActions, prism]) {
+      const rect = control.getBoundingClientRect();
+      expect(rect.left).toBeGreaterThanOrEqual(actionsBounds.left);
+      expect(rect.right).toBeLessThanOrEqual(actionsBounds.right);
+    }
+    expect(identityBounds.right).toBeLessThanOrEqual(actionsBounds.left);
+    await expect.poll(() => breadcrumbViewport.scrollWidth).toBeGreaterThan(breadcrumbViewport.clientWidth);
+    await expect.poll(() => scrollViewport.scrollWidth).toBeGreaterThan(scrollViewport.clientWidth);
   });
 
   it('places the breadcrumb fog at the pane edge and its scrollbar at the header bottom', async () => {
@@ -79,13 +118,13 @@ describe('PaneHeader priority lanes', () => {
     const host = document.querySelector<HTMLElement>('[data-pane-header-breadcrumb-test-host]');
     const region = host?.querySelector<HTMLElement>('[role="region"]');
     const viewport = document.querySelector<HTMLElement>('#pane-header-breadcrumb-only-test');
-    const scrollbar = document.querySelector<HTMLElement>('[role="scrollbar"][aria-label="문서 경로 가로 스크롤"]');
+    const scrollbar = host?.querySelector<HTMLElement>('[role="scrollbar"][aria-label="문서 경로 가로 스크롤"]');
     if (!region || !viewport || !scrollbar) throw new Error('Missing breadcrumb PaneHeader test fixture');
 
     await expect.poll(() => viewport.scrollWidth).toBeGreaterThan(viewport.clientWidth);
     const bounds = region.getBoundingClientRect();
     expect(viewport.getBoundingClientRect().left).toBeCloseTo(bounds.left + 4, 1);
-    expect(scrollbar.getBoundingClientRect().bottom).toBeCloseTo(bounds.bottom, 1);
+    expect(scrollbar.getBoundingClientRect().bottom).toBeCloseTo(bounds.bottom - 1, 1);
   });
 
   it('leaves header ownership to the loaded document while its body skeleton remains', async () => {
@@ -94,5 +133,13 @@ describe('PaneHeader priority lanes', () => {
 
     const host = document.querySelector<HTMLElement>('[data-pane-header-skeleton-handoff-test-host]');
     expect(host?.querySelectorAll('[role="region"]')).toHaveLength(1);
+  });
+
+  it('applies the focus-mode editor top inset to the document skeleton body', async () => {
+    component = mount(PaneHeaderTestRoot, { target: document.body });
+    await tick();
+
+    const body = document.querySelector<HTMLElement>('[data-pane-skeleton-body]');
+    expect(body?.style.paddingTop).toBe('78px');
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-overlay-layout.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-overlay-layout.svelte.ts
@@ -1,0 +1,42 @@
+import { prefersReducedMotion } from '@typie/ui/state';
+import { PANE_CHROME_FADE_OUT_MS, PANE_CHROME_SINGLE_TOOLBAR_TOP_INSET } from './zen-mode-pane-chrome.svelte';
+import type { ZenModePaneChrome } from './zen-mode-pane-chrome.svelte';
+
+type PaneOverlayLayoutOptions = {
+  active: () => boolean;
+  chrome: ZenModePaneChrome;
+};
+
+export const setupPaneOverlayLayout = ({ active, chrome }: PaneOverlayLayoutOptions) => {
+  let motionArmed = $state(false);
+
+  $effect(() => {
+    motionArmed = false;
+    if (!active()) return;
+    const frame = requestAnimationFrame(() => (motionArmed = true));
+    return () => cancelAnimationFrame(frame);
+  });
+
+  return {
+    get contentTopInset(): number {
+      return active() ? Math.max(chrome.floatingZoomTopInset, PANE_CHROME_SINGLE_TOOLBAR_TOP_INSET) : 0;
+    },
+    get headerInset(): number {
+      return active() ? chrome.headerInset : 0;
+    },
+    get topInset(): number {
+      return active() ? chrome.floatingZoomInset : 0;
+    },
+    get visibleAreaTopInset(): number {
+      return active() ? chrome.topOcclusion : 0;
+    },
+    get motionDuration(): number {
+      return chrome.phase === 'fading' ? PANE_CHROME_FADE_OUT_MS : 280;
+    },
+    get positionTransition(): string {
+      return !motionArmed || !active() || prefersReducedMotion.current
+        ? 'none'
+        : 'top var(--editor-pane-overlay-motion-duration, 280ms) var(--editor-pane-overlay-motion-easing, cubic-bezier(0.22, 1, 0.36, 1))';
+    },
+  };
+};

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/types.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/types.ts
@@ -63,6 +63,8 @@ export type PaneGroup = {
   swapPane: (firstPaneId: string, secondPaneId: string) => boolean;
   removePane: (paneId: string) => boolean;
   replacePane: (paneId: string, pane: PaneInit) => boolean;
+  readPanelExpandedByPaneId: (siteId: string) => Record<string, boolean>;
+  restorePanelExpandedByPaneId: (siteId: string, entry: Record<string, boolean>) => void;
 
   handleNavigation: (slug: string, siteId?: string) => void;
   switchToSite: (siteId: string, slug?: string) => void;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome-geometry.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome-geometry.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PaneChromeGeometry } from './zen-mode-pane-chrome-geometry';
+
+const rect = (top: number, height: number): DOMRect =>
+  ({ top, right: 600, bottom: top + height, left: 0, width: 600, height, x: 0, y: top }) as DOMRect;
+
+describe('PaneChromeGeometry', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('keeps chrome insets stable when a resized pane moves', () => {
+    const resize = new Map<Element, () => void>();
+    class ResizeObserverStub {
+      #callback: ResizeObserverCallback;
+      #targets = new Set<Element>();
+
+      constructor(callback: ResizeObserverCallback) {
+        this.#callback = callback;
+      }
+
+      observe(target: Element): void {
+        this.#targets.add(target);
+        resize.set(target, () => this.#callback([], this as unknown as ResizeObserver));
+      }
+
+      disconnect(): void {
+        for (const target of this.#targets) resize.delete(target);
+        this.#targets.clear();
+      }
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+
+    let rootTop = 500;
+    let headerTop = 500;
+    let toolbarTop = 537;
+    const root = { getBoundingClientRect: () => rect(rootTop, 240) } as HTMLElement;
+    const header = { getBoundingClientRect: () => rect(headerTop, 37) } as HTMLElement;
+    const toolbar = { getBoundingClientRect: () => rect(toolbarTop, 41) } as HTMLElement;
+    const geometry = new PaneChromeGeometry(vi.fn());
+
+    geometry.registerRoot(root);
+    geometry.registerHeaderLane(header);
+    geometry.registerToolbarLane(toolbar);
+    expect(geometry.floatingChromeInset()).toBe(78);
+    expect(geometry.visibleChromeInset(true, true)).toBe(78);
+
+    rootTop = 0;
+    headerTop = 0;
+    toolbarTop = 37;
+    resize.get(root)?.();
+
+    expect(geometry.floatingChromeInset()).toBe(78);
+    expect(geometry.visibleChromeInset(true, true)).toBe(78);
+  });
+
+  it('uses the current lane position when a same-sized pane moves', () => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe(): void {
+          // This case intentionally leaves the cached size unchanged.
+        }
+        disconnect(): void {
+          // No observer resources in the stub.
+        }
+      },
+    );
+
+    let headerTop = 100;
+    const header = { getBoundingClientRect: () => rect(headerTop, 36) } as HTMLElement;
+    const geometry = new PaneChromeGeometry(vi.fn());
+    geometry.registerHeaderLane(header);
+
+    expect(geometry.pointInLane({ x: 20, y: 118 }, 'header')).toEqual({ x: 20, y: 18 });
+
+    headerTop = 400;
+    expect(geometry.pointInLane({ x: 20, y: 418 }, 'header')).toEqual({ x: 20, y: 18 });
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome-geometry.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome-geometry.ts
@@ -1,0 +1,148 @@
+import type { ActionReturn } from 'svelte/action';
+
+export type PaneChromeSegment = 'identity' | 'actions' | 'toolbar';
+export type PaneChromeLane = 'header' | 'toolbar';
+export type PaneChromeSegmentGeometry = {
+  left: number;
+  right: number;
+  width: number;
+};
+
+type GeometryKey = PaneChromeSegment | 'root' | 'header';
+type Point = { x: number; y: number };
+
+const geometryKeys: readonly GeometryKey[] = ['root', 'header', 'identity', 'actions', 'toolbar'];
+
+const contains = (rect: DOMRect | undefined, x: number, y: number): boolean =>
+  rect !== undefined && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+
+export class PaneChromeGeometry {
+  #nodes: Partial<Record<GeometryKey, HTMLElement>> = {};
+  #rects: Partial<Record<GeometryKey, DOMRect>> = {};
+  #observers = new Map<HTMLElement, ResizeObserver>();
+  #onMeasure: () => void;
+
+  constructor(onMeasure: () => void) {
+    this.#onMeasure = onMeasure;
+  }
+
+  registerRoot(node: HTMLElement): ActionReturn {
+    return this.#register('root', node);
+  }
+
+  registerHeaderLane(node: HTMLElement): ActionReturn {
+    return this.#register('header', node);
+  }
+
+  registerToolbarLane(node: HTMLElement): ActionReturn {
+    return this.#register('toolbar', node);
+  }
+
+  registerSegment(segment: Exclude<PaneChromeSegment, 'toolbar'>, node: HTMLElement): ActionReturn {
+    return this.#register(segment, node);
+  }
+
+  zoneAt(x: number, y: number): PaneChromeSegment | 'gap' | null {
+    const toolbar = this.#nodes.toolbar?.getBoundingClientRect();
+    if (contains(toolbar, x, y)) return 'toolbar';
+
+    const header = this.#nodes.header?.getBoundingClientRect();
+    const identity = this.#nodes.identity?.getBoundingClientRect();
+    const actions = this.#nodes.actions?.getBoundingClientRect();
+    if (!header || !identity || !actions || y < header.top || y > header.bottom) return null;
+
+    const identityRight = header.left + identity.width;
+    const actionsLeft = header.right - actions.width;
+    if (x <= identityRight) return 'identity';
+    if (x >= actionsLeft) return 'actions';
+    if (x > identityRight && x < actionsLeft) return 'gap';
+    return null;
+  }
+
+  // eslint-disable-next-line unicorn/consistent-class-member-order -- public geometry queries stay grouped before private implementation helpers
+  #laneRect(lane: PaneChromeLane): DOMRect | undefined {
+    return (lane === 'header' ? this.#nodes.header : this.#nodes.toolbar)?.getBoundingClientRect();
+  }
+
+  pointInLane(point: Point, lane: PaneChromeLane): Point | null {
+    const rect = this.#laneRect(lane);
+    return rect ? { x: point.x - rect.left, y: point.y - rect.top } : null;
+  }
+
+  laneSize(lane: PaneChromeLane): { width: number; height: number } {
+    const rect = this.#laneRect(lane);
+    return { width: rect?.width ?? 0, height: rect?.height ?? 0 };
+  }
+
+  segmentGeometry(segment: PaneChromeSegment): PaneChromeSegmentGeometry | undefined {
+    if (segment === 'toolbar') {
+      const toolbar = this.#rects.toolbar;
+      return toolbar ? { left: 0, right: toolbar.width, width: toolbar.width } : undefined;
+    }
+    const header = this.#rects.header;
+    const rect = this.#rects[segment];
+    if (!header || !rect) return;
+    if (segment === 'identity') return { left: 0, right: rect.width, width: rect.width };
+    return { left: header.width - rect.width, right: header.width, width: rect.width };
+  }
+
+  headerInset(): number {
+    const height = this.#rects.header?.height;
+    return height === undefined ? 0 : Math.max(0, Math.round(height));
+  }
+
+  floatingChromeInset(): number {
+    const root = this.#nodes.root?.getBoundingClientRect();
+    if (!root) return 0;
+    const chromeBottom =
+      this.#nodes.toolbar?.getBoundingClientRect().bottom ?? this.#nodes.header?.getBoundingClientRect().bottom ?? root.top;
+    return Math.max(0, Math.round(chromeBottom - root.top));
+  }
+
+  visibleChromeInset(includeHeader: boolean, includeToolbar: boolean): number {
+    const root = this.#nodes.root?.getBoundingClientRect();
+    if (!root) return 0;
+    let bottom = root.top;
+    if (includeHeader) bottom = Math.max(bottom, this.#nodes.header?.getBoundingClientRect().bottom ?? root.top);
+    if (includeToolbar) bottom = Math.max(bottom, this.#nodes.toolbar?.getBoundingClientRect().bottom ?? root.top);
+    return Math.max(0, Math.round(bottom - root.top));
+  }
+
+  #register(key: GeometryKey, node: HTMLElement): ActionReturn {
+    const previous = this.#nodes[key];
+    if (previous && previous !== node) this.#unobserve(previous);
+    this.#nodes[key] = node;
+    this.#observe(node);
+    return {
+      destroy: () => {
+        this.#unobserve(node);
+        if (this.#nodes[key] !== node) return;
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- action teardown removes its DOM registration
+        delete this.#nodes[key];
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- action teardown removes its cached measurement
+        delete this.#rects[key];
+        this.#onMeasure();
+      },
+    };
+  }
+
+  #observe(node: HTMLElement): void {
+    this.#measure();
+    const observer = new ResizeObserver(() => this.#measure());
+    observer.observe(node);
+    this.#observers.set(node, observer);
+  }
+
+  #measure(): void {
+    for (const key of geometryKeys) {
+      const node = this.#nodes[key];
+      if (node) this.#rects[key] = node.getBoundingClientRect();
+    }
+    this.#onMeasure();
+  }
+
+  #unobserve(node: HTMLElement): void {
+    this.#observers.get(node)?.disconnect();
+    this.#observers.delete(node);
+  }
+}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome-test-root.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome-test-root.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { PANE_CHROME_EXPANSION_EASING, paneChromeExpansionTiming, setupZenModePaneChrome } from './zen-mode-pane-chrome.svelte';
+  import ZenModePaneChromeEffects from './ZenModePaneChromeEffects.svelte';
+  import ZenModePaneChromeSegment from './ZenModePaneChromeSegment.svelte';
+
+  type Props = { initialActive?: boolean; reclassifyActionsOnEntry?: boolean; toolbarRows?: 1 | 2 };
+
+  let { initialActive = true, reclassifyActionsOnEntry = false, toolbarRows = 1 }: Props = $props();
+  let active = $state(initialActive);
+  let headerPointerDownCount = $state(0);
+  let actionsMounted = $state(true);
+  let actionsMenuOpen = $state(false);
+  const chrome = setupZenModePaneChrome({ active: () => active, focused: () => true });
+  const registerRoot = chrome.registerRoot;
+  const registerHeader = chrome.registerHeaderLane;
+  const registerIdentity = (node: HTMLElement) => chrome.registerSegment('identity', node);
+  const registerActions = (node: HTMLElement) => chrome.registerSegment('actions', node);
+  const registerToolbar = chrome.registerToolbarLane;
+  const zoomAttachment = chrome.attachmentHandle();
+  const expansionTiming = $derived(paneChromeExpansionTiming(chrome.phase === 'expanding' ? chrome.expansionPace : 'standard'));
+
+  export function setActive(next: boolean): void {
+    active = next;
+  }
+
+  export function holdActions(): void {
+    chrome.hold('actions', 'hover');
+  }
+
+  export function holdChromeAttachment(): void {
+    zoomAttachment.hold();
+  }
+
+  export function releaseChromeAttachment(): void {
+    zoomAttachment.release();
+  }
+
+  export function holdChromeAttachmentAt(clientX: number, clientY: number): void {
+    zoomAttachment.hold(new PointerEvent('pointermove', { clientX, clientY, pointerType: 'mouse' }));
+  }
+
+  export function removeActions(): void {
+    actionsMounted = false;
+  }
+
+  export function openActionsMenu(): void {
+    actionsMenuOpen = true;
+  }
+</script>
+
+<div
+  style="position: relative; width: 600px; height: 240px"
+  data-chrome-root
+  onpointerleave={() => chrome.handlePointerLeave()}
+  onpointermove={(event) => chrome.handlePointerMove(event)}
+  role="presentation"
+  use:registerRoot
+>
+  <button style="position: absolute; inset: 0" data-editor-target type="button">Editor</button>
+  <div
+    style="position: absolute; top: 0; right: 0; left: 0; height: 37px"
+    style:pointer-events="none"
+    aria-label="Pane header test"
+    data-chrome-header
+    onpointerdown={() => (headerPointerDownCount += 1)}
+    role="region"
+    use:registerHeader
+  >
+    <ZenModePaneChromeEffects lane="header" />
+    <div
+      style="position: absolute; inset: 0"
+      style:--zen-pane-chrome-foreground-radius={`${chrome.foregroundRevealRadius('header')}px`}
+      style:clip-path={chrome.headerLaneInteractionClip()}
+      style:cursor="grab"
+      style:pointer-events={chrome.isHeaderLaneInteractive() ? 'auto' : 'none'}
+      style:transition={`clip-path ${expansionTiming.backgroundExpandMs}ms ${PANE_CHROME_EXPANSION_EASING}`}
+      aria-hidden="true"
+      data-chrome-header-foreground-hit
+    ></div>
+    <ZenModePaneChromeSegment
+      style={`position: absolute; top: 0; left: 0; width: ${reclassifyActionsOnEntry && active ? '500px' : '140px'}; height: 36px`}
+      {active}
+      contentCursor="grab"
+      data-chrome-identity
+      register={registerIdentity}
+      segment="identity"
+    >
+      Identity
+    </ZenModePaneChromeSegment>
+    {#if actionsMounted}
+      <ZenModePaneChromeSegment
+        style="position: absolute; top: 0; right: 0; width: 180px; height: 36px"
+        {active}
+        contentCursor="grab"
+        data-chrome-actions
+        register={registerActions}
+        segment="actions"
+      >
+        <button
+          aria-expanded={actionsMenuOpen}
+          aria-haspopup="menu"
+          data-chrome-focus-toggle
+          onclick={(event) => {
+            chrome.prepareEntryReveal('actions', event);
+            active = !active;
+          }}
+          type="button"
+        >
+          Actions
+        </button>
+      </ZenModePaneChromeSegment>
+    {/if}
+  </div>
+  <div style="position: absolute; top: 37px; right: 0; left: 0; pointer-events: none" data-chrome-toolbar-lane use:registerToolbar>
+    <ZenModePaneChromeEffects lane="toolbar" toolbarSeparatorOffsets={toolbarRows === 2 ? [40] : []} />
+    <ZenModePaneChromeSegment {active} data-chrome-toolbar segment="toolbar">
+      <div style:height="41px" data-chrome-toolbar-content>Toolbar</div>
+      {#if toolbarRows === 2}
+        <div style="height: 41px" data-chrome-toolbar-expanded-content>Expanded toolbar</div>
+      {/if}
+    </ZenModePaneChromeSegment>
+  </div>
+  <div
+    style="position: absolute; top: 0; right: 0; width: 180px; height: 36px"
+    data-chrome-reveal-exclusion
+    data-pane-chrome-reveal-exclusion
+  ></div>
+</div>
+
+<output data-chrome-phase>{chrome.phase}</output>
+<output data-chrome-occlusion>{chrome.topOcclusion}</output>
+<output data-chrome-header-inset>{chrome.headerInset}</output>
+<output data-chrome-zoom-top>{chrome.floatingZoomTopInset}</output>
+<output data-chrome-zoom-inset>{chrome.floatingZoomInset}</output>
+<output data-chrome-zoom-ready>{zoomAttachment.discoverable()}</output>
+<output data-chrome-zoom-attached>{zoomAttachment.attached()}</output>
+<output data-chrome-header-pointer>{JSON.stringify(chrome.pointerInLane('header'))}</output>
+<output data-chrome-toolbar-pointer>{JSON.stringify(chrome.pointerInLane('toolbar'))}</output>
+<output data-chrome-header-pointer-down-count>{headerPointerDownCount}</output>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome.browser.test.ts
@@ -1,0 +1,864 @@
+import '../../../../../app.css';
+
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ZenModePaneChromeTestRoot from './zen-mode-pane-chrome-test-root.svelte';
+
+let component: ReturnType<typeof mount> | undefined;
+
+const move = (target: HTMLElement, x: number, y: number, pointerType = 'mouse') => {
+  target.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: x, clientY: y, pointerType }));
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  const noop = () => null;
+  vi.spyOn(window, 'matchMedia').mockImplementation(
+    (query) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: noop,
+        removeEventListener: noop,
+        addListener: noop,
+        removeListener: noop,
+        dispatchEvent: () => true,
+      }) satisfies MediaQueryList,
+  );
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  if (component) await unmount(component);
+  component = undefined;
+  document.body.replaceChildren();
+});
+
+describe('pane focus-mode chrome', () => {
+  it('reveals only the directly intended header segment', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-top]')?.value).toBe('78');
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('37');
+  });
+
+  it('keeps a revealed header foreground draggable while transparent chrome passes through', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+    const clientX = rect.left + 40;
+    const clientY = rect.top + 18;
+
+    move(root, clientX, clientY);
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    const hit = document.elementFromPoint(clientX, clientY) as HTMLElement | null;
+    expect(hit?.closest('[data-chrome-identity]')).not.toBeNull();
+    expect(getComputedStyle(hit as HTMLElement).cursor).toBe('grab');
+
+    hit?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0, isPrimary: true }));
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-header-pointer-down-count]')?.value).toBe('1');
+  });
+
+  it('hands the revealed header lane foreground to pane drag while the expansion is still spreading', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+    const clientX = rect.left + 300;
+    const clientY = rect.top + 18;
+
+    move(root, clientX, clientY);
+    vi.advanceTimersByTime(999);
+    await tick();
+    expect(
+      (document.elementFromPoint(clientX, clientY) as HTMLElement | null)?.closest(
+        '[data-chrome-header-foreground-hit], [data-chrome-identity], [data-chrome-actions]',
+      ),
+    ).toBeNull();
+
+    vi.advanceTimersByTime(1);
+    await tick();
+    const hit = document.querySelector<HTMLElement>('[data-chrome-header-foreground-hit]');
+    expect(hit?.style.pointerEvents).toBe('auto');
+    expect(hit?.style.clipPath).toContain('circle(');
+    expect(getComputedStyle(hit as HTMLElement).cursor).toBe('grab');
+
+    hit?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0, isPrimary: true }));
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-header-pointer-down-count]')?.value).toBe('1');
+  });
+
+  it('starts hidden and applies normal hover intent to the segment under the pointer after activation', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body, props: { initialActive: false } });
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-top]')?.value).toBe('78');
+
+    (component as typeof component & { setActive(next: boolean): void }).setActive(true);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-top]')?.value).toBe('78');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('idle');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(399);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('pending');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('0');
+
+    vi.advanceTimersByTime(1);
+    await tick();
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('0');
+  });
+
+  it('enters with the chrome under the existing pointer already revealed', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body, props: { initialActive: false } });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 56);
+    (component as typeof component & { setActive(next: boolean): void }).setActive(true);
+    await tick();
+
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-inset]')?.value).toBe('78');
+  });
+
+  it('keeps the clicked actions segment revealed across repeated entry when layout reclassifies the pointer', async () => {
+    component = mount(ZenModePaneChromeTestRoot, {
+      target: document.body,
+      props: { initialActive: false, reclassifyActionsOnEntry: true },
+    });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    const toggle = document.querySelector<HTMLButtonElement>('[data-chrome-focus-toggle]');
+    if (!root || !toggle) throw new Error('Missing pane chrome fixture');
+    const toggleRect = toggle.getBoundingClientRect();
+
+    move(root, toggleRect.left + toggleRect.width / 2, toggleRect.top + toggleRect.height / 2);
+    toggle.click();
+    await tick();
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('1');
+
+    toggle.click();
+    await tick();
+    toggle.click();
+    await tick();
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('1');
+  });
+
+  it('places toolbar effects and content after the shared header boundary', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+
+    const header = document.querySelector<HTMLElement>('[data-chrome-header]');
+    const toolbarEffects = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-effects]');
+    const toolbar = document.querySelector<HTMLElement>('[data-chrome-toolbar-content]');
+    if (!header || !toolbarEffects || !toolbar) throw new Error('Missing pane chrome fixture');
+
+    expect(toolbarEffects.getBoundingClientRect().top).toBe(header.getBoundingClientRect().bottom);
+    expect(toolbar.getBoundingClientRect().top).toBe(header.getBoundingClientRect().bottom);
+  });
+
+  it('drops a stale segment hover hold when layout changes beneath the pointer', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    (component as typeof component & { holdActions(): void }).holdActions();
+    await tick();
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-surface="actions"]')?.style.opacity).toBe('1');
+
+    root.style.width = '720px';
+    await vi.advanceTimersByTimeAsync(16);
+    move(root, rect.left + 360, rect.top + 18);
+    vi.advanceTimersByTime(400);
+    await tick();
+
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-surface="actions"]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-lane-surface]')?.dataset.zenPaneChromeSpotX).toBe('360');
+  });
+
+  it('promotes toolbar intent and clears the group with one grace and fade', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(400);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('spot');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-surface]')?.style.maskImage).toContain('radial-gradient');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.inert).toBe(true);
+
+    vi.advanceTimersByTime(500);
+    await tick();
+    const toolbarForeground = document.querySelector<HTMLElement>('[data-chrome-toolbar]');
+    const toolbarEffects = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-effects]');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-surface]')?.style.maskImage).toContain('radial-gradient');
+    expect(toolbarForeground?.style.opacity).toBe('1');
+    expect(toolbarForeground?.inert).toBe(true);
+    expect(toolbarForeground?.style.maskImage).toContain('radial-gradient');
+    expect(toolbarForeground?.style.getPropertyValue('--zen-pane-chrome-foreground-opacity')).toBe('0');
+    expect(toolbarForeground?.style.getPropertyValue('--zen-pane-chrome-foreground-radius')).toBe('88px');
+    expect(toolbarEffects?.style.getPropertyValue('--zen-pane-chrome-spot-radius')).not.toBe('88px');
+
+    vi.advanceTimersByTime(100);
+    await tick();
+    expect(toolbarForeground?.inert).toBe(false);
+    expect(toolbarForeground?.style.getPropertyValue('--zen-pane-chrome-foreground-opacity')).toBe('1');
+    expect(toolbarForeground?.style.getPropertyValue('--zen-pane-chrome-foreground-radius')).not.toBe('88px');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('1');
+    expect(
+      document
+        .querySelector<HTMLElement>('[data-chrome-toolbar]')
+        ?.contains(document.querySelector('[data-zen-pane-chrome-toolbar-surface]')),
+    ).toBe(false);
+    expect(document.querySelector('[data-zen-pane-chrome-toolbar-engaged-surface]')).toBeNull();
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-spot]')?.style.maskImage).toContain(
+      'radial-gradient',
+    );
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('78');
+
+    move(root, rect.left + 300, rect.top + 140);
+    vi.advanceTimersByTime(1000);
+    move(root, rect.left + 320, rect.top + 150);
+    vi.advanceTimersByTime(500);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('fading');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('0');
+
+    vi.advanceTimersByTime(400);
+    await tick();
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('0');
+  });
+
+  it('makes the zoom hover target available as toolbar expansion starts', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(400);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-header-inset]')?.value).toBe('37');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-inset]')?.value).toBe('37');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-attached]')?.value).toBe('true');
+
+    vi.advanceTimersByTime(180);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-header-inset]')?.value).toBe('37');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-inset]')?.value).toBe('37');
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(99);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('preview');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+
+    vi.advanceTimersByTime(1);
+    await tick();
+
+    const toolbarEffects = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-effects]');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('spot');
+    expect(toolbarEffects?.style.getPropertyValue('--zen-pane-chrome-spot-radius')).toBe('88px');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-surface]')?.style.maskImage).toContain('radial-gradient');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('37');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-inset]')?.value).toBe('37');
+
+    vi.advanceTimersByTime(16);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+    expect(toolbarEffects?.style.getPropertyValue('--zen-pane-chrome-spot-radius')).not.toBe('88px');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-inset]')?.value).toBe('78');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-ready]')?.value).toBe('true');
+  });
+
+  it('hit-tests only the toolbar foreground region as it reveals', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    const editor = document.querySelector<HTMLElement>('[data-editor-target]');
+    if (!root || !editor) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+    const originX = rect.left + 300;
+    const originY = rect.top + 56;
+
+    move(root, originX, originY);
+    vi.advanceTimersByTime(999);
+    await tick();
+
+    expect(document.elementFromPoint(originX, originY)).toBe(editor);
+
+    vi.advanceTimersByTime(1);
+    await tick();
+
+    expect(document.elementFromPoint(originX, originY)?.closest('[data-chrome-toolbar]')).not.toBeNull();
+    expect(document.elementFromPoint(rect.left + 20, originY)).toBe(editor);
+  });
+
+  it('attaches the zoom surface directly to a revealed header', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(580);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-header-inset]')?.value).toBe('37');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('37');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-inset]')?.value).toBe('37');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-zoom-attached]')?.value).toBe('true');
+  });
+
+  it('keeps a revealed header visible while its attached zoom control is hovered', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(580);
+    await tick();
+
+    (component as typeof component & { holdChromeAttachment(): void }).holdChromeAttachment();
+    vi.advanceTimersByTime(2000);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).not.toBe('fading');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+  });
+
+  it('lets an attachment hold chrome revealed later without revealing chrome itself', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    (component as typeof component & { holdChromeAttachment(): void }).holdChromeAttachment();
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('idle');
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(580);
+    move(root, rect.left + 300, rect.top + 140);
+    vi.advanceTimersByTime(2000);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('held');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+  });
+
+  it('does not reveal the toolbar when attached zoom takes hover ownership', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(580);
+    await tick();
+
+    move(root, rect.right - 40, rect.top + 54);
+    (component as typeof component & { holdChromeAttachment(): void }).holdChromeAttachment();
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('37');
+  });
+
+  it('does not project an attached zoom hover into either chrome lane', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(580);
+    await tick();
+
+    (component as typeof component & { holdChromeAttachmentAt(clientX: number, clientY: number): void }).holdChromeAttachmentAt(
+      rect.right - 40,
+      rect.top + 54,
+    );
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-header-pointer]')?.value).toBe('null');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-toolbar-pointer]')?.value).toBe('null');
+  });
+
+  it('publishes the pointer only to the lane under it', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(1900);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-header-pointer]')?.value).toBe('null');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-toolbar-pointer]')?.value).not.toBe('null');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-engaged-spot]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-spot]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-engaged-edge]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-edge]')?.style.opacity).toBe('1');
+
+    move(root, rect.left + 40, rect.top + 18);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-header-pointer]')?.value).not.toBe('null');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-toolbar-pointer]')?.value).toBe('null');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-engaged-spot]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-spot]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-engaged-edge]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-edge]')?.style.opacity).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-engaged-edge]')?.dataset.zenPaneChromeEngagedEdgeRadius).toBe(
+      '80',
+    );
+  });
+
+  it('lights both toolbar boundaries around the pointer', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    const toolbarEffects = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-effects]');
+    if (!root || !toolbarEffects) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(1900);
+    await tick();
+
+    const topEdge = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="top"]');
+    const bottomEdge = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="bottom"]');
+    expect(topEdge?.getBoundingClientRect().top).toBe(toolbarEffects.getBoundingClientRect().top - 1);
+    expect(bottomEdge?.getBoundingClientRect().bottom).toBe(toolbarEffects.getBoundingClientRect().bottom);
+  });
+
+  it('keeps the boundary between two toolbar rows and lights it around the pointer', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body, props: { toolbarRows: 2 } });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    const toolbarEffects = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-effects]');
+    if (!root || !toolbarEffects) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(1900);
+    await tick();
+
+    const transientSeparator = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-edge-boundary="separator"]');
+    const engagedSeparator = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="separator"]');
+    expect(transientSeparator?.getBoundingClientRect().top).toBe(toolbarEffects.getBoundingClientRect().top + 40);
+    expect(engagedSeparator?.getBoundingClientRect().top).toBe(toolbarEffects.getBoundingClientRect().top + 40);
+  });
+
+  it('confines the pointer light and its boundaries to the active toolbar row', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body, props: { toolbarRows: 2 } });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    const engagedSpot = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-engaged-spot]');
+    if (!root || !engagedSpot) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(1900);
+    await tick();
+
+    const firstRowClip = engagedSpot.style.clipPath;
+    expect(firstRowClip).not.toBe('');
+    expect(document.querySelector('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="top"]')).not.toBeNull();
+    expect(document.querySelector('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="separator"]')).not.toBeNull();
+    expect(document.querySelector('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="bottom"]')).toBeNull();
+
+    move(root, rect.left + 300, rect.top + 100);
+    await tick();
+
+    expect(engagedSpot.style.clipPath).not.toBe(firstRowClip);
+    expect(document.querySelector('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="top"]')).toBeNull();
+    expect(document.querySelector('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="separator"]')).not.toBeNull();
+    expect(document.querySelector('[data-zen-pane-chrome-toolbar-engaged-edge-boundary="bottom"]')).not.toBeNull();
+  });
+
+  it('keeps the transient segment surface underneath its engaged hover fade', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(1400);
+    await tick();
+
+    const laneSurface = document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-lane-surface]');
+    expect(laneSurface?.style.maskImage).not.toBe('linear-gradient(transparent, transparent)');
+  });
+
+  it('leaves a fading engaged spot at its last pointer position when the pointer changes lanes', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    const engagedSpot = document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-engaged-spot]');
+    if (!root || !engagedSpot) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(1400);
+    await tick();
+    const lastPointerMask = engagedSpot.style.maskImage;
+
+    move(root, rect.left + 300, rect.top + 56);
+    await tick();
+
+    expect(engagedSpot.style.opacity).toBe('0');
+    expect(engagedSpot.style.maskImage).toBe(lastPointerMask);
+  });
+
+  it('shows a middle-gap spot before expanding both header segments', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 18);
+    vi.advanceTimersByTime(400);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('spot');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]')?.value).toBe('0');
+    expect(document.querySelector<HTMLElement>('[data-chrome-header-foreground-hit]')?.style.pointerEvents).toBe('none');
+    expect(document.querySelector('[data-zen-pane-chrome-header-lane-surface]')).not.toBeNull();
+    expect(document.querySelectorAll('[data-zen-pane-chrome-header-surface]')).toHaveLength(2);
+
+    move(root, rect.left + 340, rect.top + 18);
+    await tick();
+    const laneSurface = document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-lane-surface]');
+    expect(laneSurface?.dataset.zenPaneChromeSpotX).toBe('340');
+    expect(laneSurface?.dataset.zenPaneChromeSpotStrength).toBe('0.7');
+
+    vi.advanceTimersByTime(600);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-lane-surface]')?.style.maskImage).toContain('radial-gradient');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.maskImage).toContain('radial-gradient');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+  });
+
+  it('shares cold hover intent while the pointer moves between the header and toolbar lanes', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 18);
+    vi.advanceTimersByTime(250);
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(150);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('spot');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-surface]')?.style.maskImage).toContain('radial-gradient');
+
+    vi.advanceTimersByTime(250);
+    move(root, rect.left + 340, rect.top + 18);
+    vi.advanceTimersByTime(250);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-toolbar]')?.style.opacity).toBe('0');
+  });
+
+  it('publishes one chrome inset as each revealed lane joins the layout', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+    const inset = document.querySelector<HTMLOutputElement>('[data-chrome-header-inset]');
+    const topInset = document.querySelector<HTMLOutputElement>('[data-chrome-occlusion]');
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(900);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+    expect(inset?.value).toBe('37');
+    expect(topInset?.value).toBe('78');
+
+    vi.advanceTimersByTime(1000);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('held');
+    expect(inset?.value).toBe('37');
+    expect(topInset?.value).toBe('78');
+  });
+
+  it('keeps an already revealed header segment stable while toolbar expansion fills the remaining chrome', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18);
+    vi.advanceTimersByTime(400);
+    await tick();
+    const identity = document.querySelector<HTMLElement>('[data-chrome-identity]');
+    expect(identity?.style.opacity).toBe('1');
+    expect(identity?.style.maskImage).toBe('none');
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(116);
+    await tick();
+
+    const headerSurface = document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-lane-surface]');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+    expect(identity?.style.opacity).toBe('1');
+    expect(identity?.style.maskImage).toBe('none');
+    expect(headerSurface?.style.maskImage).toContain('radial-gradient');
+    expect(headerSurface?.style.maskImage).toContain('linear-gradient');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.maskImage).toContain('radial-gradient');
+
+    const toolbarEffects = document.querySelector<HTMLElement>('[data-zen-pane-chrome-toolbar-effects]');
+    expect(toolbarEffects?.style.transition).toContain('520ms');
+    vi.advanceTimersByTime(560);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('held');
+  });
+
+  it('keeps an already unified header surface connected while the toolbar expands', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 18);
+    vi.advanceTimersByTime(1900);
+    await tick();
+
+    const headerSurface = document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-lane-surface]');
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('held');
+    expect(headerSurface?.style.maskImage).toBe('linear-gradient(black, black)');
+
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(116);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+    expect(headerSurface?.style.maskImage).toBe('linear-gradient(black, black)');
+  });
+
+  it('keeps the two-stage toolbar reveal running when visible chrome or an attachment takes hold', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 18);
+    vi.advanceTimersByTime(1900);
+    move(root, rect.left + 300, rect.top + 56);
+    vi.advanceTimersByTime(116);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+
+    (component as typeof component & { holdActions(): void }).holdActions();
+    (component as typeof component & { holdChromeAttachment(): void }).holdChromeAttachment();
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('expanding');
+  });
+
+  it('keeps the pointer light active when the pointer returns to an already revealed header gap', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 18);
+    vi.advanceTimersByTime(1900);
+    move(root, rect.left + 300, rect.top + 140);
+    move(root, rect.left + 340, rect.top + 18);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('held');
+    expect(document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-engaged-spot]')?.style.opacity).toBe('1');
+  });
+
+  it('cancels the shared fade when the pointer returns to revealed chrome', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 300, rect.top + 18);
+    vi.advanceTimersByTime(1900);
+    move(root, rect.left + 300, rect.top + 140);
+    vi.advanceTimersByTime(1500);
+    await tick();
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('fading');
+
+    move(root, rect.left + 300, rect.top + 18);
+    vi.advanceTimersByTime(400);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('held');
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('1');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('1');
+  });
+
+  it('releases an open-menu hold when its segment is removed', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+
+    (component as typeof component & { openActionsMenu(): void }).openActionsMenu();
+    await tick();
+    await vi.advanceTimersByTimeAsync(0);
+    (component as typeof component & { removeActions(): void }).removeActions();
+    await tick();
+    root.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true, pointerType: 'mouse' }));
+    vi.advanceTimersByTime(1900);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('idle');
+  });
+
+  it('keeps the trailing segment surface anchored after the pane width changes', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.right - 40, rect.top + 18);
+    vi.advanceTimersByTime(500);
+    await tick();
+
+    const surface = document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-surface="actions"]');
+    const header = document.querySelector<HTMLElement>('[data-zen-pane-chrome-header-effects]');
+    expect(surface).not.toBeNull();
+    expect(header).not.toBeNull();
+
+    root.style.width = '480px';
+    await vi.advanceTimersByTimeAsync(16);
+    await tick();
+
+    expect(surface?.getBoundingClientRect().right).toBe(header?.getBoundingClientRect().right);
+  });
+
+  it('recomputes the middle gap hit target after the pane widens', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+
+    root.style.width = '720px';
+    await vi.advanceTimersByTimeAsync(16);
+    await tick();
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 480, rect.top + 18);
+    vi.advanceTimersByTime(400);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('spot');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('0');
+  });
+
+  it('ignores touch pointer intent', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    if (!root) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(root, rect.left + 40, rect.top + 18, 'touch');
+    vi.advanceTimersByTime(1000);
+    await tick();
+
+    expect(document.querySelector<HTMLElement>('[data-chrome-identity]')?.style.opacity).toBe('0');
+  });
+
+  it('ignores pointer intent owned by an overlapping panel', async () => {
+    component = mount(ZenModePaneChromeTestRoot, { target: document.body });
+    await tick();
+    const root = document.querySelector<HTMLElement>('[data-chrome-root]');
+    const exclusion = document.querySelector<HTMLElement>('[data-chrome-reveal-exclusion]');
+    if (!root || !exclusion) throw new Error('Missing pane chrome fixture');
+    const rect = root.getBoundingClientRect();
+
+    move(exclusion, rect.right - 40, rect.top + 18);
+    vi.advanceTimersByTime(1000);
+    await tick();
+
+    expect(document.querySelector<HTMLOutputElement>('[data-chrome-phase]')?.value).toBe('idle');
+    expect(document.querySelector<HTMLElement>('[data-chrome-actions]')?.style.opacity).toBe('0');
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome.svelte.ts
@@ -1,0 +1,952 @@
+import { hoverIntent } from '@typie/ui/actions';
+import { createStableContext } from '@typie/ui/context/stable';
+import { smootherstep } from '@typie/ui/utils';
+import { untrack } from 'svelte';
+import { PaneChromeGeometry } from './zen-mode-pane-chrome-geometry';
+import type { HoverIntentParameter } from '@typie/ui/actions';
+import type { ActionReturn as SvelteActionReturn } from 'svelte/action';
+import type { PaneChromeLane, PaneChromeSegment, PaneChromeSegmentGeometry } from './zen-mode-pane-chrome-geometry';
+
+export type { PaneChromeLane, PaneChromeSegment, PaneChromeSegmentGeometry } from './zen-mode-pane-chrome-geometry';
+export type PaneChromePhase = 'idle' | 'pending' | 'preview' | 'spot' | 'expanding' | 'held' | 'fading';
+export type PaneChromeTone = 'transient' | 'engaged';
+export type PaneChromeExpansionPace = 'standard' | 'adjacent';
+type PaneChromePoint = { x: number; y: number };
+type PaneChromeStablePhase = Exclude<PaneChromePhase, 'spot' | 'expanding' | 'fading'>;
+type PaneChromeTransition =
+  | { phase: PaneChromeStablePhase }
+  | { phase: 'spot'; spot: PaneChromePoint; spotLane: PaneChromeLane }
+  | {
+      phase: 'expanding';
+      spot: PaneChromePoint;
+      spotLane: PaneChromeLane;
+      expansionOrigin: PaneChromePoint;
+      expansionTargets: Record<PaneChromeSegment, boolean>;
+      expansionPace: PaneChromeExpansionPace;
+      foregroundRevealStarted: Record<PaneChromeSegment, boolean>;
+    }
+  | { phase: 'fading'; spot: PaneChromePoint | null; spotLane: PaneChromeLane | null };
+
+export type PaneChromeExpansionTiming = {
+  spotEnterMs: number;
+  spotSurfaceMs: number;
+  foregroundDelayMs: number;
+  backgroundExpandMs: number;
+  totalMs: number;
+};
+
+export type PaneChromeHoldHandle = {
+  hold(reason: string): void;
+  release(reason: string): void;
+};
+
+export type PaneChromeAttachmentHandle = {
+  hold(event?: PointerEvent): void;
+  release(): void;
+  discoverable(): boolean;
+  attached(): boolean;
+  pointer(): PaneChromePoint | null;
+};
+
+type PaneChromeOptions = {
+  active: () => boolean;
+  focused: () => boolean;
+};
+
+type ActionReturn = { destroy(): void };
+type HoverIntentActionReturn = SvelteActionReturn<HoverIntentParameter>;
+
+const INTENT_MS = 400;
+const GAP_DWELL_MS = 500;
+export const PANE_CHROME_FOREGROUND_DELAY_MS = 100;
+export const PANE_CHROME_FOREGROUND_FADE_IN_MS = 180;
+export const PANE_CHROME_FADE_OUT_MS = 400;
+export const PANE_CHROME_BACKGROUND_EXPAND_MS = 900;
+export const PANE_CHROME_EXPANSION_MS = 1000;
+export const PANE_CHROME_FADE_WIDTH = 24;
+export const PANE_CHROME_SPOT_RADIUS = 88;
+export const PANE_CHROME_SPOT_MASK_INSET = 8;
+export const PANE_CHROME_SPOT_EDGE_WIDTH = 48;
+export const PANE_CHROME_EXPANSION_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)';
+export const PANE_CHROME_SINGLE_TOOLBAR_TOP_INSET = 78;
+export const PANE_CHROME_BOUNDARY = 1;
+const EXIT_GRACE_MS = 1500;
+
+const STANDARD_EXPANSION_TIMING: PaneChromeExpansionTiming = {
+  spotEnterMs: 500,
+  spotSurfaceMs: 600,
+  foregroundDelayMs: PANE_CHROME_FOREGROUND_DELAY_MS,
+  backgroundExpandMs: PANE_CHROME_BACKGROUND_EXPAND_MS,
+  totalMs: PANE_CHROME_EXPANSION_MS,
+};
+const ADJACENT_EXPANSION_TIMING: PaneChromeExpansionTiming = {
+  spotEnterMs: 120,
+  spotSurfaceMs: 200,
+  foregroundDelayMs: 20,
+  backgroundExpandMs: 520,
+  totalMs: 560,
+};
+
+export const paneChromeExpansionTiming = (pace: PaneChromeExpansionPace): PaneChromeExpansionTiming =>
+  pace === 'adjacent' ? ADJACENT_EXPANSION_TIMING : STANDARD_EXPANSION_TIMING;
+
+const segments: readonly PaneChromeSegment[] = ['identity', 'actions', 'toolbar'];
+
+const emptyFlags = (): Record<PaneChromeSegment, boolean> => ({ identity: false, actions: false, toolbar: false });
+const EMPTY_FLAGS: Readonly<Record<PaneChromeSegment, boolean>> = Object.freeze(emptyFlags());
+const transientTones = (): Record<PaneChromeSegment, PaneChromeTone> => ({
+  identity: 'transient',
+  actions: 'transient',
+  toolbar: 'transient',
+});
+
+export const paneChromeRadialMask = (x: number, y: number, radiusVariable: string, opacityVariable: string): string => {
+  const edgeStops = Array.from({ length: 9 }, (_, index) => {
+    const progress = index / 8;
+    const alpha = 1 - smootherstep(progress);
+    return `rgb(0 0 0 / calc(${alpha} * var(${opacityVariable}))) calc(var(${radiusVariable}) - ${PANE_CHROME_SPOT_MASK_INSET + PANE_CHROME_SPOT_EDGE_WIDTH * (1 - progress)}px)`;
+  });
+  return `radial-gradient(circle at ${x}px ${y}px, rgb(0 0 0 / var(${opacityVariable})) 0, rgb(0 0 0 / var(${opacityVariable})) calc(var(${radiusVariable}) - ${PANE_CHROME_SPOT_MASK_INSET + PANE_CHROME_SPOT_EDGE_WIDTH}px), ${edgeStops.join(', ')})`;
+};
+
+export const paneChromeRevealTargets = (zone: PaneChromeSegment | 'gap'): readonly PaneChromeSegment[] =>
+  zone === 'toolbar' ? segments : zone === 'gap' ? ['identity', 'actions'] : [zone];
+
+const [getZenModePaneChrome, setZenModePaneChrome] = createStableContext<ZenModePaneChrome>('dashboard.ZenModePaneChrome');
+
+export { getZenModePaneChrome };
+
+export class ZenModePaneChrome {
+  #options: PaneChromeOptions;
+  #active = $state(false);
+  #synced = false;
+  #suppressStaleHolds = false;
+  #coarsePointer = false;
+  #geometry: PaneChromeGeometry;
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperative hold registry; presentation state is mirrored separately
+  #holds = new Map<string, number>();
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperative MutationObserver bookkeeping
+  #menuRegistrations = new Map<HTMLElement, { observer: MutationObserver; segment: PaneChromeSegment; open: boolean }>();
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- every consumer owns an independent attachment lifetime
+  #attachmentHolds = new Set<symbol>();
+  #adjacentHoverIntent: HoverIntentActionReturn | undefined;
+  #adjacentZone: PaneChromeSegment | 'gap' | null = null;
+  #adjacentExpansionFrame: number | undefined;
+  #intentTimer: ReturnType<typeof setTimeout> | undefined;
+  #dwellTimer: ReturnType<typeof setTimeout> | undefined;
+  #foregroundTimer: ReturnType<typeof setTimeout> | undefined;
+  #expansionTimer: ReturnType<typeof setTimeout> | undefined;
+  #hideTimer: ReturnType<typeof setTimeout> | undefined;
+  #fadeTimer: ReturnType<typeof setTimeout> | undefined;
+  #pendingZone: PaneChromeSegment | 'gap' | null = null;
+  #pointerZone: PaneChromeSegment | 'gap' | null = null;
+  #lastPointer: { x: number; y: number } | null = null;
+  #preparedEntry: { zone: PaneChromeSegment; point: PaneChromePoint } | null = null;
+  #transition = $state.raw<PaneChromeTransition>({ phase: 'idle' });
+  shown = $state.raw(emptyFlags());
+  tone = $state.raw(transientTones());
+  pointer = $state.raw<PaneChromePoint | null>(null);
+  topOcclusion = $state(0);
+  layoutRevision = $state(0);
+
+  constructor(options: PaneChromeOptions) {
+    this.#options = options;
+    this.#geometry = new PaneChromeGeometry(() => {
+      this.layoutRevision += 1;
+      this.#measureOcclusion();
+    });
+  }
+
+  get phase(): PaneChromePhase {
+    return this.#transition.phase;
+  }
+
+  get foreground(): Readonly<Record<PaneChromeSegment, boolean>> {
+    return this.phase === 'fading' ? EMPTY_FLAGS : this.shown;
+  }
+
+  get spot(): PaneChromePoint | null {
+    return this.#transition.phase === 'spot' || this.#transition.phase === 'expanding' || this.#transition.phase === 'fading'
+      ? this.#transition.spot
+      : null;
+  }
+
+  get spotLane(): PaneChromeLane | null {
+    return this.#transition.phase === 'spot' || this.#transition.phase === 'expanding' || this.#transition.phase === 'fading'
+      ? this.#transition.spotLane
+      : null;
+  }
+
+  get expansionOrigin(): PaneChromePoint | null {
+    return this.#transition.phase === 'expanding' ? this.#transition.expansionOrigin : null;
+  }
+
+  get expansionTargets(): Readonly<Record<PaneChromeSegment, boolean>> {
+    return this.#transition.phase === 'expanding' ? this.#transition.expansionTargets : EMPTY_FLAGS;
+  }
+
+  get expansionPace(): PaneChromeExpansionPace {
+    return this.#transition.phase === 'expanding' ? this.#transition.expansionPace : 'standard';
+  }
+
+  get foregroundRevealStarted(): Readonly<Record<PaneChromeSegment, boolean>> {
+    return this.#transition.phase === 'expanding' ? this.#transition.foregroundRevealStarted : EMPTY_FLAGS;
+  }
+
+  sync(): void {
+    const active = this.#options.active();
+    const focused = this.#options.focused();
+
+    if (!active) {
+      this.#active = false;
+      this.#suppressStaleHolds = false;
+      this.#preparedEntry = null;
+      this.#reset();
+      this.#synced = true;
+      return;
+    }
+
+    const entered = this.#synced && !this.#active;
+    const preparedEntry = entered ? this.#preparedEntry : null;
+    if (entered) this.#preparedEntry = null;
+    this.#active = true;
+    this.#synced = true;
+    if (entered) this.#suppressStaleHolds = true;
+    this.#measureOcclusion();
+
+    if (this.#coarsePointer) {
+      if (focused) this.#revealAll(false);
+      else this.#reset();
+      return;
+    }
+
+    if (entered) {
+      if (preparedEntry) this.#revealEntry(preparedEntry.zone, preparedEntry.point);
+      else this.#revealEntryPointer();
+    }
+  }
+
+  // eslint-disable-next-line unicorn/consistent-class-member-order -- bound actions follow lifecycle synchronization for readability
+  registerRoot = (node: HTMLElement): ActionReturn => {
+    const geometryRegistration = this.#geometry.registerRoot(node);
+    const adjacentHoverIntent = hoverIntent(node, this.#adjacentHoverIntentParameter(false)) ?? undefined;
+    this.#adjacentHoverIntent = adjacentHoverIntent;
+
+    const media = window.matchMedia('(hover: none), (pointer: coarse)');
+    const syncPointer = () => {
+      this.#coarsePointer = media.matches;
+      this.sync();
+    };
+    syncPointer();
+    media.addEventListener('change', syncPointer);
+
+    return {
+      destroy: () => {
+        media.removeEventListener('change', syncPointer);
+        this.#cancelAdjacentIntent();
+        adjacentHoverIntent?.destroy?.();
+        geometryRegistration.destroy?.();
+        if (this.#adjacentHoverIntent === adjacentHoverIntent) this.#adjacentHoverIntent = undefined;
+      },
+    };
+  };
+
+  registerHeaderLane = (node: HTMLElement): ActionReturn => {
+    const geometryRegistration = this.#geometry.registerHeaderLane(node);
+    this.#refreshPointerAfterRegistration();
+    return {
+      destroy: () => geometryRegistration.destroy?.(),
+    };
+  };
+
+  registerToolbarLane = (node: HTMLElement): ActionReturn => {
+    const geometryRegistration = this.#geometry.registerToolbarLane(node);
+    this.#observeMenus(node, 'toolbar');
+    this.#refreshPointerAfterRegistration();
+    return {
+      destroy: () => {
+        geometryRegistration.destroy?.();
+        this.#unobserveMenus(node);
+      },
+    };
+  };
+
+  registerSegment(segment: Exclude<PaneChromeSegment, 'toolbar'>, node: HTMLElement): ActionReturn {
+    const geometryRegistration = this.#geometry.registerSegment(segment, node);
+    this.#observeMenus(node, segment);
+    this.#refreshPointerAfterRegistration();
+    return {
+      destroy: () => {
+        geometryRegistration.destroy?.();
+        this.#unobserveMenus(node);
+      },
+    };
+  }
+
+  handlePointerMove(event: PointerEvent): void {
+    if (event.pointerType === 'touch') return;
+    const excluded = event.target instanceof Element && event.target.closest('[data-pane-chrome-reveal-exclusion]') !== null;
+    this.#lastPointer = excluded ? null : { x: event.clientX, y: event.clientY };
+    if (!this.#active || this.#coarsePointer) return;
+    if (excluded) {
+      this.#pointerZone = null;
+      this.pointer = null;
+      this.#reconcileHoverHolds(null);
+      this.#syncTones();
+      this.#cancelIntent();
+      if (this.#anythingShown()) this.#scheduleHide();
+      return;
+    }
+    const zone = this.#zoneAt(event.clientX, event.clientY);
+    this.#suppressStaleHolds = false;
+    this.#pointerZone = zone;
+    this.pointer = zone === null ? null : { x: event.clientX, y: event.clientY };
+    this.#reconcileHoverHolds(zone);
+    this.#syncTones();
+    if (zone === null) {
+      this.#cancelIntent();
+      if (this.#anythingShown()) this.#scheduleHide();
+      return;
+    }
+
+    this.#clearHide();
+    if (this.phase === 'fading' && this.#anythingShown()) {
+      this.#cancelFade();
+      this.#showStablePhase('held');
+      this.#measureOcclusion();
+    }
+    const targets = paneChromeRevealTargets(zone);
+    if (this.#adjacentExpansionFrame !== undefined) {
+      if (targets.every((segment) => this.shown[segment])) {
+        this.#cancelIntent();
+      } else {
+        this.#adjacentZone = zone;
+        this.#pendingZone = zone;
+        this.#showSpot({ x: event.clientX, y: event.clientY }, zone === 'toolbar' ? 'toolbar' : 'header');
+        this.#measureOcclusion();
+      }
+      return;
+    }
+    if (this.phase === 'spot' && this.#pendingZone === zone && (zone === 'gap' || zone === 'toolbar')) {
+      this.#moveSpot({ x: event.clientX, y: event.clientY });
+      return;
+    }
+    if (targets.every((segment) => this.shown[segment])) {
+      this.#cancelIntent();
+      return;
+    }
+    if (this.#pendingZone === zone) return;
+    if (this.phase !== 'fading' && this.#anythingShown() && targets.some((segment) => !this.shown[segment])) {
+      this.#startAdjacentIntent(zone);
+      return;
+    }
+    this.#startIntent(zone, event.clientX, event.clientY);
+  }
+
+  handlePointerLeave(): void {
+    this.#lastPointer = null;
+    if (!this.#active || this.#coarsePointer) return;
+    this.#suppressStaleHolds = false;
+    this.#pointerZone = null;
+    this.pointer = null;
+    this.#reconcileHoverHolds(null);
+    this.#syncTones();
+    this.#cancelIntent();
+    this.#scheduleHide();
+  }
+
+  prepareEntryReveal(segment: PaneChromeSegment, event: Pick<PointerEvent, 'clientX' | 'clientY'>): void {
+    if (this.#options.active()) return;
+    this.#preparedEntry = { zone: segment, point: { x: event.clientX, y: event.clientY } };
+  }
+
+  hold(segment: PaneChromeSegment, reason: string): void {
+    if (!this.#active || this.#suppressStaleHolds) return;
+    const key = `${segment}:${reason}`;
+    this.#holds.set(key, (this.#holds.get(key) ?? 0) + 1);
+    this.#clearHide();
+    if (this.phase !== 'expanding') {
+      if (segment === 'toolbar') this.#revealAll(true);
+      else this.#reveal([segment], true);
+    }
+    this.#syncTones();
+  }
+
+  release(segment: PaneChromeSegment, reason: string): void {
+    const key = `${segment}:${reason}`;
+    const count = this.#holds.get(key) ?? 0;
+    if (count <= 1) this.#holds.delete(key);
+    else this.#holds.set(key, count - 1);
+    this.#syncTones();
+    this.#scheduleHide();
+  }
+
+  segmentHandle(segment: PaneChromeSegment): PaneChromeHoldHandle {
+    return {
+      hold: (reason) => this.hold(segment, reason),
+      release: (reason) => this.release(segment, reason),
+    };
+  }
+
+  attachmentHandle(): PaneChromeAttachmentHandle {
+    const owner = Symbol('pane-chrome-attachment');
+    return {
+      hold: (event) => this.#holdAttachment(owner, event),
+      release: () => this.#releaseAttachment(owner),
+      discoverable: () => this.#attachmentDiscoverable(),
+      attached: () => this.#attachmentAttached(),
+      pointer: () => this.#lastPointer,
+    };
+  }
+
+  isShown(segment: PaneChromeSegment): boolean {
+    return this.shown[segment] || !this.#options.active();
+  }
+
+  isSurfaceVisible(segment: PaneChromeSegment): boolean {
+    return (this.shown[segment] && this.phase !== 'fading') || !this.#options.active();
+  }
+
+  isForegroundVisible(segment: PaneChromeSegment): boolean {
+    return this.foreground[segment] || !this.#options.active();
+  }
+
+  isForegroundRevealStarted(segment: PaneChromeSegment): boolean {
+    return this.foregroundRevealStarted[segment];
+  }
+
+  isInteractive(segment: PaneChromeSegment): boolean {
+    if (!this.#options.active()) return true;
+    if (!this.shown[segment] || this.phase === 'fading') return false;
+    return this.phase !== 'expanding' || !this.expansionTargets[segment] || this.foregroundRevealStarted[segment];
+  }
+
+  isHeaderGapInteractive(): boolean {
+    if (!this.#options.active()) return true;
+    return this.phase !== 'expanding' && this.phase !== 'fading' && this.shown.identity && this.shown.actions;
+  }
+
+  isHeaderLaneInteractive(): boolean {
+    if (!this.#options.active()) return true;
+    if (this.phase === 'fading') return false;
+    if (this.phase === 'expanding' && (this.expansionTargets.identity || this.expansionTargets.actions)) {
+      return (
+        (this.expansionTargets.identity && this.foregroundRevealStarted.identity) ||
+        (this.expansionTargets.actions && this.foregroundRevealStarted.actions)
+      );
+    }
+    return this.isInteractive('identity') && this.isInteractive('actions');
+  }
+
+  headerLaneInteractionClip(): string {
+    if (!this.#options.active()) return 'none';
+    if (this.phase === 'expanding' && (this.expansionTargets.identity || this.expansionTargets.actions)) {
+      const origin = this.expansionOriginInLane('header');
+      if (!origin) return 'circle(0px at 0 0)';
+      return `circle(${this.foregroundRevealRadius('header')}px at ${origin.x}px ${origin.y}px)`;
+    }
+    return this.isInteractive('identity') && this.isInteractive('actions') ? 'none' : 'circle(0px at 0 0)';
+  }
+
+  isLaneSurfaceVisible(lane: PaneChromeLane): boolean {
+    if (!this.#options.active()) return true;
+    if (this.phase === 'fading') return false;
+    if (lane === 'toolbar') {
+      return this.spotLane === 'toolbar' || this.expansionTargets.toolbar || this.shown.toolbar;
+    }
+    return (
+      this.spotLane === 'header' ||
+      this.expansionTargets.identity ||
+      this.expansionTargets.actions ||
+      this.shown.identity ||
+      this.shown.actions
+    );
+  }
+
+  spotInLane(lane: PaneChromeLane): { x: number; y: number } | null {
+    void this.layoutRevision;
+    if (this.spotLane !== lane) return null;
+    const spot = this.spot;
+    return spot ? this.#geometry.pointInLane(spot, lane) : null;
+  }
+
+  pointerInLane(lane: PaneChromeLane): { x: number; y: number } | null {
+    void this.layoutRevision;
+    const pointer = this.pointer;
+    if (!pointer) return null;
+    const pointerLane = this.#pointerZone === null ? null : this.#pointerZone === 'toolbar' ? 'toolbar' : 'header';
+    if (pointerLane !== lane) return null;
+    return this.#geometry.pointInLane(pointer, lane);
+  }
+
+  get floatingZoomTopInset(): number {
+    void this.layoutRevision;
+    return this.#geometry.floatingChromeInset();
+  }
+
+  get floatingZoomInset(): number {
+    void this.layoutRevision;
+    if (this.phase === 'fading') return 0;
+    if (this.shown.toolbar) return this.floatingZoomTopInset;
+    if (this.shown.identity || this.shown.actions) return this.topOcclusion;
+    return 0;
+  }
+
+  get headerInset(): number {
+    void this.layoutRevision;
+    if (!this.#active || this.phase === 'fading' || (!this.shown.identity && !this.shown.actions)) return 0;
+    return this.#geometry.headerInset();
+  }
+
+  expansionOriginInLane(lane: PaneChromeLane): { x: number; y: number } | null {
+    void this.layoutRevision;
+    const origin = this.expansionOrigin;
+    return origin ? this.#geometry.pointInLane(origin, lane) : null;
+  }
+
+  laneSize(lane: PaneChromeLane): { width: number; height: number } {
+    void this.layoutRevision;
+    return this.#geometry.laneSize(lane);
+  }
+
+  segmentGeometry(segment: PaneChromeSegment): PaneChromeSegmentGeometry | undefined {
+    void this.layoutRevision;
+    return this.#geometry.segmentGeometry(segment);
+  }
+
+  foregroundMask(segment: PaneChromeSegment): string {
+    const geometry = this.segmentGeometry(segment);
+    const lane: PaneChromeLane = segment === 'toolbar' ? 'toolbar' : 'header';
+    const origin = this.expansionOriginInLane(lane);
+    if (!geometry || !origin || this.phase !== 'expanding' || !this.expansionTargets[segment]) return 'none';
+    return paneChromeRadialMask(
+      origin.x - geometry.left,
+      origin.y,
+      '--zen-pane-chrome-foreground-radius',
+      '--zen-pane-chrome-foreground-opacity',
+    );
+  }
+
+  foregroundClip(segment: PaneChromeSegment): string {
+    const geometry = this.segmentGeometry(segment);
+    const lane: PaneChromeLane = segment === 'toolbar' ? 'toolbar' : 'header';
+    const origin = this.expansionOriginInLane(lane);
+    if (!geometry || !origin || this.phase !== 'expanding' || !this.expansionTargets[segment]) return 'none';
+    return `circle(${this.foregroundRevealRadius(lane)}px at ${origin.x - geometry.left}px ${origin.y}px)`;
+  }
+
+  foregroundRevealRadius(lane: PaneChromeLane): number {
+    const { width, height } = this.laneSize(lane);
+    const revealStarted =
+      lane === 'toolbar'
+        ? this.expansionTargets.toolbar && this.foregroundRevealStarted.toolbar
+        : (this.expansionTargets.identity && this.foregroundRevealStarted.identity) ||
+          (this.expansionTargets.actions && this.foregroundRevealStarted.actions);
+    return revealStarted && this.phase === 'expanding'
+      ? Math.hypot(width, height) + PANE_CHROME_FADE_WIDTH + PANE_CHROME_SPOT_MASK_INSET
+      : PANE_CHROME_SPOT_RADIUS;
+  }
+
+  #showStablePhase(phase: PaneChromeStablePhase): void {
+    this.#transition = { phase };
+  }
+
+  #showSpot(spot: PaneChromePoint, spotLane: PaneChromeLane): void {
+    this.#transition = { phase: 'spot', spot, spotLane };
+  }
+
+  #moveSpot(spot: PaneChromePoint): void {
+    if (this.#transition.phase !== 'spot') return;
+    this.#transition = { ...this.#transition, spot };
+  }
+
+  #zoneAt(x: number, y: number): PaneChromeSegment | 'gap' | null {
+    return this.#geometry.zoneAt(x, y);
+  }
+
+  #revealEntryPointer(): void {
+    const point = this.#lastPointer;
+    if (!point) return;
+    const zone = this.#zoneAt(point.x, point.y);
+    if (zone === null) return;
+    this.#revealEntry(zone, point);
+  }
+
+  #revealEntry(zone: PaneChromeSegment | 'gap', point: PaneChromePoint): void {
+    this.#pointerZone = zone;
+    this.pointer = point;
+    this.#reconcileHoverHolds(zone);
+    this.#syncTones();
+    this.#reveal(paneChromeRevealTargets(zone), true);
+  }
+
+  #startIntent(zone: PaneChromeSegment | 'gap', x: number, y: number): void {
+    const origin = this.pointer ?? { x, y };
+    if (this.phase === 'pending' && this.#intentTimer) {
+      this.#pendingZone = zone;
+      return;
+    }
+    if (this.phase === 'spot' && this.#dwellTimer) {
+      this.#pendingZone = zone;
+      if (zone === 'identity' || zone === 'actions') {
+        clearTimeout(this.#dwellTimer);
+        this.#dwellTimer = undefined;
+        this.#reveal(paneChromeRevealTargets(zone), false);
+      } else {
+        this.#showSpot(origin, zone === 'toolbar' ? 'toolbar' : 'header');
+        this.#measureOcclusion();
+      }
+      return;
+    }
+
+    this.#cancelIntent();
+    this.#pendingZone = zone;
+    this.#showStablePhase('pending');
+    this.#intentTimer = setTimeout(() => {
+      this.#intentTimer = undefined;
+      const currentZone = this.#pendingZone;
+      if (currentZone === null) return;
+      if (currentZone === 'gap' || currentZone === 'toolbar') {
+        const currentOrigin = this.pointer ?? origin;
+        this.#showSpot(currentOrigin, currentZone === 'toolbar' ? 'toolbar' : 'header');
+        this.#measureOcclusion();
+        this.#dwellTimer = setTimeout(() => {
+          this.#dwellTimer = undefined;
+          const dwellZone = this.#pendingZone;
+          if (dwellZone === null) return;
+          this.#startExpansion(paneChromeRevealTargets(dwellZone));
+        }, GAP_DWELL_MS);
+      } else {
+        this.#reveal(paneChromeRevealTargets(currentZone), false);
+      }
+    }, INTENT_MS);
+  }
+
+  #adjacentHoverIntentParameter(intentEnabled: boolean): HoverIntentParameter {
+    return {
+      delay: INTENT_MS,
+      intentEnabled,
+      samples: 1,
+      onIntent: (event) => this.#startAdjacentSpot(event),
+    };
+  }
+
+  #startAdjacentIntent(zone: PaneChromeSegment | 'gap'): void {
+    this.#adjacentZone = zone;
+    const intent = this.#adjacentHoverIntent;
+    if (!intent?.update) {
+      const pointer = this.pointer;
+      if (pointer) this.#startAdjacentSpot({ clientX: pointer.x, clientY: pointer.y });
+      return;
+    }
+    intent.update(this.#adjacentHoverIntentParameter(true));
+  }
+
+  #startAdjacentSpot(event: Pick<PointerEvent, 'clientX' | 'clientY'>): void {
+    const zone = this.#adjacentZone;
+    if (zone === null) return;
+    const targets = paneChromeRevealTargets(zone);
+    if (targets.every((segment) => this.shown[segment])) {
+      this.#cancelAdjacentIntent();
+      return;
+    }
+
+    this.#adjacentHoverIntent?.update?.(this.#adjacentHoverIntentParameter(false));
+    this.#pendingZone = zone;
+    this.#showSpot(this.pointer ?? { x: event.clientX, y: event.clientY }, zone === 'toolbar' ? 'toolbar' : 'header');
+    this.#measureOcclusion();
+    this.#adjacentExpansionFrame = requestAnimationFrame(() => {
+      this.#adjacentExpansionFrame = undefined;
+      const currentZone = this.#pendingZone;
+      this.#pendingZone = null;
+      this.#adjacentZone = null;
+      if (currentZone === null) return;
+      this.#startExpansion(paneChromeRevealTargets(currentZone), 'adjacent');
+    });
+  }
+
+  #attachmentDiscoverable(): boolean {
+    return this.#active && this.phase !== 'fading' && this.shown.toolbar;
+  }
+
+  #attachmentAttached(): boolean {
+    return this.#active && this.phase !== 'fading' && this.floatingZoomInset > 0;
+  }
+
+  #holdAttachment(owner: symbol, event?: PointerEvent): void {
+    if (!this.#active || this.#coarsePointer || event?.pointerType === 'touch') return;
+    if (event) this.#lastPointer = { x: event.clientX, y: event.clientY };
+    this.#attachmentHolds.add(owner);
+    if (!this.#anythingShown()) return;
+    this.#cancelIntent();
+    if (this.phase === 'fading') this.#cancelFade();
+    this.#pointerZone = null;
+    this.pointer = null;
+    this.#reconcileHoverHolds(null);
+    this.#syncTones();
+    this.#clearHide();
+    if (this.phase !== 'expanding') this.#showStablePhase('held');
+    this.#measureOcclusion();
+  }
+
+  #releaseAttachment(owner: symbol): void {
+    if (!this.#attachmentHolds.delete(owner)) return;
+    this.#pointerZone = null;
+    this.pointer = null;
+    this.#reconcileHoverHolds(null);
+    this.#syncTones();
+    this.#scheduleHide();
+  }
+
+  #revealAll(held: boolean): void {
+    this.#reveal([...segments], held);
+  }
+
+  #reveal(targets: readonly PaneChromeSegment[], held: boolean): void {
+    this.#cancelIntent();
+    this.#cancelFade();
+    this.shown = { ...this.shown, ...Object.fromEntries(targets.map((segment) => [segment, true])) };
+    this.#showStablePhase(held || this.#attachmentHolds.size > 0 ? 'held' : 'preview');
+    this.#syncTones();
+    this.#measureOcclusion();
+  }
+
+  #startExpansion(targets: readonly PaneChromeSegment[], pace: PaneChromeExpansionPace = 'standard'): void {
+    if (this.#reducedMotion()) {
+      this.#reveal(targets, true);
+      return;
+    }
+    this.#cancelFade();
+    const hiddenTargets = targets.filter((segment) => !this.shown[segment]);
+    if (hiddenTargets.length === 0) {
+      this.#reveal(targets, true);
+      return;
+    }
+    const targetFlags = { ...emptyFlags(), ...Object.fromEntries(hiddenTargets.map((segment) => [segment, true])) };
+    const timing = paneChromeExpansionTiming(pace);
+    const origin = this.spot;
+    const spotLane = this.spotLane;
+    if (!origin || !spotLane) {
+      this.#reveal(targets, true);
+      return;
+    }
+    this.#pendingZone = null;
+    this.shown = { ...this.shown, ...Object.fromEntries(targets.map((segment) => [segment, true])) };
+    this.#transition = {
+      phase: 'expanding',
+      spot: origin,
+      spotLane,
+      expansionOrigin: origin,
+      expansionTargets: targetFlags,
+      expansionPace: pace,
+      foregroundRevealStarted: emptyFlags(),
+    };
+    this.#syncTones();
+    this.#measureOcclusion();
+
+    this.#foregroundTimer = setTimeout(() => {
+      this.#foregroundTimer = undefined;
+      if (this.#transition.phase === 'expanding') {
+        this.#transition = { ...this.#transition, foregroundRevealStarted: targetFlags };
+      }
+    }, timing.foregroundDelayMs);
+    this.#expansionTimer = setTimeout(() => {
+      this.#expansionTimer = undefined;
+      if (this.phase !== 'expanding') return;
+      this.#showStablePhase('held');
+    }, timing.totalMs);
+  }
+
+  #scheduleHide(): void {
+    if (
+      !this.#active ||
+      this.#coarsePointer ||
+      this.#holds.size > 0 ||
+      this.#hasOpenMenu() ||
+      this.#attachmentHolds.size > 0 ||
+      !this.#anythingPresented()
+    )
+      return;
+    if (this.#hideTimer) return;
+    this.#hideTimer = setTimeout(() => {
+      this.#hideTimer = undefined;
+      if (this.#holds.size > 0 || this.#hasOpenMenu() || this.#attachmentHolds.size > 0) return;
+      this.#beginFade();
+    }, EXIT_GRACE_MS);
+  }
+
+  #beginFade(): void {
+    const fadingSpot = this.spot;
+    const fadingSpotLane = this.spotLane;
+    this.#showStablePhase(this.#anythingShown() ? 'held' : 'idle');
+    this.#cancelIntent();
+    this.#transition = { phase: 'fading', spot: fadingSpot, spotLane: fadingSpotLane };
+    this.#measureOcclusion();
+    this.#fadeTimer = setTimeout(
+      () => {
+        this.#fadeTimer = undefined;
+        this.shown = emptyFlags();
+        this.#showStablePhase('idle');
+        this.#measureOcclusion();
+      },
+      this.#reducedMotion() ? 0 : PANE_CHROME_FADE_OUT_MS,
+    );
+  }
+
+  #observeMenus(node: HTMLElement, segment: PaneChromeSegment): void {
+    const sync = () => {
+      const expanded = node.querySelector('[aria-haspopup][aria-expanded="true"]') !== null;
+      const registration = this.#menuRegistrations.get(node);
+      const previous = registration?.open ?? false;
+      if (expanded === previous) return;
+      if (registration) registration.open = expanded;
+      if (expanded) {
+        this.#clearHide();
+        if (segment === 'toolbar') this.#revealAll(true);
+        else this.#reveal([segment], true);
+        this.#syncTones();
+      } else {
+        this.#syncTones();
+        this.#scheduleHide();
+      }
+    };
+    const observer = new MutationObserver(sync);
+    observer.observe(node, { subtree: true, attributes: true, attributeFilter: ['aria-expanded'] });
+    this.#menuRegistrations.set(node, { observer, segment, open: false });
+    sync();
+  }
+
+  #unobserveMenus(node: HTMLElement): void {
+    const registration = this.#menuRegistrations.get(node);
+    registration?.observer.disconnect();
+    this.#menuRegistrations.delete(node);
+    if (registration?.open) {
+      this.#syncTones();
+      this.#scheduleHide();
+    }
+  }
+
+  #measureOcclusion(): void {
+    if (!this.#active || this.phase === 'fading') {
+      this.topOcclusion = 0;
+      return;
+    }
+    this.topOcclusion = this.#geometry.visibleChromeInset(this.shown.identity || this.shown.actions, this.shown.toolbar);
+  }
+
+  #syncTones(): void {
+    this.tone = Object.fromEntries(
+      segments.map((segment) => {
+        const held = [...this.#holds.keys()].some((key) => key.startsWith(`${segment}:`)) || this.#segmentHasOpenMenu(segment);
+        return [segment, held || this.#pointerZone === segment ? 'engaged' : 'transient'];
+      }),
+    ) as Record<PaneChromeSegment, PaneChromeTone>;
+  }
+
+  #reconcileHoverHolds(zone: PaneChromeSegment | 'gap' | null): void {
+    for (const segment of segments) {
+      if (zone !== segment) this.#holds.delete(`${segment}:hover`);
+    }
+  }
+
+  #anythingShown(): boolean {
+    return segments.some((segment) => this.shown[segment]);
+  }
+
+  #anythingPresented(): boolean {
+    return this.#anythingShown() || this.spot !== null;
+  }
+
+  #hasOpenMenu(): boolean {
+    return [...this.#menuRegistrations.values()].some(({ open }) => open);
+  }
+
+  #segmentHasOpenMenu(segment: PaneChromeSegment): boolean {
+    return [...this.#menuRegistrations.values()].some((registration) => registration.segment === segment && registration.open);
+  }
+
+  #refreshPointerAfterRegistration(): void {
+    if (!this.#active || !this.#lastPointer || this.#coarsePointer) return;
+    this.#revealEntryPointer();
+  }
+
+  #clearHide(): void {
+    if (this.#hideTimer) clearTimeout(this.#hideTimer);
+    this.#hideTimer = undefined;
+  }
+
+  #cancelIntent(): void {
+    this.#cancelAdjacentIntent();
+    if (this.#intentTimer) clearTimeout(this.#intentTimer);
+    if (this.#dwellTimer) clearTimeout(this.#dwellTimer);
+    this.#intentTimer = undefined;
+    this.#dwellTimer = undefined;
+    this.#pendingZone = null;
+    if (this.phase === 'pending') this.#showStablePhase(this.#anythingShown() ? 'held' : 'idle');
+    if (this.spot !== null && !this.#anythingShown()) this.#beginFade();
+  }
+
+  #cancelAdjacentIntent(): void {
+    const hadExpansionFrame = this.#adjacentExpansionFrame !== undefined;
+    if (this.#adjacentExpansionFrame !== undefined) cancelAnimationFrame(this.#adjacentExpansionFrame);
+    this.#adjacentExpansionFrame = undefined;
+    this.#adjacentZone = null;
+    this.#adjacentHoverIntent?.update?.(this.#adjacentHoverIntentParameter(false));
+    if (!hadExpansionFrame) return;
+    this.#pendingZone = null;
+    if (this.phase === 'spot') this.#showStablePhase(this.#anythingShown() ? 'held' : 'idle');
+    this.#measureOcclusion();
+  }
+
+  #cancelFade(): void {
+    this.#clearHide();
+    if (this.#fadeTimer) clearTimeout(this.#fadeTimer);
+    this.#fadeTimer = undefined;
+    if (this.#foregroundTimer) clearTimeout(this.#foregroundTimer);
+    this.#foregroundTimer = undefined;
+    if (this.#expansionTimer) clearTimeout(this.#expansionTimer);
+    this.#expansionTimer = undefined;
+    if (this.#transition.phase === 'expanding') {
+      this.#transition = { ...this.#transition, foregroundRevealStarted: emptyFlags() };
+    }
+  }
+
+  #reset(): void {
+    this.#cancelIntent();
+    this.#cancelFade();
+    if (this.#foregroundTimer) clearTimeout(this.#foregroundTimer);
+    this.#foregroundTimer = undefined;
+    this.#holds.clear();
+    this.#attachmentHolds.clear();
+    this.shown = emptyFlags();
+    this.tone = transientTones();
+    this.#pointerZone = null;
+    this.pointer = null;
+    this.#showStablePhase('idle');
+    this.topOcclusion = 0;
+  }
+
+  destroy(): void {
+    this.#active = false;
+    this.#reset();
+    for (const { observer } of this.#menuRegistrations.values()) observer.disconnect();
+    this.#menuRegistrations.clear();
+  }
+
+  #reducedMotion(): boolean {
+    return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+}
+
+export const setupZenModePaneChrome = (options: PaneChromeOptions): ZenModePaneChrome => {
+  const chrome = new ZenModePaneChrome(options);
+  setZenModePaneChrome(chrome);
+  chrome.sync();
+  $effect(() => {
+    options.active();
+    options.focused();
+    untrack(() => chrome.sync());
+  });
+  $effect(() => () => chrome.destroy());
+  return chrome;
+};

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/zen-mode-pane-chrome.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { paneChromeRevealTargets, ZenModePaneChrome } from './zen-mode-pane-chrome.svelte';
+
+afterEach(() => vi.useRealTimers());
+
+describe('paneChromeRevealTargets', () => {
+  it('keeps direct header segments independent', () => {
+    expect(paneChromeRevealTargets('identity')).toEqual(['identity']);
+    expect(paneChromeRevealTargets('actions')).toEqual(['actions']);
+  });
+
+  it('unifies the header after middle-gap dwell and promotes toolbar intent to the full group', () => {
+    expect(paneChromeRevealTargets('gap')).toEqual(['identity', 'actions']);
+    expect(paneChromeRevealTargets('toolbar')).toEqual(['identity', 'actions', 'toolbar']);
+  });
+});
+
+describe('ZenModePaneChrome lifetime', () => {
+  it('holds promoted toolbar chrome and clears every surface after the shared grace and fade', () => {
+    vi.useFakeTimers();
+    const chrome = new ZenModePaneChrome({ active: () => true, focused: () => true });
+    chrome.sync();
+
+    chrome.hold('toolbar', 'focus');
+    vi.advanceTimersByTime(100);
+    expect(chrome.foreground).toEqual({ identity: true, actions: true, toolbar: true });
+
+    chrome.release('toolbar', 'focus');
+    vi.advanceTimersByTime(1500);
+    expect(chrome.phase).toBe('fading');
+    expect(chrome.shown).toEqual({ identity: true, actions: true, toolbar: true });
+
+    vi.advanceTimersByTime(400);
+    expect(chrome.phase).toBe('idle');
+    expect(chrome.shown).toEqual({ identity: false, actions: false, toolbar: false });
+  });
+
+  it('does not replay the entrance reveal for an active reload revision', () => {
+    const chrome = new ZenModePaneChrome({ active: () => true, focused: () => true });
+    chrome.sync();
+    expect(chrome.shown).toEqual({ identity: false, actions: false, toolbar: false });
+  });
+
+  it('replays an actions-segment entry prepared by repeated focus-mode button clicks', () => {
+    let active = false;
+    const chrome = new ZenModePaneChrome({ active: () => active, focused: () => true });
+    chrome.sync();
+
+    for (let count = 0; count < 2; count += 1) {
+      chrome.prepareEntryReveal('actions', { clientX: 500, clientY: 18 });
+      active = true;
+      chrome.sync();
+      expect(chrome.shown).toEqual({ identity: false, actions: true, toolbar: false });
+
+      active = false;
+      chrome.sync();
+    }
+  });
+
+  it('ignores the stale focus release from the control that entered focus mode', () => {
+    let active = false;
+    const chrome = new ZenModePaneChrome({ active: () => active, focused: () => true });
+    chrome.sync();
+
+    active = true;
+    chrome.sync();
+    chrome.release('actions', 'focus');
+    chrome.hold('actions', 'hover');
+
+    expect(chrome.shown).toEqual({ identity: false, actions: false, toolbar: false });
+  });
+
+  it('drops attachment ownership across a focus-mode lifecycle', () => {
+    vi.useFakeTimers();
+    let active = true;
+    const chrome = new ZenModePaneChrome({ active: () => active, focused: () => true });
+    const attachment = chrome.attachmentHandle();
+    chrome.sync();
+    attachment.hold();
+
+    active = false;
+    chrome.sync();
+    active = true;
+    chrome.sync();
+    chrome.handlePointerLeave();
+    chrome.hold('identity', 'focus');
+    chrome.release('identity', 'focus');
+    vi.advanceTimersByTime(1500);
+
+    expect(chrome.phase).toBe('fading');
+  });
+});

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
@@ -16,7 +16,6 @@
   import { DocumentPaneDragController } from '../../@pane/document-pane-drag.svelte';
   import DocumentPaneDragGhost from '../../@pane/DocumentPaneDragGhost.svelte';
   import BreadcrumbEntityTree from './BreadcrumbEntityTree.svelte';
-  import type { EditorContextBarSegmentState } from '$lib/editor-ffi/components/ui/editor-context-bar.svelte';
   import type { EntityIcon_entity$key } from '$mearie';
   import type { BreadcrumbContainer } from './BreadcrumbEntityTree.svelte';
 
@@ -27,6 +26,11 @@
   };
 
   export type EditorBreadcrumbTarget = { kind: 'home' } | { kind: 'entity'; slug: string };
+
+  export type EditorBreadcrumbHoldHandle = {
+    hold(reason: string): void;
+    release(reason: string): void;
+  };
 
   export type EditorBreadcrumbCurrent = { kind: 'home' } | ({ kind: 'entity' } & EditorBreadcrumbPathEntity & { slug: string });
 
@@ -45,7 +49,7 @@
     isOwner: boolean;
     onNavigate: (target: EditorBreadcrumbTarget) => void;
     popupId: string;
-    segment?: EditorContextBarSegmentState;
+    segment?: EditorBreadcrumbHoldHandle;
     siteId: string | null;
   };
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanel.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@document-panel/DocumentPanel.svelte
@@ -5,6 +5,7 @@
   import { pointerCapture } from '@typie/ui/actions';
   import { Button, FullAccessBadge, Icon } from '@typie/ui/components';
   import { getAppContext } from '@typie/ui/context';
+  import { prefersReducedMotion } from '@typie/ui/state';
   import { clamp } from '@typie/ui/utils';
   import { onDestroy } from 'svelte';
   import ConstructionIcon from '~icons/lucide/construction';
@@ -12,6 +13,7 @@
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { graphql } from '$mearie';
   import { SubscribeModal } from '../../../@subscription/subscribe-modal.svelte';
+  import { getZenMode } from '../../../zen-mode.svelte';
   import { getPane, getPaneGroup } from '../../@pane/context.svelte';
   import DocumentPanelComment from './DocumentPanelComment.svelte';
   import DocumentPanelInfo from './DocumentPanelInfo.svelte';
@@ -75,6 +77,7 @@
 
   const paneId = getPane().id;
   const paneGroup = getPaneGroup();
+  const zenMode = getZenMode();
   const focusReturn = getDocumentPanelFocusReturn();
 
   const isExpanded = $derived(
@@ -165,10 +168,14 @@
 >
   {#if isExpanded}
     <aside
+      style:padding-top="var(--editor-pane-header-inset, 0px)"
+      style:transition-duration={prefersReducedMotion.current || !zenMode.active
+        ? '0ms'
+        : 'var(--editor-pane-overlay-motion-duration, 280ms)'}
       class={flex({
         position: 'absolute',
         inset: '0',
-        zIndex: 'panel',
+        zIndex: 'editorOverlay',
         backgroundColor: 'surface.default',
         flexDirection: 'column',
         width: 'full',
@@ -176,7 +183,12 @@
         overflow: 'hidden',
         borderLeftWidth: '1px',
         borderColor: 'border.subtle',
+        transitionProperty: '[padding-top]',
+        transitionTimingFunction: '[var(--editor-pane-overlay-motion-easing, cubic-bezier(0.22, 1, 0.36, 1))]',
       })}
+      data-document-panel
+      data-pane-chrome-reveal-exclusion
+      data-zen-mode-closing-surface
       onfocusin={(event) => {
         if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
         focusReturn.capture(event.relatedTarget);
@@ -222,7 +234,7 @@
       style:transform="translateX(-50%)"
       class={css({
         position: 'absolute',
-        zIndex: 'overEditor',
+        zIndex: 'editorOverlay',
         top: '0',
         left: '0',
         display: 'flex',
@@ -240,6 +252,7 @@
           opacity: '50',
         },
       })}
+      data-pane-chrome-reveal-exclusion
       use:pointerCapture={{
         start: (event): ResizeSession | null => {
           if (!event.isPrimary || event.button !== 0) return null;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
@@ -239,6 +239,7 @@
       userSelect: 'text',
       WebkitUserSelect: 'text',
     })}
+    data-zen-mode-closing-surface
     draggable={false}
     onclick={(event) => event.stopPropagation()}
     oncontextmenu={(event) => event.stopPropagation()}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
@@ -11,6 +11,8 @@
   import { graphql } from '$mearie';
   import { PRISM_VISIBILITY_MOTION, prismVisibilityEasing, reducedMotion } from '../../../@prism/lib/motion.ts';
   import { TIER_OPTIONS } from '../../../@prism/review/tiers.ts';
+  import { getZenMode } from '../../../zen-mode.svelte';
+  import { getPane } from '../../@pane/context.svelte';
   import { setupMarginContext } from './context.svelte.ts';
   import {
     contentMotionOffset,
@@ -26,6 +28,7 @@
   import type { Snippet } from 'svelte';
   import type { MarginJump } from '$lib/prism/margin-jump.svelte';
   import type { DetailRound } from '../../../@prism/review/round-view.ts';
+  import type { ZenModeReviewParticipant } from '../../../zen-mode.svelte';
   import type { MarginActivation, MarginItem, MarginPlacement, MarginSegment } from './context.svelte.ts';
   import type { MarginMode, RoundOption } from './margin-view.ts';
 
@@ -58,6 +61,8 @@
   };
 
   const ctx = getEditorContext();
+  const pane = getPane();
+  const zenMode = getZenMode();
   const editor = $derived(ctx.editor);
   const idle = $derived(documentId === null || entityId === null);
 
@@ -138,6 +143,39 @@
   });
 
   const selectedRoundId = $derived(selection === undefined ? null : rounds.some((r) => r.id === selection) ? selection : null);
+
+  let zenParticipant = $state.raw<ZenModeReviewParticipant | null>(null);
+  $effect(() => {
+    const id = documentId;
+    if (id === null) {
+      zenParticipant = null;
+      return;
+    }
+
+    const participant: ZenModeReviewParticipant = {
+      paneId: pane.id,
+      documentId: id,
+      ready: () => selectedFor === id && selection !== undefined,
+      selectedRoundId: () => selectedRoundId,
+      roundIds: () => rounds.map((round) => round.id),
+      applySelection: (roundId) => {
+        if (documentId === id) selection = roundId;
+      },
+    };
+    zenParticipant = participant;
+    const unregister = zenMode.registerReview(participant);
+    return () => {
+      unregister();
+      if (zenParticipant === participant) zenParticipant = null;
+    };
+  });
+
+  $effect(() => {
+    void selection;
+    void rounds;
+    const participant = zenParticipant;
+    if (participant) untrack(() => zenMode.syncReview(participant));
+  });
 
   // 리뷰가 없는 문서에까지 여백을 잡아 두면 본문이 통째로 밀린다 — 회차가 걸린 뒤에만 자리를 낸다.
   // 짚은 곳이 하나도 없는 회차도 컬럼은 선다: 자리가 아예 없으면 "짚은 곳이 없어요"를 말할 자리도 없다.

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -3,7 +3,7 @@
   import { css } from '@typie/styled-system/css';
   import { center, flex } from '@typie/styled-system/patterns';
   import { autosize, tooltip } from '@typie/ui/actions';
-  import { Helmet, HorizontalDivider, Icon, Menu, MenuItem, VerticalDivider } from '@typie/ui/components';
+  import { Helmet, HorizontalDivider, Icon, Menu, MenuItem } from '@typie/ui/components';
   import { getAppContext, getThemeContext } from '@typie/ui/context';
   import { Tip, Toast } from '@typie/ui/notification';
   import { LocalStore } from '@typie/ui/state';
@@ -17,12 +17,10 @@
   import InfoIcon from '~icons/lucide/info';
   import LockIcon from '~icons/lucide/lock';
   import LockOpenIcon from '~icons/lucide/lock-open';
-  import Maximize2Icon from '~icons/lucide/maximize-2';
   import MessageSquareTextIcon from '~icons/lucide/message-square-text';
   import SettingsIcon from '~icons/lucide/settings';
   import SpellCheckIcon from '~icons/lucide/spell-check';
   import StickyNoteIcon from '~icons/lucide/sticky-note';
-  import XIcon from '~icons/lucide/x';
   import { desktop } from '$lib/desktop';
   import { Editor as EditorComponent, EditorFailureOverlay } from '$lib/editor-ffi/components';
   import EditorBreadcrumb from '$lib/editor-ffi/components/ui/EditorBreadcrumb.svelte';
@@ -37,11 +35,14 @@
   import DocumentMenu from '../../@context-menu/DocumentMenu.svelte';
   import { SubscribeModal } from '../../@subscription/subscribe-modal.svelte';
   import FontUploadModal from '../../FontUploadModal.svelte';
-  import CloseButton from '../@pane/CloseButton.svelte';
+  import { getZenMode } from '../../zen-mode.svelte';
   import { getPane, getPaneGroup } from '../@pane/context.svelte';
   import { getEditorRegistry } from '../@pane/editor-registry.svelte';
+  import { paneChromeAttachment } from '../@pane/pane-chrome-attachment';
   import PaneHeader from '../@pane/PaneHeader.svelte';
+  import PaneHeaderControls from '../@pane/PaneHeaderControls.svelte';
   import TabIcon from '../@pane/TabIcon.svelte';
+  import { getZenModePaneChrome } from '../@pane/zen-mode-pane-chrome.svelte';
   import EditorBreadcrumbNavigation from './@breadcrumb/EditorBreadcrumbNavigation.svelte';
   import CommentPopover from './@document-comments/CommentPopover.svelte';
   import DocumentComments from './@document-comments/DocumentComments.svelte';
@@ -292,6 +293,11 @@
   const paneGroup = getPaneGroup();
   const pane = getPane();
   const editorRegistry = getEditorRegistry();
+  const paneChrome = getZenModePaneChrome();
+  const zenMode = getZenMode();
+  const floatingZoomChromeAttachment = paneChrome.attachmentHandle();
+  const lockedToastChromeAttachment = paneChrome.attachmentHandle();
+  const breadcrumbHoldHandle = paneChrome.segmentHandle('identity');
 
   const ctx = getEditorContext();
   const theme = getThemeContext();
@@ -858,28 +864,14 @@
     });
   }
 
-  const currentViewZenModeEnabled = $derived(app.preference.current.zenModeEnabled && pane.id === paneGroup.state.current.focusedPaneId);
-
-  function toggleZenMode() {
-    const enabled = !app.preference.current.zenModeEnabled;
-    app.preference.current.zenModeEnabled = enabled;
-    mixpanel.track(enabled ? 'zen_mode_enabled' : 'zen_mode_disabled', { via: 'document' });
-  }
-
-  function exitZenModeFromCloseButton() {
-    app.preference.current.zenModeEnabled = false;
-    mixpanel.track('zen_mode_disabled', { via: 'close_button' });
-  }
-
   $effect(() => {
     const editor = ctx.liveEditor;
     if (!editor) return;
 
     const handler = () => {
-      if (!currentViewZenModeEnabled || editor.appliedSnapshot.selectionKind === 'range') return false;
+      if (!focused || !zenMode.active || editor.appliedSnapshot.selectionKind === 'range') return false;
 
-      app.preference.current.zenModeEnabled = false;
-      mixpanel.track('zen_mode_disabled', { via: 'esc' });
+      void zenMode.exit('esc');
       return true;
     };
 
@@ -957,7 +949,7 @@
   }
 
   $effect(() => {
-    if (currentViewZenModeEnabled) {
+    if (focused && zenMode.active) {
       Tip.show('editor.zen-mode.enabled', '집중 모드가 활성화되었어요. Esc 키를 눌러 빠져나올 수 있어요.');
     }
   });
@@ -1105,6 +1097,35 @@
         myId={query.data.me.id}
       >
         {#snippet children(insets)}
+          {#snippet documentPaneMenu()}
+            <Menu placement="bottom-end">
+              {#snippet button({ open })}
+                <button
+                  class={center({
+                    borderRadius: '4px',
+                    size: '24px',
+                    color: 'text.faint',
+                    transition: 'common',
+                    _hover: { color: 'text.subtle', backgroundColor: 'surface.muted' },
+                    _pressed: { color: 'text.subtle', backgroundColor: 'surface.muted' },
+                  })}
+                  aria-pressed={open}
+                  type="button"
+                >
+                  <Icon icon={EllipsisIcon} size={16} />
+                </button>
+              {/snippet}
+
+              <DocumentMenu {document} {entity} via="editor">
+                {#if query.data.me.entitled}
+                  <MenuItem icon={document.locked ? LockOpenIcon : LockIcon} onclick={() => toggleEditLock()}>
+                    {document.locked ? '편집 잠금 해제' : '편집 잠금'}
+                  </MenuItem>
+                {/if}
+              </DocumentMenu>
+            </Menu>
+          {/snippet}
+
           <PaneHeader placement={headerPlacement}>
             <EditorBreadcrumb pathIdentity={breadcrumbPathIdentity} viewportId={breadcrumbViewportId}>
               {#key breadcrumbPathIdentity}
@@ -1116,6 +1137,7 @@
                     paneGroup.replacePane(pane.id, target.kind === 'home' ? { kind: 'home' } : { kind: 'entity', slug: target.slug });
                   }}
                   popupId={`${breadcrumbViewportId}-tree`}
+                  segment={breadcrumbHoldHandle}
                   siteId={entity.site.id}
                 />
               {/key}
@@ -1174,64 +1196,7 @@
             {/snippet}
 
             {#snippet fixedActions()}
-              <VerticalDivider style={css.raw({ height: '12px' })} />
-
-              {#if query.data.me.id === entity.user.id}
-                <Menu placement="bottom-end">
-                  {#snippet button({ open })}
-                    <button
-                      class={center({
-                        borderRadius: '4px',
-                        size: '24px',
-                        color: 'text.faint',
-                        transition: 'common',
-                        _hover: {
-                          color: 'text.subtle',
-                          backgroundColor: 'surface.muted',
-                        },
-                        _pressed: {
-                          color: 'text.subtle',
-                          backgroundColor: 'surface.muted',
-                        },
-                      })}
-                      aria-pressed={open}
-                      type="button"
-                    >
-                      <Icon icon={EllipsisIcon} size={16} />
-                    </button>
-                  {/snippet}
-
-                  <DocumentMenu {document} {entity} via="editor">
-                    {#if query.data.me.entitled}
-                      <MenuItem icon={document.locked ? LockOpenIcon : LockIcon} onclick={() => toggleEditLock()}>
-                        {document.locked ? '편집 잠금 해제' : '편집 잠금'}
-                      </MenuItem>
-                    {/if}
-                  </DocumentMenu>
-                </Menu>
-              {/if}
-
-              <button
-                class={center({
-                  borderRadius: '4px',
-                  size: '24px',
-                  color: 'text.faint',
-                  transition: 'common',
-                  _hover: { color: 'text.subtle', backgroundColor: 'surface.muted' },
-                })}
-                aria-label="집중 모드 켜기"
-                data-editor-focus-mode-control
-                onclick={toggleZenMode}
-                onpointerdown={(event) => event.preventDefault()}
-                type="button"
-                use:tooltip={{ message: '집중 모드 켜기', keys: ['Mod', 'Shift', 'M'] }}
-              >
-                <Icon icon={Maximize2Icon} size={16} />
-              </button>
-
-              <CloseButton>
-                <Icon icon={XIcon} size={16} />
-              </CloseButton>
+              <PaneHeaderControls menu={query.data.me.id === entity.user.id ? documentPaneMenu : undefined} />
             {/snippet}
           </PaneHeader>
 
@@ -1255,56 +1220,26 @@
 
                     <div
                       bind:this={ctx.editorAreaEl}
-                      style:position={currentViewZenModeEnabled ? 'fixed' : 'relative'}
-                      style:top={currentViewZenModeEnabled ? '0' : 'auto'}
-                      style:left={currentViewZenModeEnabled ? '0' : 'auto'}
-                      style:right={currentViewZenModeEnabled ? '0' : 'auto'}
-                      style:bottom={currentViewZenModeEnabled ? '0' : 'auto'}
                       class={flex({
                         position: 'relative',
                         flexDirection: 'column',
                         flexGrow: '1',
                         overflowX: 'auto',
                         overflowY: 'hidden',
-                        zIndex: !currentViewZenModeEnabled && app.preference.current.zenModeEnabled ? 'underEditor' : 'editor',
+                        zIndex: 'editor',
                         backgroundColor: 'surface.default',
                       })}
                       bind:clientWidth={editorAreaWidth}
                     >
-                      {#if currentViewZenModeEnabled}
-                        <button
-                          class={center({
-                            position: 'absolute',
-                            top: '0',
-                            right: '0',
-                            zIndex: 'overEditor',
-                            size: '32px',
-                            borderRadius: '8px',
-                            color: 'text.subtle',
-                            backgroundColor: { base: 'surface.default', _hover: 'surface.subtle' },
-                          })}
-                          aria-label="집중 모드 끄기"
-                          data-editor-focus-mode-close
-                          onclick={exitZenModeFromCloseButton}
-                          onpointerdown={(event) => event.preventDefault()}
-                          type="button"
-                          use:tooltip={{ message: '집중 모드 끄기', keys: ['Esc'] }}
-                        >
-                          <Icon icon={XIcon} />
-                        </button>
-                      {/if}
-
                       {#if showEditLockedToast}
                         <div
+                          style:top={zenMode.active ? 'calc(var(--editor-pane-overlay-top-inset, 0px) + 12px)' : undefined}
+                          style:transition="var(--editor-pane-overlay-position-transition, none)"
                           class={flex({
                             position: 'absolute',
-                            top: currentViewZenModeEnabled
-                              ? '60px'
-                              : ctx.editor?.rootAttrs?.layout_mode.type === 'paginated'
-                                ? '36px'
-                                : '12px',
+                            top: zenMode.active ? undefined : ctx.editor?.rootAttrs?.layout_mode.type === 'paginated' ? '36px' : '12px',
                             right: '12px',
-                            zIndex: 'sidebar',
+                            zIndex: 'editorOverlay',
                             alignItems: 'center',
                             gap: '10px',
                             paddingX: '14px',
@@ -1317,6 +1252,7 @@
                             fontSize: '13px',
                             color: 'text.subtle',
                           })}
+                          data-pane-chrome-reveal-exclusion
                           onpointerenter={() => {
                             if (!lockedToastTimer) {
                               return;
@@ -1331,6 +1267,7 @@
                             }, 5000);
                           }}
                           role="alert"
+                          use:paneChromeAttachment={lockedToastChromeAttachment}
                           transition:fly={{ y: -8, duration: 150 }}
                         >
                           <Icon style={css.raw({ flexShrink: '0' })} icon={LockIcon} size={14} />
@@ -1377,12 +1314,22 @@
                           <svelte:boundary onerror={(error) => handleEditorBoundaryError(editor, error)}>
                             <EditorComponent
                               active={focused}
-                              contentInsetLeft={insets.left}
-                              contentInsetRight={insets.right}
-                              contentMotion={insets.contentMotion}
                               document$key={document}
-                              floatingZoomRightInset={currentViewZenModeEnabled ? 36 : 0}
                               onReady={handleEditorReady}
+                              viewSurfaceLayout={{
+                                contentInset: {
+                                  left: insets.left,
+                                  right: insets.right,
+                                  top: zenMode.active ? paneChrome.floatingZoomTopInset : 0,
+                                },
+                                contentMotion: insets.contentMotion,
+                                visibleAreaTopInset: zenMode.active ? paneChrome.topOcclusion : 0,
+                                floatingZoom: {
+                                  chromeAttachment: zenMode.active ? floatingZoomChromeAttachment : undefined,
+                                  layoutOriginOffset: zenMode.active ? 0 : paneChrome.floatingZoomTopInset,
+                                  topInset: zenMode.active ? paneChrome.floatingZoomInset : 0,
+                                },
+                              }}
                             >
                               {#snippet placeholderAction()}
                                 {#if currentSite}
@@ -1504,6 +1451,7 @@
                           </svelte:boundary>
                         {/key}
                       </div>
+
                       {#if showFindReplace}
                         <DocumentFindReplace bind:this={findReplaceComponent} onclose={() => (showFindReplace = false)} />
                       {/if}
@@ -1543,43 +1491,6 @@
           {/if}
         {/snippet}
       </PrismReviewMargin>
-
-      {#if currentViewZenModeEnabled && !entity.user.subscription}
-        <div
-          class={flex({
-            position: 'fixed',
-            top: '44px',
-            right: '18px',
-            zIndex: 'editor',
-            alignItems: 'center',
-            gap: '8px',
-          })}
-        >
-          <button
-            class={flex({
-              alignItems: 'center',
-              gap: '4px',
-              height: '[31.5px]',
-              paddingX: '8px',
-              borderWidth: '1px',
-              borderColor: 'border.brand',
-              borderRadius: '6px',
-              fontSize: '11px',
-              fontWeight: 'semibold',
-              color: 'text.brand',
-              backgroundColor: 'surface.default',
-              cursor: 'pointer',
-              transition: 'common',
-              _hover: { backgroundColor: 'accent.brand.subtle' },
-            })}
-            onclick={() => SubscribeModal.show('document_zen_mode')}
-            type="button"
-          >
-            <Icon icon={CrownIcon} size={12} />
-            <span>업그레이드</span>
-          </button>
-        </div>
-      {/if}
     </div>
   </div>
 

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentFindReplace.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentFindReplace.svelte
@@ -16,6 +16,8 @@
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { FocusReturnSession } from '$lib/focus-return-session';
   import { getPane } from '../@pane/context.svelte';
+  import { paneChromeAttachment } from '../@pane/pane-chrome-attachment';
+  import { getZenModePaneChrome } from '../@pane/zen-mode-pane-chrome.svelte';
   import type { Editor } from '$lib/editor-ffi/editor.svelte';
 
   type Props = {
@@ -26,6 +28,7 @@
 
   const ctx = getEditorContext();
   const pane = getPane();
+  const chromeAttachment = getZenModePaneChrome().attachmentHandle();
   const app = getAppContext();
   const editor = $derived(ctx.editor?.terminal ? undefined : ctx.editor);
 
@@ -148,11 +151,12 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <div
+  style:top="var(--editor-pane-overlay-top-inset, 0px)"
+  style:transition="var(--editor-pane-overlay-position-transition, none)"
   class={flex({
     gap: '4px',
     padding: '8px',
     position: 'absolute',
-    top: '0',
     right: '52px',
     zIndex: 'overEditor',
     backgroundColor: 'surface.default',
@@ -160,9 +164,11 @@
     boxShadow: 'small',
   })}
   aria-label="찾기 및 바꾸기"
+  data-pane-chrome-reveal-exclusion
   onfocusin={handleFocusIn}
   role="dialog"
   tabindex="-1"
+  use:paneChromeAttachment={chromeAttachment}
 >
   <div class={flex({ flexDirection: 'column', gap: '4px' })}>
     <div class={css({ position: 'relative', display: 'flex', alignItems: 'center' })}>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentToolbars.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentToolbars.svelte
@@ -13,6 +13,9 @@
   import { FormatToolbarItems, InsertToolbarItems, ToolbarButton } from '$lib/editor-ffi/components';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { getPane, getPaneGroup } from '../@pane/context.svelte';
+  import { getZenModePaneChrome } from '../@pane/zen-mode-pane-chrome.svelte';
+  import ZenModePaneChromeEffects from '../@pane/ZenModePaneChromeEffects.svelte';
+  import ZenModePaneChromeSegment from '../@pane/ZenModePaneChromeSegment.svelte';
   import { otherToolbarKind, readPrimaryToolbar, writePrimaryToolbar } from './toolbar-kind';
   import type { Message } from '@typie/editor-ffi/browser';
   import type { ComponentProps } from 'svelte';
@@ -31,12 +34,14 @@
   const ctx = getEditorContext();
   const paneId = getPane().id;
   const paneGroup = getPaneGroup();
+  const paneChrome = getZenModePaneChrome();
   const primaryToolbarId = `document-toolbar-primary-${paneId}`;
   const expandedToolbarId = `document-toolbar-expanded-${paneId}`;
 
   let stored = $state<ToolbarKind | null>(null);
   let primaryScrollContainer = $state<HTMLElement>();
   let expandedScrollContainer = $state<HTMLElement>();
+  let primaryRowHeight = $state(0);
 
   const row = css.raw({
     display: 'flex',
@@ -67,6 +72,8 @@
   const expanded = $derived(otherToolbarKind(primary));
   const open = $derived(paneGroup.state.current.toolbarExpandedByPaneId[paneId] ?? false);
   const editingDisabled = $derived(ctx.editor?.terminal === true || (ctx.editor !== undefined && ctx.editor !== ctx.liveEditor));
+  const zenModeEnabled = $derived(app.preference.current.zenModeEnabled);
+  const registerToolbarLane = paneChrome.registerToolbarLane;
 
   const enqueue = (message: Message) => {
     if (editingDisabled) return;
@@ -100,84 +107,117 @@
   {/if}
 {/snippet}
 
-<div class={css(rowShell, { zIndex: app.preference.current.zenModeEnabled ? 'underEditor' : 'overEditor' })} role="presentation">
-  <div bind:this={primaryScrollContainer} id={primaryToolbarId} class={css(row)} role="toolbar" tabindex="-1">
-    <ToolbarButton
-      active={open}
-      icon={expanded === 'insert' ? PlusIcon : TypeIcon}
-      label={expanded === 'insert' ? '삽입 도구' : '서식 도구'}
-      onclick={toggle}
-    />
+<div
+  class={css({
+    position: zenModeEnabled ? 'absolute' : 'relative',
+    top: zenModeEnabled ? '37px' : undefined,
+    left: zenModeEnabled ? '0' : undefined,
+    right: zenModeEnabled ? '0' : undefined,
+    zIndex: 'overEditor',
+    flexShrink: '0',
+    pointerEvents: 'none',
+  })}
+  data-zen-mode-pane-chrome
+  use:registerToolbarLane
+>
+  {#if zenModeEnabled}
+    <ZenModePaneChromeEffects lane="toolbar" toolbarSeparatorOffsets={open && primaryRowHeight > 0 ? [primaryRowHeight - 1] : []} />
+  {/if}
 
-    <VerticalDivider style={css.raw({ height: '12px' })} />
-
+  <ZenModePaneChromeSegment class={css({ position: 'relative' })} active={zenModeEnabled} aria-label="문서 도구" segment="toolbar">
     <div
-      class={flex({
-        alignItems: 'center',
-        gap: '4px',
-        opacity: editingDisabled ? '50' : '100',
-        pointerEvents: editingDisabled ? 'none' : 'auto',
-      })}
+      class={css(
+        rowShell,
+        zenModeEnabled ? { borderColor: 'transparent', backgroundColor: 'transparent' } : { backgroundColor: 'surface.default' },
+      )}
+      role="presentation"
+      bind:clientHeight={primaryRowHeight}
     >
-      <ToolbarButton
-        style={css.raw({ borderRightRadius: '0' })}
-        icon={UndoIcon}
-        keys={['Mod', 'Z']}
-        label="실행 취소"
-        onclick={() => enqueue({ type: 'history', op: { type: 'undo' } })}
-      />
+      <div bind:this={primaryScrollContainer} id={primaryToolbarId} class={css(row)} role="toolbar" tabindex="-1">
+        <ToolbarButton
+          active={open}
+          icon={expanded === 'insert' ? PlusIcon : TypeIcon}
+          label={expanded === 'insert' ? '삽입 도구' : '서식 도구'}
+          onclick={toggle}
+        />
 
-      <ToolbarButton
-        style={css.raw({ borderLeftRadius: '0' })}
-        icon={RedoIcon}
-        keys={['Mod', 'Shift', 'Z']}
-        label="다시 실행"
-        onclick={() => enqueue({ type: 'history', op: { type: 'redo' } })}
+        <VerticalDivider style={css.raw({ height: '12px' })} />
+
+        <div
+          class={flex({
+            alignItems: 'center',
+            gap: '4px',
+            opacity: editingDisabled ? '50' : '100',
+            pointerEvents: editingDisabled ? 'none' : 'auto',
+          })}
+        >
+          <ToolbarButton
+            style={css.raw({ borderRightRadius: '0' })}
+            icon={UndoIcon}
+            keys={['Mod', 'Z']}
+            label="실행 취소"
+            onclick={() => enqueue({ type: 'history', op: { type: 'undo' } })}
+          />
+
+          <ToolbarButton
+            style={css.raw({ borderLeftRadius: '0' })}
+            icon={RedoIcon}
+            keys={['Mod', 'Shift', 'Z']}
+            label="다시 실행"
+            onclick={() => enqueue({ type: 'history', op: { type: 'redo' } })}
+          />
+        </div>
+
+        <VerticalDivider style={css.raw({ height: '12px' })} />
+
+        {@render items(primary)}
+
+        <div class={css({ flexGrow: '1' })}></div>
+
+        <div
+          class={flex({
+            alignItems: 'center',
+            opacity: editingDisabled ? '50' : '100',
+            pointerEvents: editingDisabled ? 'none' : 'auto',
+          })}
+        >
+          <ToolbarButton icon={SearchIcon} keys={['Mod', 'F']} label="찾기 및 바꾸기" onclick={() => onSearchClick?.()} />
+        </div>
+      </div>
+
+      <Scrollbar
+        controls={primaryToolbarId}
+        label="툴바 가로 스크롤"
+        orientation="horizontal"
+        scrollContainer={primaryScrollContainer}
+        size="sm"
       />
     </div>
 
-    <VerticalDivider style={css.raw({ height: '12px' })} />
+    {#if open}
+      <div
+        class={css(
+          rowShell,
+          zenModeEnabled ? { borderColor: 'transparent', backgroundColor: 'transparent' } : { backgroundColor: 'surface.default' },
+        )}
+        role="presentation"
+      >
+        <div bind:this={expandedScrollContainer} id={expandedToolbarId} class={css(row)} role="toolbar" tabindex="-1">
+          <ToolbarButton disabled={documentId === null} icon={ArrowUpDownIcon} label="기본 툴바와 맞바꾸기" onclick={swap} />
 
-    {@render items(primary)}
+          <VerticalDivider style={css.raw({ height: '12px' })} />
 
-    <div class={css({ flexGrow: '1' })}></div>
+          {@render items(expanded)}
+        </div>
 
-    <div
-      class={flex({
-        alignItems: 'center',
-        opacity: editingDisabled ? '50' : '100',
-        pointerEvents: editingDisabled ? 'none' : 'auto',
-      })}
-    >
-      <ToolbarButton icon={SearchIcon} keys={['Mod', 'F']} label="찾기 및 바꾸기" onclick={() => onSearchClick?.()} />
-    </div>
-  </div>
-
-  <Scrollbar
-    controls={primaryToolbarId}
-    label="툴바 가로 스크롤"
-    orientation="horizontal"
-    scrollContainer={primaryScrollContainer}
-    size="sm"
-  />
+        <Scrollbar
+          controls={expandedToolbarId}
+          label="툴바 가로 스크롤"
+          orientation="horizontal"
+          scrollContainer={expandedScrollContainer}
+          size="sm"
+        />
+      </div>
+    {/if}
+  </ZenModePaneChromeSegment>
 </div>
-
-{#if open}
-  <div class={css(rowShell, { zIndex: app.preference.current.zenModeEnabled ? 'underEditor' : 'overEditor' })} role="presentation">
-    <div bind:this={expandedScrollContainer} id={expandedToolbarId} class={css(row)} role="toolbar" tabindex="-1">
-      <ToolbarButton disabled={documentId === null} icon={ArrowUpDownIcon} label="기본 툴바와 맞바꾸기" onclick={swap} />
-
-      <VerticalDivider style={css.raw({ height: '12px' })} />
-
-      {@render items(expanded)}
-    </div>
-
-    <Scrollbar
-      controls={expandedToolbarId}
-      label="툴바 가로 스크롤"
-      orientation="horizontal"
-      scrollContainer={expandedScrollContainer}
-      size="sm"
-    />
-  </div>
-{/if}

--- a/apps/website/src/routes/website/(dashboard)/zen-mode.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/zen-mode.svelte.ts
@@ -1,0 +1,376 @@
+import { createStableContext } from '@typie/ui/context/stable';
+import mixpanel from 'mixpanel-browser';
+import { tick } from 'svelte';
+import { writeReviewRoundSelection } from '$lib/prism/review-round-selection';
+import type { AppContext, ZenModeRestoreState } from '@typie/ui/context';
+import type { PaneGroup } from './[slug]/@pane/context.svelte';
+import type { RegisteredEditor } from './[slug]/@pane/editor-registry.svelte';
+
+export type ZenModeVia = 'shortcut' | 'command_palette' | 'pane_header' | 'esc';
+
+export type ZenModeReviewParticipant = {
+  paneId: string;
+  documentId: string;
+  ready: () => boolean;
+  selectedRoundId: () => string | null;
+  roundIds: () => readonly string[];
+  applySelection: (roundId: string | null) => void;
+};
+
+type ReviewRegistration = {
+  participant: ZenModeReviewParticipant;
+  closeWhenReady: boolean;
+};
+
+type EditorRegistry = {
+  get(paneId: string, slug: string): RegisteredEditor | undefined;
+};
+
+type ZenModeControllerOptions = {
+  app: Pick<AppContext, 'preference' | 'state'>;
+  paneGroup: PaneGroup;
+  editorRegistry: EditorRegistry;
+  focusWorkbench?: () => void;
+  track?: (event: 'zen_mode_enabled' | 'zen_mode_disabled', properties: { via: ZenModeVia }) => void;
+};
+
+const [getZenMode, setZenMode] = createStableContext<ZenModeController>('dashboard.ZenMode');
+
+export { getZenMode };
+
+export const restoreVisible = (entryVisible: boolean, currentVisible: boolean): boolean => entryVisible || currentVisible;
+
+export const restoreReviewRound = (entryRoundId: string | null, currentRoundId: string | null): string | null =>
+  currentRoundId ?? entryRoundId;
+
+const emptyRestoreState = (sidebarHidden: boolean, prismPanelOpen: boolean): ZenModeRestoreState => ({
+  version: 1,
+  sidebarHidden,
+  prismPanelOpen,
+  panelExpandedBySiteAndPaneId: {},
+  reviewRoundByPaneAndDocumentId: {},
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isBooleanRecord = (value: unknown): value is Record<string, boolean> =>
+  isRecord(value) && Object.values(value).every((entry) => typeof entry === 'boolean');
+
+const isPanelRestoreState = (value: unknown): value is ZenModeRestoreState['panelExpandedBySiteAndPaneId'] =>
+  isRecord(value) && Object.values(value).every(isBooleanRecord);
+
+const isReviewRoundRecord = (value: unknown): value is Record<string, string | null> =>
+  isRecord(value) && Object.values(value).every((entry) => entry === null || typeof entry === 'string');
+
+const isReviewRestoreState = (value: unknown): value is ZenModeRestoreState['reviewRoundByPaneAndDocumentId'] =>
+  isRecord(value) && Object.values(value).every(isReviewRoundRecord);
+
+const isRestoreState = (value: unknown): value is ZenModeRestoreState =>
+  isRecord(value) &&
+  value.version === 1 &&
+  typeof value.sidebarHidden === 'boolean' &&
+  typeof value.prismPanelOpen === 'boolean' &&
+  isPanelRestoreState(value.panelExpandedBySiteAndPaneId) &&
+  isReviewRestoreState(value.reviewRoundByPaneAndDocumentId);
+
+const hasOwn = <T extends object>(value: T, key: PropertyKey): boolean => Object.hasOwn(value, key);
+
+export class ZenModeController {
+  #app: ZenModeControllerOptions['app'];
+  #paneGroup: PaneGroup;
+  #editorRegistry: EditorRegistry;
+  #focusWorkbench: () => void;
+  #track: NonNullable<ZenModeControllerOptions['track']>;
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperative registration ownership; no render reads this collection directly
+  #reviews = new Set<ReviewRegistration>();
+  #restoreChecked = false;
+
+  constructor({ app, paneGroup, editorRegistry, focusWorkbench, track }: ZenModeControllerOptions) {
+    this.#app = app;
+    this.#paneGroup = paneGroup;
+    this.#editorRegistry = editorRegistry;
+    this.#focusWorkbench = focusWorkbench ?? (() => null);
+    this.#track = track ?? ((event, properties) => mixpanel.track(event, properties));
+  }
+
+  get active(): boolean {
+    return this.#app.preference.current.zenModeEnabled;
+  }
+
+  async restoreAfterReload(): Promise<void> {
+    if (this.#restoreChecked) return;
+    this.#restoreChecked = true;
+
+    const preference = this.#app.preference.current;
+    if (!preference.zenModeEnabled) {
+      if (preference.zenModeRestoreState !== null) this.#writePreference(false, null);
+      return;
+    }
+
+    if (isRestoreState(preference.zenModeRestoreState)) return;
+
+    const handoff = this.#needsFocusHandoff();
+    const restoreState = this.#captureRestoreState();
+    this.#markRegisteredReviewsForClose();
+    this.#writePreference(true, restoreState);
+    this.#closeGlobalSurfaces();
+    this.#closeCurrentPanePanels();
+    this.#closeReadyReviews();
+    if (handoff) await this.#handoffFocus();
+  }
+
+  async enter(via: Exclude<ZenModeVia, 'esc'>): Promise<void> {
+    if (this.active) return;
+
+    const handoff = this.#needsFocusHandoff();
+    this.#markRegisteredReviewsForClose();
+    const restoreState = this.#captureRestoreState();
+    this.#writePreference(true, restoreState);
+    this.#closeGlobalSurfaces();
+    this.#closeCurrentPanePanels();
+    this.#closeReadyReviews();
+    this.#track('zen_mode_enabled', { via });
+
+    if (handoff) await this.#handoffFocus();
+  }
+
+  async exit(via: ZenModeVia): Promise<void> {
+    if (!this.active) return;
+
+    const preference = this.#app.preference.current;
+    const restoreState = this.#restoreState() ?? this.#captureRestoreState();
+
+    const sidebarHidden = restoreState.sidebarHidden && preference.sidebarHidden;
+    const prismPanelOpen = restoreVisible(restoreState.prismPanelOpen, preference.prismPanelOpen);
+
+    for (const [siteId, entry] of Object.entries(restoreState.panelExpandedBySiteAndPaneId)) {
+      this.#paneGroup.restorePanelExpandedByPaneId(siteId, entry);
+    }
+
+    this.#restoreReviews(restoreState.reviewRoundByPaneAndDocumentId);
+    this.#app.state.sidebarPeek = false;
+    this.#app.preference.current = {
+      ...preference,
+      sidebarHidden,
+      prismPanelOpen,
+      zenModeEnabled: false,
+      zenModeRestoreState: null,
+    };
+    for (const registration of this.#reviews) registration.closeWhenReady = false;
+    this.#track('zen_mode_disabled', { via });
+  }
+
+  async toggle(via: Exclude<ZenModeVia, 'esc'>): Promise<void> {
+    if (this.active) await this.exit(via);
+    else await this.enter(via);
+  }
+
+  syncPanePanels(): void {
+    if (!this.active) return;
+    const restoreState = this.#restoreState();
+    if (!restoreState) return;
+
+    const siteId = this.#paneGroup.currentSiteId;
+    const entry = restoreState.panelExpandedBySiteAndPaneId[siteId] ?? {};
+    const current = this.#paneGroup.state.current.panelExpandedByPaneId;
+    const missing = this.#paneGroup.panes.filter((pane) => !hasOwn(entry, pane.id));
+    if (missing.length === 0) return;
+
+    const nextEntry = { ...entry };
+    const nextCurrent = { ...current };
+    const handoff = this.#needsFocusHandoff();
+    for (const pane of missing) {
+      nextEntry[pane.id] = current[pane.id] ?? false;
+      nextCurrent[pane.id] = false;
+    }
+
+    this.#persistRestoreState({
+      ...restoreState,
+      panelExpandedBySiteAndPaneId: { ...restoreState.panelExpandedBySiteAndPaneId, [siteId]: nextEntry },
+    });
+    this.#paneGroup.state.current.panelExpandedByPaneId = nextCurrent;
+    if (handoff) void this.#handoffFocus();
+  }
+
+  registerReview(participant: ZenModeReviewParticipant): () => void {
+    const restoreState = this.#restoreState();
+    const registration: ReviewRegistration = {
+      participant,
+      closeWhenReady:
+        this.active &&
+        !(restoreState && hasOwn(restoreState.reviewRoundByPaneAndDocumentId[participant.paneId] ?? {}, participant.documentId)),
+    };
+    this.#reviews.add(registration);
+    this.syncReview(participant);
+    return () => this.#reviews.delete(registration);
+  }
+
+  syncReview(participant: ZenModeReviewParticipant): void {
+    if (!this.active || !participant.ready()) return;
+    const registration = [...this.#reviews].find((candidate) => candidate.participant === participant);
+    if (!registration) return;
+
+    let restoreState = this.#restoreState();
+    if (!restoreState) return;
+
+    const documentId = participant.documentId;
+    const paneEntry = restoreState.reviewRoundByPaneAndDocumentId[participant.paneId] ?? {};
+    if (!hasOwn(paneEntry, documentId)) {
+      restoreState = {
+        ...restoreState,
+        reviewRoundByPaneAndDocumentId: {
+          ...restoreState.reviewRoundByPaneAndDocumentId,
+          [participant.paneId]: { ...paneEntry, [documentId]: participant.selectedRoundId() },
+        },
+      };
+      this.#persistRestoreState(restoreState);
+      registration.closeWhenReady = true;
+    }
+
+    if (!registration.closeWhenReady) return;
+    const handoff = this.#needsFocusHandoff();
+    registration.closeWhenReady = false;
+    participant.applySelection(null);
+    writeReviewRoundSelection(documentId, null);
+    if (handoff) void this.#handoffFocus();
+  }
+
+  // eslint-disable-next-line unicorn/consistent-class-member-order -- private lifecycle helpers stay together after the public command surface
+  #restoreState(): ZenModeRestoreState | null {
+    const restoreState = this.#app.preference.current.zenModeRestoreState;
+    return isRestoreState(restoreState) ? restoreState : null;
+  }
+
+  #writePreference(active: boolean, restoreState: ZenModeRestoreState | null): void {
+    this.#app.preference.current = {
+      ...this.#app.preference.current,
+      zenModeEnabled: active,
+      zenModeRestoreState: restoreState,
+    };
+  }
+
+  #persistRestoreState(restoreState: ZenModeRestoreState): void {
+    this.#writePreference(true, restoreState);
+  }
+
+  #captureRestoreState(): ZenModeRestoreState {
+    const preference = this.#app.preference.current;
+    const restoreState = emptyRestoreState(preference.sidebarHidden, preference.prismPanelOpen);
+    const siteId = this.#paneGroup.currentSiteId;
+    const panels = this.#paneGroup.readPanelExpandedByPaneId(siteId);
+    restoreState.panelExpandedBySiteAndPaneId[siteId] = Object.fromEntries(
+      this.#paneGroup.panes.map((pane) => [pane.id, panels[pane.id] ?? false]),
+    );
+
+    for (const { participant } of this.#reviews) {
+      if (!participant.ready()) continue;
+      const paneEntry = restoreState.reviewRoundByPaneAndDocumentId[participant.paneId] ?? {};
+      if (hasOwn(paneEntry, participant.documentId)) continue;
+      restoreState.reviewRoundByPaneAndDocumentId[participant.paneId] = {
+        ...paneEntry,
+        [participant.documentId]: participant.selectedRoundId(),
+      };
+    }
+    return restoreState;
+  }
+
+  #closeGlobalSurfaces(): void {
+    this.#app.state.sidebarPeek = false;
+    this.#app.preference.current = {
+      ...this.#app.preference.current,
+      sidebarHidden: true,
+      prismPanelOpen: false,
+    };
+  }
+
+  #closeCurrentPanePanels(): void {
+    const current = this.#paneGroup.state.current.panelExpandedByPaneId;
+    const closed = Object.fromEntries(Object.keys(current).map((paneId) => [paneId, false]));
+    for (const pane of this.#paneGroup.panes) closed[pane.id] = false;
+    this.#paneGroup.state.current.panelExpandedByPaneId = closed;
+  }
+
+  #markRegisteredReviewsForClose(): void {
+    for (const registration of this.#reviews) registration.closeWhenReady = true;
+  }
+
+  #closeReadyReviews(): void {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local deduplication for one close transaction
+    const documentIds = new Set<string>();
+    for (const registration of this.#reviews) {
+      if (!registration.closeWhenReady || !registration.participant.ready()) continue;
+      registration.closeWhenReady = false;
+      registration.participant.applySelection(null);
+      documentIds.add(registration.participant.documentId);
+    }
+    for (const documentId of documentIds) writeReviewRoundSelection(documentId, null);
+  }
+
+  #restoreReviews(entryByPaneAndDocumentId: ZenModeRestoreState['reviewRoundByPaneAndDocumentId']): void {
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local deduplication for one restore transaction
+    const persistedByDocumentId = new Map<string, string | null>();
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local precedence tracking for one restore transaction
+    const restoredLiveDocumentIds = new Set<string>();
+    for (const paneEntry of Object.values(entryByPaneAndDocumentId)) {
+      for (const [documentId, roundId] of Object.entries(paneEntry)) {
+        if (!persistedByDocumentId.has(documentId)) persistedByDocumentId.set(documentId, roundId);
+      }
+    }
+
+    for (const { participant } of this.#reviews) {
+      if (!participant.ready()) continue;
+      const paneEntry = entryByPaneAndDocumentId[participant.paneId];
+      if (!paneEntry || !hasOwn(paneEntry, participant.documentId)) continue;
+
+      const entryRoundId = paneEntry[participant.documentId] ?? null;
+      const currentRoundId = participant.selectedRoundId();
+      let resolved = restoreReviewRound(entryRoundId, currentRoundId);
+      if (resolved !== null && !participant.roundIds().includes(resolved)) resolved = null;
+      participant.applySelection(resolved);
+
+      if (!restoredLiveDocumentIds.has(participant.documentId) || participant.paneId === this.#paneGroup.state.current.focusedPaneId) {
+        persistedByDocumentId.set(participant.documentId, resolved);
+        restoredLiveDocumentIds.add(participant.documentId);
+      }
+    }
+    for (const [documentId, roundId] of persistedByDocumentId) writeReviewRoundSelection(documentId, roundId);
+  }
+
+  #needsFocusHandoff(): boolean {
+    if (typeof document === 'undefined') return false;
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) return true;
+    if (active.closest('[data-zen-mode-closing-surface], [data-zen-mode-pane-chrome]')) return true;
+    return active.closest('[data-pane-id]') === null;
+  }
+
+  async #handoffFocus(): Promise<void> {
+    if (typeof document === 'undefined') return;
+    await tick();
+
+    const focusedPaneId = this.#paneGroup.state.current.focusedPaneId;
+    const pane = focusedPaneId ? this.#paneGroup.panes.find((candidate) => candidate.id === focusedPaneId) : undefined;
+    if (pane?.kind === 'entity') {
+      const editor = this.#editorRegistry.get(pane.id, pane.slug);
+      if (editor) {
+        editor.focus();
+        return;
+      }
+    }
+
+    const escapedPaneId = focusedPaneId ? CSS.escape(focusedPaneId) : null;
+    const paneElement = escapedPaneId ? document.querySelector<HTMLElement>(`[data-pane-id="${escapedPaneId}"]`) : null;
+    if (paneElement?.isConnected) {
+      paneElement.focus({ preventScroll: true });
+      return;
+    }
+
+    this.#focusWorkbench();
+  }
+}
+
+export const setupZenMode = (options: ZenModeControllerOptions): ZenModeController => {
+  const controller = new ZenModeController(options);
+  setZenMode(controller);
+  return controller;
+};

--- a/apps/website/src/routes/website/(dashboard)/zen-mode.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/zen-mode.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest';
+import { restoreReviewRound, restoreVisible, ZenModeController } from './zen-mode.svelte';
+import type { AppContext, AppPreference, ZenModeRestoreState } from '@typie/ui/context';
+import type { PaneGroup, PaneGroupState } from './[slug]/@pane/types';
+
+const { writeReviewRoundSelection } = vi.hoisted(() => ({ writeReviewRoundSelection: vi.fn() }));
+vi.mock('$lib/prism/review-round-selection', () => ({ writeReviewRoundSelection }));
+
+const restoreState = (overrides: Partial<ZenModeRestoreState> = {}): ZenModeRestoreState => ({
+  version: 1,
+  sidebarHidden: false,
+  prismPanelOpen: true,
+  panelExpandedBySiteAndPaneId: { site: { first: true, deleted: true } },
+  reviewRoundByPaneAndDocumentId: {},
+  ...overrides,
+});
+
+const preference = (overrides: Partial<AppPreference> = {}) =>
+  ({
+    sidebarHidden: false,
+    prismPanelOpen: true,
+    zenModeEnabled: false,
+    zenModeRestoreState: null,
+    ...overrides,
+  }) as AppPreference;
+
+const fixture = (initialPreference: AppPreference = preference()) => {
+  const app = {
+    preference: { current: initialPreference },
+    state: { sidebarPeek: true },
+  } as unknown as Pick<AppContext, 'preference' | 'state'>;
+  const paneState: PaneGroupState = {
+    root: { id: 'first', type: 'pane', kind: 'entity', slug: 'document' },
+    focusedPaneId: 'first',
+    panelExpandedByPaneId: { first: true },
+    panelTabByPaneId: {},
+    toolbarExpandedByPaneId: {},
+  };
+  const restored: [string, Record<string, boolean>][] = [];
+  const paneGroup = {
+    currentSiteId: 'site',
+    panes: [{ id: 'first', type: 'pane', kind: 'entity', slug: 'document' }],
+    state: { current: paneState },
+    readPanelExpandedByPaneId: () => ({ ...paneState.panelExpandedByPaneId }),
+    restorePanelExpandedByPaneId: (siteId: string, entry: Record<string, boolean>) => {
+      restored.push([siteId, entry]);
+      const next = { ...paneState.panelExpandedByPaneId };
+      for (const [paneId, wasOpen] of Object.entries(entry)) {
+        if (paneId === 'first') next[paneId] = wasOpen || (next[paneId] ?? false);
+      }
+      paneState.panelExpandedByPaneId = next;
+    },
+  } as unknown as PaneGroup;
+  const track = vi.fn();
+  const controller = new ZenModeController({ app, paneGroup, editorRegistry: { get: vi.fn() }, track });
+  return { app, controller, paneGroup, paneState, restored, track };
+};
+
+describe('focus-mode restore rules', () => {
+  it.each([
+    [false, false, false],
+    [false, true, true],
+    [true, false, true],
+    [true, true, true],
+  ])('restores entry %s OR current %s as %s', (entry, current, expected) => {
+    expect(restoreVisible(entry, current)).toBe(expected);
+  });
+
+  it('keeps an in-mode review selection and otherwise restores the entry round', () => {
+    expect(restoreReviewRound('entry', 'current')).toBe('current');
+    expect(restoreReviewRound('entry', null)).toBe('entry');
+    expect(restoreReviewRound(null, null)).toBeNull();
+  });
+});
+
+describe('ZenModeController', () => {
+  it('captures and closes participants once, then restores entry OR current state', async () => {
+    const { app, controller, paneState, restored, track } = fixture();
+
+    await controller.enter('shortcut');
+    expect(app.preference.current).toMatchObject({ sidebarHidden: true, prismPanelOpen: false, zenModeEnabled: true });
+    expect(paneState.panelExpandedByPaneId.first).toBe(false);
+    expect(app.preference.current.zenModeRestoreState).toMatchObject({ sidebarHidden: false, prismPanelOpen: true });
+
+    app.preference.current.prismPanelOpen = false;
+    app.preference.current.sidebarHidden = false;
+    await controller.exit('esc');
+
+    expect(app.preference.current).toMatchObject({
+      sidebarHidden: false,
+      prismPanelOpen: true,
+      zenModeEnabled: false,
+      zenModeRestoreState: null,
+    });
+    expect(restored).toEqual([['site', { first: true }]]);
+    expect(track.mock.calls).toEqual([
+      ['zen_mode_enabled', { via: 'shortcut' }],
+      ['zen_mode_disabled', { via: 'esc' }],
+    ]);
+
+    await controller.exit('esc');
+    expect(track).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves current visibility on reload with a valid snapshot', async () => {
+    const snapshot = restoreState({ panelExpandedBySiteAndPaneId: { site: { first: true } } });
+    const { app, controller, paneState, track } = fixture(
+      preference({ sidebarHidden: false, prismPanelOpen: true, zenModeEnabled: true, zenModeRestoreState: snapshot }),
+    );
+    paneState.panelExpandedByPaneId.first = true;
+
+    await controller.restoreAfterReload();
+
+    expect(app.preference.current.zenModeRestoreState).toBe(snapshot);
+    expect(paneState.panelExpandedByPaneId.first).toBe(true);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('captures and closes once when an active preference has no restore snapshot', async () => {
+    const { app, controller, paneState, track } = fixture(preference({ zenModeEnabled: true, zenModeRestoreState: null }));
+
+    await controller.restoreAfterReload();
+    await controller.restoreAfterReload();
+
+    expect(app.preference.current.zenModeRestoreState).toMatchObject({ version: 1, sidebarHidden: false, prismPanelOpen: true });
+    expect(app.preference.current).toMatchObject({ sidebarHidden: true, prismPanelOpen: false, zenModeEnabled: true });
+    expect(paneState.panelExpandedByPaneId.first).toBe(false);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('captures and closes a pane first seen during the active session', () => {
+    const snapshot = restoreState({ panelExpandedBySiteAndPaneId: { site: { first: false } } });
+    const { app, controller, paneGroup, paneState } = fixture(
+      preference({ sidebarHidden: true, prismPanelOpen: false, zenModeEnabled: true, zenModeRestoreState: snapshot }),
+    );
+    paneGroup.panes.push({ id: 'second', type: 'pane', kind: 'home' });
+    paneState.panelExpandedByPaneId.second = true;
+
+    controller.syncPanePanels();
+
+    expect(paneState.panelExpandedByPaneId.second).toBe(false);
+    expect(app.preference.current.zenModeRestoreState?.panelExpandedBySiteAndPaneId.site?.second).toBe(true);
+  });
+
+  it('restores the review round independently for each pane showing the same document', async () => {
+    const { controller } = fixture();
+    let first: string | null = 'first-entry';
+    let second: string | null = 'second-entry';
+    const firstParticipant = {
+      paneId: 'first',
+      documentId: 'document',
+      ready: () => true,
+      selectedRoundId: () => first,
+      roundIds: () => ['first-entry', 'second-entry', 'second-current'],
+      applySelection: (roundId: string | null) => (first = roundId),
+    };
+    const secondParticipant = {
+      ...firstParticipant,
+      paneId: 'second',
+      selectedRoundId: () => second,
+      applySelection: (roundId: string | null) => (second = roundId),
+    };
+    controller.registerReview(firstParticipant);
+    controller.registerReview(secondParticipant);
+
+    await controller.enter('pane_header');
+    expect([first, second]).toEqual([null, null]);
+
+    second = 'second-current';
+    await controller.exit('pane_header');
+    expect([first, second]).toEqual(['first-entry', 'second-current']);
+  });
+
+  it('restores the persisted review round after its pane was unmounted in focus mode', async () => {
+    const { controller } = fixture();
+    let selected: string | null = 'entry';
+    const unregister = controller.registerReview({
+      paneId: 'first',
+      documentId: 'document',
+      ready: () => true,
+      selectedRoundId: () => selected,
+      roundIds: () => ['entry'],
+      applySelection: (roundId) => (selected = roundId),
+    });
+
+    await controller.enter('pane_header');
+    expect(selected).toBeNull();
+    unregister();
+    writeReviewRoundSelection.mockClear();
+
+    await controller.exit('pane_header');
+
+    expect(writeReviewRoundSelection).toHaveBeenCalledWith('document', 'entry');
+  });
+
+  it('persists the current review round from a live pane even when another pane is focused', async () => {
+    const { controller } = fixture();
+    let selected: string | null = 'entry';
+    controller.registerReview({
+      paneId: 'second',
+      documentId: 'document',
+      ready: () => true,
+      selectedRoundId: () => selected,
+      roundIds: () => ['entry', 'current'],
+      applySelection: (roundId) => (selected = roundId),
+    });
+
+    await controller.enter('pane_header');
+    selected = 'current';
+    writeReviewRoundSelection.mockClear();
+
+    await controller.exit('pane_header');
+
+    expect(writeReviewRoundSelection).toHaveBeenCalledWith('document', 'current');
+  });
+
+  it('drops an entry review round that no longer exists', async () => {
+    const { controller } = fixture();
+    let selected: string | null = 'deleted';
+    controller.registerReview({
+      paneId: 'first',
+      documentId: 'document',
+      ready: () => true,
+      selectedRoundId: () => selected,
+      roundIds: () => ['remaining'],
+      applySelection: (roundId) => (selected = roundId),
+    });
+
+    await controller.enter('command_palette');
+    await controller.exit('command_palette');
+    expect(selected).toBeNull();
+  });
+});

--- a/packages/ui/src/context/app.svelte.ts
+++ b/packages/ui/src/context/app.svelte.ts
@@ -1,6 +1,14 @@
 import { LocalStore, SessionStore } from '../state';
 import { createStableContext } from './stable-context';
 
+export type ZenModeRestoreState = {
+  version: 1;
+  sidebarHidden: boolean;
+  prismPanelOpen: boolean;
+  panelExpandedBySiteAndPaneId: Record<string, Record<string, boolean>>;
+  reviewRoundByPaneAndDocumentId: Record<string, Record<string, string | null>>;
+};
+
 export type AppPreference = {
   sidebarWidth: number;
   sidebarHidden: boolean;
@@ -35,6 +43,7 @@ export type AppPreference = {
   autoSurroundEnabled: boolean;
 
   zenModeEnabled: boolean;
+  zenModeRestoreState: ZenModeRestoreState | null;
 
   contextBarPinned: boolean;
 
@@ -178,6 +187,7 @@ export const setupAppContext = (userId: string) => {
       autoSurroundEnabled: true,
 
       zenModeEnabled: false,
+      zenModeRestoreState: null,
 
       contextBarPinned: true,
 


### PR DESCRIPTION
- 집중 모드에서도 현재 split view 배치를 그대로 유지합니다.
- 에디터가 pane header와 툴바 영역까지 차지하고, 헤더와 툴바는 포인터를 올렸을 때만 드러납니다.
- 헤더와 툴바가 자연스럽게 함께 나타나고 사라지도록 인터랙션을 개선했습니다.
- 줌 컨트롤, 찾기 및 바꾸기, 편집 잠금 안내와 문서 패널이 드러난 헤더와 툴바에 맞춰 배치됩니다.
- 진입 시 사이드바, PRISM, 문서 패널과 리뷰를 닫습니다. 집중 모드 중 다시 열 수 있으며, 종료할 때는 진입 전 또는 집중 모드 중 열었던 상태를 유지합니다.
- 새로고침 후에도 집중 모드를 유지합니다.
- 홈, 삭제된 문서, 로딩 중인 문서에서도 동일한 pane header와 집중 모드 조작을 제공합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>