### PR TITLE
pane divider transition 디버그

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Panes.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Panes.svelte
@@ -164,21 +164,26 @@
   {/if}
 
   {#if context.enabled && !context.draggingPaneId && layout}
-    {@const focusedRect = layout.panes.get(context.state.current.focusedPaneId ?? '')}
+    {@const focusedPaneId = context.state.current.focusedPaneId}
+    {@const focusedRect = layout.panes.get(focusedPaneId ?? '')}
     {#if focusedRect}
-      <div
-        style:left="{focusedRect.left}px"
-        style:top="{focusedRect.top}px"
-        style:width="{focusedRect.width}px"
-        style:height="{focusedRect.height}px"
-        class={css({
-          position: 'absolute',
-          pointerEvents: 'none',
-          boxShadow: '[0 0 0 1px token(colors.border.default)]',
-          zIndex: 'overEditor',
-        })}
-        transition:fade|global={{ duration: 150 }}
-      ></div>
+      {#key focusedPaneId}
+        <div
+          style:left="{focusedRect.left}px"
+          style:top="{focusedRect.top}px"
+          style:width="{focusedRect.width}px"
+          style:height="{focusedRect.height}px"
+          class={css({
+            position: 'absolute',
+            pointerEvents: 'none',
+            boxShadow: '[0 0 0 1px token(colors.border.default)]',
+            zIndex: 'overEditor',
+          })}
+          out:fade|global={{
+            duration: context.enabled && !context.draggingPaneId && context.panes.some((pane) => pane.id === focusedPaneId) ? 150 : 0,
+          }}
+        ></div>
+      {/key}
     {/if}
   {/if}
 


### PR DESCRIPTION
- pane 제거 시 stale한 divider가 허공에 잠시 남아 보이는 버그를 수정
- focused pane이 전환될 때 focused pane outline이 transition 될 수 있도록 디버그 (다만, outro transition만 남김)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>