### PR TITLE
프리즘 리뷰 회차 전환을 자연스럽게 개선

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -1437,16 +1437,16 @@ type PrismReviewStrength {
 }
 
 type PrismReviewThread {
-  anchors: [PrismReviewAnchor!]!
+  anchors(roundId: ID): [PrismReviewAnchor!]!
   body: String
   comments: [PrismReviewThreadComment!]!
   id: ID!
-  isNew: Boolean!
+  isNew(roundId: ID): Boolean!
   issueId: String
-  issueIndex: Int!
+  issueIndex(roundId: ID): Int!
   lineage: PrismReviewLineage!
   pass: PrismReviewPass!
-  quote: String!
+  quote(roundId: ID): String!
   reaction: PrismReaction
   settledRound: PrismReviewRound
   state: PrismReviewThreadState!

--- a/apps/api/src/graphql/resolvers/prism-review.ts
+++ b/apps/api/src/graphql/resolvers/prism-review.ts
@@ -166,8 +166,9 @@ PrismReviewThread.implement({
   fields: (t) => ({
     id: t.exposeID('id'),
     issueIndex: t.int({
-      resolve: async (self, _, ctx) => {
-        const seat = await viewSeat(ctx, self.id);
+      args: { roundId: t.arg.id({ required: false, validate: validateDbId(TableCode.PRISM_REVIEW_ROUNDS) }) },
+      resolve: async (self, args, ctx) => {
+        const seat = await viewSeat(ctx, self.id, args.roundId ?? undefined);
         return seat?.issueIndex ?? 0;
       },
     }),
@@ -177,15 +178,17 @@ PrismReviewThread.implement({
     body: t.exposeString('body', { nullable: true }),
     anchors: t.field({
       type: [PrismReviewAnchor],
-      resolve: async (self, _, ctx) => {
-        const seat = await viewSeat(ctx, self.id);
+      args: { roundId: t.arg.id({ required: false, validate: validateDbId(TableCode.PRISM_REVIEW_ROUNDS) }) },
+      resolve: async (self, args, ctx) => {
+        const seat = await viewSeat(ctx, self.id, args.roundId ?? undefined);
         return seat?.anchors ?? [];
       },
     }),
     quote: t.string({
+      args: { roundId: t.arg.id({ required: false, validate: validateDbId(TableCode.PRISM_REVIEW_ROUNDS) }) },
       // 카드는 앵커가 살아 있든 자리를 잃었든 이 인용을 보여 준다
-      resolve: async (self, _, ctx) => {
-        const seat = await viewSeat(ctx, self.id);
+      resolve: async (self, args, ctx) => {
+        const seat = await viewSeat(ctx, self.id, args.roundId ?? undefined);
         if (seat === null) {
           return '';
         }
@@ -200,9 +203,10 @@ PrismReviewThread.implement({
     lineage: t.field({ type: PrismReviewLineage, resolve: (self) => self.lineageId }),
     settledRound: t.field({ type: PrismReviewRound, nullable: true, resolve: (self) => self.settledRoundId }),
     isNew: t.boolean({
+      args: { roundId: t.arg.id({ required: false, validate: validateDbId(TableCode.PRISM_REVIEW_ROUNDS) }) },
       // 어느 회차의 눈으로 보는지 기록이 없으면(뮤테이션 반환 등) 표지를 세우지 않는다
-      resolve: async (self, _, ctx) => {
-        const viewRoundId = viewedRoundOf(ctx, self.id);
+      resolve: async (self, args, ctx) => {
+        const viewRoundId = args.roundId ?? viewedRoundOf(ctx, self.id);
         if (viewRoundId === null) {
           return false;
         }

--- a/apps/api/src/utils/prism-review-threads.ts
+++ b/apps/api/src/utils/prism-review-threads.ts
@@ -134,8 +134,11 @@ export const latestSeat = async (threadId: string): Promise<Seat | null> =>
 
 // 뷰 회차의 좌석이 있으면 그것, 없으면(정리된 스레드) 마지막 좌석.
 // 폴백은 한 스레드의 issueIndex·anchors·quote가 저마다 다시 치므로 요청 안에서 한 번만 읽는다.
-export const viewSeat = async (scope: object, threadId: string): Promise<Seat | null> => {
-  const roundId = viewedRoundOf(scope, threadId);
+export const viewSeat = async (
+  scope: object,
+  threadId: string,
+  roundId: string | null = viewedRoundOf(scope, threadId),
+): Promise<Seat | null> => {
   if (roundId !== null) {
     const seats = await roundSeats(scope, roundId);
     const seat = seats.get(threadId);

--- a/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewDetail.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@prism/review/PrismReviewDetail.svelte
@@ -34,7 +34,7 @@
 
           threads {
             id
-            issueIndex
+            issueIndex(roundId: $roundId)
           }
 
           detail {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardPopover.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismCardPopover.svelte
@@ -8,6 +8,7 @@
   import { fade } from 'svelte/transition';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { pageRectsToVirtualElement } from '$lib/editor-ffi/geometry';
+  import { fadeIn, fadeOut, reducedMotion } from '../../../@prism/lib/motion.ts';
   import { getMarginContext } from './context.svelte.ts';
   import { COLUMN_GAP, COLUMN_WIDTH } from './margin-view.ts';
   import PrismCard from './PrismCard.svelte';
@@ -44,6 +45,10 @@
   // 카드는 큰 블록이다 — 짧으면 전환이 있었는지조차 보이지 않는다. quintOut ≈ cubic-bezier(0.22, 1, 0.36, 1)
   const FADE_MS = 300;
   const cardFade = { duration: FADE_MS, easing: quintOut };
+  const reduceMotion = reducedMotion();
+  const roundFadeIn = { ...fadeIn, duration: reduceMotion ? 0 : fadeIn.duration };
+  const roundFadeOut = { ...fadeOut, duration: reduceMotion ? 0 : fadeOut.duration };
+  const roundTransitioning = $derived(margin.selectedRoundId !== margin.presentationRoundId || margin.roundVisibilityProgress < 1);
 
   const scroller = $derived(ctx.editor?.scrollContainerEl);
 
@@ -179,8 +184,18 @@
   >
     <!-- 전환은 안쪽에서 받는다 — 바깥 요소의 opacity는 앵커 이탈 숨김이 쓰고 있어,
          켜짐/꺼짐 페이드까지 같은 요소에 얹으면 두 기제가 같은 속성을 다툰다 -->
-    <div class={css({ display: 'flex', flexDirection: 'column', minHeight: '0' })} in:fade={cardFade} out:fade={cardFade}>
-      <PrismCard expanded={true} item={active} onClose={() => margin.activate(null)} onToggle={() => margin.activate(null)} scrollable />
+    <div
+      style:pointer-events={margin.roundInteractive ? undefined : 'none'}
+      class={css({ display: 'flex', flexDirection: 'column', minHeight: '0' })}
+      inert={!margin.roundInteractive}
+    >
+      <div
+        class={css({ display: 'flex', flexDirection: 'column', minHeight: '0' })}
+        in:fade={roundTransitioning ? roundFadeIn : cardFade}
+        out:fade={roundTransitioning ? roundFadeOut : cardFade}
+      >
+        <PrismCard expanded={true} item={active} onClose={() => margin.activate(null)} onToggle={() => margin.activate(null)} scrollable />
+      </div>
     </div>
   </div>
 {/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
   import { css } from '@typie/styled-system/css';
-  import { Button, SegmentButtons } from '@typie/ui/components';
+  import { portal } from '@typie/ui/actions';
+  import { Button, RingSpinner, SegmentButtons } from '@typie/ui/components';
   import { untrack } from 'svelte';
+  import { fade } from 'svelte/transition';
   import { PAGE_GAP } from '$lib/editor-ffi/constants';
   import { getEditorContext } from '$lib/editor-ffi/editor.svelte';
   import { resolveCachedPageSpans } from '$lib/editor-ffi/geometry';
   import { resolveContinuousViewPadding } from '$lib/editor-ffi/zoom';
+  import { fadeIn, fadeOut, reducedMotion } from '../../../@prism/lib/motion.ts';
   import PrismReviewDetail from '../../../@prism/review/PrismReviewDetail.svelte';
   import { getMarginContext } from './context.svelte.ts';
-  import { lanePresentation, targetColumnLeft } from './margin-motion.ts';
+  import { lanePresentation, targetColumnLeft, visibleAreaCenterY } from './margin-motion.ts';
   import { COLUMN_GAP, COLUMN_WIDTH, GUTTER } from './margin-view.ts';
   import PrismCardColumn from './PrismCardColumn.svelte';
   import PrismCardPopover from './PrismCardPopover.svelte';
@@ -34,6 +37,8 @@
   let marks = $state.raw<Mark[]>([]);
   let bodyLeft = $state(0);
   let columnLeft = $state(0);
+  let spinnerLeft = $state<number | null>(null);
+  let spinnerTop = $state<number | null>(null);
   const railAnimation = $derived.by(() => {
     if (!contentMotion || contentMotion.fromX === 0) return;
     const name = contentMotion.fromX > 0 ? 'editor-content-from-right' : 'editor-content-from-left';
@@ -64,7 +69,11 @@
     const editor = ctx.editor;
     const area = editor?.extensionAreaEl;
     const snapshot = editor?.published?.snapshot;
-    if (!editor || !area || !snapshot) return;
+    if (!editor || !area || !snapshot) {
+      spinnerLeft = null;
+      spinnerTop = null;
+      return;
+    }
 
     const areaRect = area.getBoundingClientRect();
     const zoom = editor.safeDisplayZoom();
@@ -156,6 +165,16 @@
         columnLeft = targetColumnLeft(pageLayoutLeft + pageRect.width, layoutProgress);
       }
     }
+
+    if (scroller) {
+      const viewport = scroller.getBoundingClientRect();
+      const visibleArea = ctx.scroll?.visibleArea ?? { topInset: 0, bottomInset: 0 };
+      spinnerLeft = areaRect.left + columnLeft + COLUMN_WIDTH / 2;
+      spinnerTop = visibleAreaCenterY(viewport.top, viewport.height, visibleArea);
+    } else {
+      spinnerLeft = null;
+      spinnerTop = null;
+    }
   };
 
   // 의미 좌표는 판이 바뀔 때만 갱신한다. presentation 측정은 아래 effect 한 곳에서 수행한다.
@@ -173,6 +192,8 @@
     const editor = ctx.editor;
     void itemsKey;
     void editor?.presentationGeometryRevision;
+    void ctx.scroll?.visibleArea.topInset;
+    void ctx.scroll?.visibleArea.bottomInset;
     untrack(measure);
   });
 
@@ -231,6 +252,7 @@
        tabindex는 포커스 탐색을 여기서 멈추기 위한 것이다 — 없으면 클릭이 레이어를 지나쳐
        에디터 쪽 조상에 포커스를 앉히고, 그 focusin이 원고 입력을 도로 잡아채 카드 선택이 지워진다. -->
   <div
+    style:opacity={margin.roundVisibilityProgress}
     class={css({
       position: 'absolute',
       inset: '0',
@@ -241,6 +263,7 @@
     })}
     data-zen-mode-closing-surface
     draggable={false}
+    inert={!margin.roundInteractive}
     onclick={(event) => event.stopPropagation()}
     oncontextmenu={(event) => event.stopPropagation()}
     ondragenter={(event) => event.stopPropagation()}
@@ -336,11 +359,26 @@
          잡힌 포인터 캡처가 click을 가로채 활성화 자체가 불발된다.
          변형 조상이 없으므로 position:fixed는 여기서도 뷰포트 기준 그대로다. -->
     {#if margin.selectedRoundId !== null}
-      <PrismOverviewRuler {marks} />
+      <PrismOverviewRuler interactive={margin.roundInteractive} {marks} opacity={margin.roundVisibilityProgress} />
     {/if}
   </div>
 
   {#if margin.detailRound !== null}
     <PrismReviewDetail round={margin.detailRound} bind:open={detailOpen} />
   {/if}
+{/if}
+
+{#if margin.roundLoading && margin.mode === 'column' && spinnerLeft !== null && spinnerTop !== null}
+  <div
+    style:left={`${spinnerLeft}px`}
+    style:top={`${spinnerTop}px`}
+    class={css({ position: 'fixed', zIndex: '10', pointerEvents: 'none', transform: 'translate(-50%, -50%)' })}
+    aria-label="리뷰 불러오는 중"
+    role="status"
+    use:portal
+    in:fade={{ ...fadeIn, duration: reducedMotion() ? 0 : fadeIn.duration }}
+    out:fade={{ ...fadeOut, duration: reducedMotion() ? 0 : fadeOut.duration }}
+  >
+    <RingSpinner style={css.raw({ size: '20px', color: 'text.faint' })} />
+  </div>
 {/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismOverviewRuler.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismOverviewRuler.svelte
@@ -5,8 +5,12 @@
   import { getMarginContext } from './context.svelte.ts';
   import type { RailTone } from './rail-layout.ts';
 
-  type Props = { marks: { itemId: string; ratio: number; tone: RailTone }[] };
-  let { marks }: Props = $props();
+  type Props = {
+    marks: { itemId: string; ratio: number; tone: RailTone }[];
+    opacity?: number;
+    interactive?: boolean;
+  };
+  let { marks, opacity = 1, interactive = true }: Props = $props();
 
   const ctx = getEditorContext();
   const margin = getMarginContext();
@@ -73,7 +77,9 @@
     style:top={`${rect.top}px`}
     style:right={`${window.innerWidth - rect.right + SCROLLBAR_TRACK}px`}
     style:height={`${rect.height - bottomInset}px`}
+    style:opacity
     class={css({ position: 'fixed', zIndex: '10', width: '10px', pointerEvents: 'none' })}
+    inert={!interactive}
     use:portal
   >
     {#each marks as mark (mark.itemId)}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewHighlightLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewHighlightLayer.svelte
@@ -40,7 +40,7 @@
 </script>
 
 {#if editor}
-  {#each highlight.rects as rect (`${rect.rangeId}:${rect.fragmentIndex}`)}
+  {#each highlight.rects as rect (`${margin.presentationRoundId}:${rect.rangeId}:${rect.fragmentIndex}`)}
     <PrismReviewHighlightRect {edge} {editor} {fill} kind={highlight.kind} rect={rect.pageRect} />
   {/each}
 {/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewHighlightRect.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewHighlightRect.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { fade } from 'svelte/transition';
   import { presentedPageElement } from '$lib/editor-ffi/geometry';
+  import { fadeIn, fadeOut, reducedMotion } from '../../../@prism/lib/motion.ts';
   import type { PageRect } from '@typie/editor-ffi/browser';
   import type { Editor } from '$lib/editor-ffi/editor.svelte';
 
@@ -34,6 +36,8 @@
   style:height={`${rect.rect.height}px`}
   class="prism-review-highlight"
   data-prism-review-highlight={kind}
+  in:fade={{ ...fadeIn, duration: reducedMotion() ? 0 : fadeIn.duration }}
+  out:fade={{ ...fadeOut, duration: reducedMotion() ? 0 : fadeOut.duration }}
 ></div>
 
 <style>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
@@ -9,7 +9,7 @@
   import { takeMarginJump } from '$lib/prism/margin-jump.svelte';
   import { readReviewRoundSelection, writeReviewRoundSelection } from '$lib/prism/review-round-selection';
   import { graphql } from '$mearie';
-  import { PRISM_VISIBILITY_MOTION, prismVisibilityEasing, reducedMotion } from '../../../@prism/lib/motion.ts';
+  import { fadeIn, fadeOut, PRISM_VISIBILITY_MOTION, prismVisibilityEasing, reducedMotion } from '../../../@prism/lib/motion.ts';
   import { TIER_OPTIONS } from '../../../@prism/review/tiers.ts';
   import { getZenMode } from '../../../zen-mode.svelte';
   import { getPane } from '../../@pane/context.svelte';
@@ -20,16 +20,19 @@
     marginMotionDuration,
     marginMotionTarget,
     nextMarginReserved,
-    resolvePresentedRoundId,
+    resolveRoundSwap,
   } from './margin-motion.ts';
   import { describeThread, resolveMode } from './margin-view.ts';
   import PrismReviewHighlightLayer from './PrismReviewHighlightLayer.svelte';
+  import type { DataOf } from '@mearie/svelte';
   import type { StableSelection } from '@typie/editor-ffi/browser';
   import type { Snippet } from 'svelte';
   import type { MarginJump } from '$lib/prism/margin-jump.svelte';
+  import type { DocumentPrismReviewMargin_Round_Query } from '$mearie';
   import type { DetailRound } from '../../../@prism/review/round-view.ts';
   import type { ZenModeReviewParticipant } from '../../../zen-mode.svelte';
   import type { MarginActivation, MarginItem, MarginPlacement, MarginSegment } from './context.svelte.ts';
+  import type { RoundSwapState } from './margin-motion.ts';
   import type { MarginMode, RoundOption } from './margin-view.ts';
 
   // 인셋은 모드에 따라 정해지므로 자식에게 인자로 넘긴다 — DocumentEditor가 그대로 EditorComponent에 준다
@@ -53,6 +56,7 @@
   let { documentId, entityId, myId, available, bodyWidth, children }: Props = $props();
 
   type Seat = { id: string; selection: StableSelection; tone: 'issue' | 'strength' };
+  type ReviewRound = DataOf<DocumentPrismReviewMargin_Round_Query>['prismReviewRound'];
   type Spec = {
     anchors: readonly { selection?: unknown }[];
     tone: 'issue' | 'strength';
@@ -224,12 +228,12 @@
     if (mode !== 'column') presentationPrepared = false;
   });
 
-  // 선택은 즉시 바뀌되, 닫힘을 그리는 데이터만 진행률이 0이 될 때까지 마지막 회차를 붙잡는다.
-  let lastRoundId = $state<string | null>(null);
-  $effect(() => {
-    if (selectedRoundId !== null) lastRoundId = selectedRoundId;
-  });
-  const presentedRoundId = $derived(resolvePresentedRoundId(selectedRoundId, lastRoundId, presentation.current));
+  // 패널 열림/닫힘과 회차 교체는 서로 다른 수명이다. 회차 교체 중에는 기존 결과를 fade-out 끝까지
+  // 붙잡고, 새 데이터와 카드 배치가 모두 준비된 뒤에만 전체 표면을 다시 드러낸다.
+  let presentedRound = $state.raw<ReviewRound | null>(null);
+  let presentedFor: string | null = null;
+  let roundSwap = $state.raw<RoundSwapState>({ phase: 'idle' });
+  const roundVisibility = new Tween(1);
 
   const select = (roundId: string | null) => {
     selection = roundId;
@@ -240,7 +244,7 @@
   const detailRound = $derived.by((): DetailRound | null => {
     const entity = roundsQuery.data?.entity;
     if (idle || entity === undefined || entity.node.__typename !== 'Document') return null;
-    const selected = entity.node.prismReviewRounds.find((round) => round.id === presentedRoundId);
+    const selected = entity.node.prismReviewRounds.find((round) => round.id === presentedRound?.id);
     if (selected === undefined || !selected.hasDetail) return null;
     return {
       id: selected.id,
@@ -260,14 +264,14 @@
           issueCount
           threads {
             id
-            issueIndex
+            issueIndex(roundId: $roundId)
             trait
             body
-            quote
+            quote(roundId: $roundId)
             state
             reaction
-            isNew
-            anchors {
+            isNew(roundId: $roundId)
+            anchors(roundId: $roundId) {
               selection
             }
             comments {
@@ -289,14 +293,14 @@
           }
           settledThreads {
             id
-            issueIndex
+            issueIndex(roundId: $roundId)
             trait
             body
-            quote
+            quote(roundId: $roundId)
             state
             reaction
-            isNew
-            anchors {
+            isNew(roundId: $roundId)
+            anchors(roundId: $roundId) {
               selection
             }
             comments {
@@ -347,8 +351,8 @@
         }
       }
     `),
-    () => ({ roundId: presentedRoundId ?? '' }),
-    () => ({ skip: presentedRoundId === null }),
+    () => ({ roundId: selectedRoundId ?? '' }),
+    () => ({ skip: selectedRoundId === null }),
   );
 
   createSubscription(
@@ -384,11 +388,40 @@
     }),
   );
 
-  // 지금 표시할 회차의 것이 아닌 응답은 쓰지 않는다 — 회차를 바꾼 직후 한 틱 동안 옛 회차가 그려진다
-  const round = $derived.by(() => {
+  // 쿼리는 목표 회차를 미리 불러오지만, 실제 표시 데이터의 교체는 fade-out 경계가 소유한다.
+  const loadedRound = $derived.by(() => {
     const detail = detailQuery.data?.prismReviewRound;
-    return detail !== undefined && detail.id === presentedRoundId ? detail : null;
+    return detail !== undefined && detail.id === selectedRoundId ? detail : null;
   });
+
+  $effect(() => {
+    const id = documentId;
+    if (presentedFor === id) return;
+    untrack(() => {
+      presentedFor = id;
+      presentedRound = null;
+      roundSwap = { phase: 'idle' };
+      void roundVisibility.set(1, { duration: 0 });
+    });
+  });
+
+  // 첫 표시와 완전 닫힘은 컬럼 presentation이 맡는다. 같은 회차의 갱신은 즉시 받되,
+  // 서로 다른 회차의 교체만 아래 roundSwap 상태가 fade-out 경계에서 수행한다.
+  $effect(() => {
+    const selected = selectedRoundId;
+    const loaded = loadedRound;
+    const current = presentedRound;
+    const progress = presentation.current;
+    untrack(() => {
+      if (selected === null) {
+        if (progress === 0) presentedRound = null;
+      } else if (current !== loaded && loaded?.id === selected && (current === null || current.id === selected)) {
+        presentedRound = loaded;
+      }
+    });
+  });
+
+  const round = $derived(presentedRound);
 
   // 그 계보의 다음 리뷰가 도는 동안에는 답글·닫기가 사영의 입력을 바꾼다 — 회차 경계 밖에서 잠근다
   const locked = $derived(round?.lineage.locked ?? false);
@@ -413,6 +446,8 @@
   let raw = $state.raw<MarginPlacement[]>([]);
   // 지금 선 항목이 어느 회차의 것인지 — 회차를 갈아 끼운 직후엔 고른 회차와 어긋난다
   let builtRoundId = $state<string | null>(null);
+  // clear/add를 요청한 판보다 새 editor 판이 적용되어야 새 앵커의 자리를 준비했다고 볼 수 있다.
+  let rangeInstallation = $state.raw<{ roundId: string; previousRevision: number } | null>(null);
 
   // 앵커는 서버가 리뷰 시점에 캡처한 selection이라 회차당 정적이다 — 회차 전환·데이터 도착 때만 전량 재설치하고,
   // 편집 뒤의 자리는 코어가 매 판 해소한다(자리를 잃은 range는 tracked_ranges()에서 빠지고, 되돌리기로 돌아오면 다시 선다).
@@ -423,6 +458,7 @@
       raw = [];
       ready = false;
       builtRoundId = null;
+      rangeInstallation = null;
       presentationPrepared = false;
       return;
     }
@@ -438,7 +474,7 @@
       ...round.threads.map((thread) => ({
         anchors: thread.anchors,
         tone: 'issue' as const,
-        rangeId: (at: number) => `${thread.id}:${at}`,
+        rangeId: (at: number) => `${round.id}:${thread.id}:${at}`,
         item: {
           id: thread.id,
           kind: 'issue' as const,
@@ -450,7 +486,7 @@
       ...strengths.map((strength, index) => ({
         anchors: strength.anchors,
         tone: 'strength' as const,
-        rangeId: (at: number) => `strength:${index}:${at}`,
+        rangeId: (at: number) => `${round.id}:strength:${index}:${at}`,
         item: {
           id: `strength:${index}`,
           kind: 'strength' as const,
@@ -474,10 +510,12 @@
       nextRaw.push({ ...spec.item, rangeIds });
     }
 
+    const previousRevision = current.appliedRevision;
     current.setPrismReviewRanges(installs);
     raw = nextRaw;
     ready = true;
     builtRoundId = round.id;
+    rangeInstallation = { roundId: round.id, previousRevision };
   };
 
   const markPresentationPrepared = (roundId: string) => {
@@ -520,6 +558,50 @@
     void editor;
     void placementKey;
     untrack(() => buildItems());
+  });
+
+  const rangesApplied = $derived(
+    editor !== undefined &&
+      rangeInstallation !== null &&
+      rangeInstallation.roundId === builtRoundId &&
+      editor.appliedRevision > rangeInstallation.previousRevision,
+  );
+  const selectedRoundPrepared = $derived(
+    selectedRoundId !== null && builtRoundId === selectedRoundId && ready && rangesApplied && (mode !== 'column' || presentationPrepared),
+  );
+  const roundLoading = $derived(roundSwap.phase === 'waiting' || (roundSwap.phase === 'preparing' && roundSwap.spinnerVisible));
+  const roundInteractive = $derived(
+    roundSwap.phase === 'idle' && selectedRoundPrepared && roundVisibility.target === 1 && roundVisibility.current === 1,
+  );
+
+  $effect(() => {
+    const state = roundSwap;
+    const selected = selectedRoundId;
+    const presented = presentedRound;
+    const loaded = loadedRound;
+    const resolution = resolveRoundSwap(state, {
+      selectedRoundId: selected,
+      presentedRoundId: presented?.id ?? null,
+      loadedRoundId: loaded?.id ?? null,
+      visibilityProgress: roundVisibility.current,
+      prepared: selectedRoundPrepared,
+      failed: detailQuery.error !== undefined,
+    });
+
+    untrack(() => {
+      if (resolution.state !== state) roundSwap = resolution.state;
+      if (resolution.replacePresented && loaded?.id === selected) presentedRound = loaded;
+
+      if (presented !== null && resolution.restoreSelection) {
+        select(presented.id);
+        Toast.error('리뷰를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.');
+      }
+
+      if (roundVisibility.target !== resolution.visibilityTarget) {
+        const options = resolution.visibilityTarget === 0 ? fadeOut : fadeIn;
+        void roundVisibility.set(resolution.visibilityTarget, { ...options, duration: reduceMotion ? 0 : options.duration });
+      }
+    });
   });
 
   // 닫는다고 목록에서 빠지지 않는다 — 이번 회차의 피드백은 닫혀도 회색으로 제자리에 남는다.
@@ -618,7 +700,7 @@
     }
 
     // 강점 id는 회차마다 되풀이된다 — 아직 옛 회차의 항목이 서 있는 동안 엉뚱한 곳으로 가지 않도록 회차까지 본다
-    if (builtRoundId !== target.roundId || items.every((item) => item.id !== target.itemId)) return;
+    if (!selectedRoundPrepared || builtRoundId !== target.roundId || items.every((item) => item.id !== target.itemId)) return;
 
     untrack(() => {
       activate(target.itemId);
@@ -791,8 +873,17 @@
     get presentationProgress() {
       return presentation.current;
     },
+    get roundVisibilityProgress() {
+      return roundVisibility.current;
+    },
+    get roundLoading() {
+      return roundLoading;
+    },
+    get roundInteractive() {
+      return roundInteractive;
+    },
     get presentationInteractive() {
-      return presentationTarget === 1 && presentation.current === 1;
+      return presentationTarget === 1 && presentation.current === 1 && roundInteractive;
     },
     get myId() {
       return myId;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/context.svelte.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/context.svelte.ts
@@ -44,6 +44,9 @@ export type MarginController = {
   readonly ready: boolean;
   readonly presentationRoundId: string | null;
   readonly presentationProgress: number;
+  readonly roundVisibilityProgress: number;
+  readonly roundLoading: boolean;
+  readonly roundInteractive: boolean;
   readonly presentationInteractive: boolean;
   readonly myId: string;
   readonly locked: boolean;

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/margin-motion.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/margin-motion.test.ts
@@ -6,8 +6,9 @@ import {
   marginMotionDuration,
   marginMotionTarget,
   nextMarginReserved,
-  resolvePresentedRoundId,
+  resolveRoundSwap,
   targetColumnLeft,
+  visibleAreaCenterY,
 } from './margin-motion.ts';
 import { COLUMN_GAP, COLUMN_WIDTH, GUTTER } from './margin-view.ts';
 
@@ -23,24 +24,6 @@ describe('marginInsets', () => {
     expect(marginInsets(1.2)).toEqual(marginInsets(1));
     expect(lanePresentation(-0.2)).toEqual(lanePresentation(0));
     expect(lanePresentation(1.2)).toEqual(lanePresentation(1));
-  });
-});
-
-describe('resolvePresentedRoundId', () => {
-  it('닫힘이 끝나기 전까지만 마지막 회차를 유지한다', () => {
-    expect(resolvePresentedRoundId(null, 'round-a', 1)).toBe('round-a');
-    expect(resolvePresentedRoundId(null, 'round-a', 0.2)).toBe('round-a');
-    expect(resolvePresentedRoundId(null, 'round-a', 0)).toBeNull();
-    expect(resolvePresentedRoundId('round-b', 'round-a', 0.2)).toBe('round-b');
-  });
-
-  it('닫히는 중 다시 열면 표시 회차를 비우지 않고 목표를 되돌린다', () => {
-    const closingProgress = 0.4;
-    expect(resolvePresentedRoundId(null, 'round-a', closingProgress)).toBe('round-a');
-    expect(marginMotionTarget('column', false, false, true)).toBe(0);
-
-    expect(resolvePresentedRoundId('round-a', 'round-a', closingProgress)).toBe('round-a');
-    expect(marginMotionTarget('column', false, true, true)).toBe(1);
   });
 });
 
@@ -93,5 +76,111 @@ describe('contentMotionOffset', () => {
     const closingVisualLeft = closingLayoutLeft + contentMotionOffset(0, progress, shift);
 
     expect(openingVisualLeft).toBeCloseTo(closingVisualLeft);
+  });
+});
+
+type RoundSwapInput = {
+  selectedRoundId: string | null;
+  presentedRoundId: string | null;
+  loadedRoundId: string | null;
+  visibilityProgress: number;
+  prepared: boolean;
+  failed: boolean;
+};
+
+const swappingFromAToB = (overrides: Partial<RoundSwapInput> = {}): RoundSwapInput => ({
+  selectedRoundId: 'round-b',
+  presentedRoundId: 'round-a',
+  loadedRoundId: null,
+  visibilityProgress: 1,
+  prepared: false,
+  failed: false,
+  ...overrides,
+});
+
+describe('회차 교체 상태', () => {
+  it('완료된 상태를 다시 계산할 때 같은 객체를 유지해 reactive effect를 재실행하지 않는다', () => {
+    const idle = { phase: 'idle' } as const;
+    const resolution = resolveRoundSwap(idle, swappingFromAToB({ selectedRoundId: 'round-a', loadedRoundId: 'round-a' }));
+
+    expect(resolution.state).toBe(idle);
+  });
+
+  it('fade-out 안에 데이터가 오면 스피너 없이 배치를 마친 뒤 fade-in한다', () => {
+    let resolution = resolveRoundSwap({ phase: 'idle' }, swappingFromAToB());
+    expect(resolution).toMatchObject({ state: { phase: 'fading-out', targetId: 'round-b' }, visibilityTarget: 0 });
+
+    resolution = resolveRoundSwap(resolution.state, swappingFromAToB({ loadedRoundId: 'round-b', visibilityProgress: 0 }));
+    expect(resolution).toEqual({
+      state: { phase: 'preparing', targetId: 'round-b', spinnerVisible: false },
+      replacePresented: true,
+      restoreSelection: false,
+      visibilityTarget: 0,
+    });
+
+    resolution = resolveRoundSwap(resolution.state, swappingFromAToB({ presentedRoundId: 'round-b', loadedRoundId: 'round-b' }));
+    expect(resolution.state).toMatchObject({ phase: 'preparing', spinnerVisible: false });
+
+    resolution = resolveRoundSwap(
+      resolution.state,
+      swappingFromAToB({ presentedRoundId: 'round-b', loadedRoundId: 'round-b', visibilityProgress: 0, prepared: true }),
+    );
+    expect(resolution).toMatchObject({ state: { phase: 'fading-in', targetId: 'round-b' }, visibilityTarget: 1 });
+
+    resolution = resolveRoundSwap(
+      resolution.state,
+      swappingFromAToB({ presentedRoundId: 'round-b', loadedRoundId: 'round-b', visibilityProgress: 1, prepared: true }),
+    );
+    expect(resolution.state).toEqual({ phase: 'idle' });
+  });
+
+  it('fade-out이 끝나도 데이터가 없으면 배치가 끝날 때까지 스피너를 유지한다', () => {
+    let resolution = resolveRoundSwap({ phase: 'fading-out', targetId: 'round-b' }, swappingFromAToB({ visibilityProgress: 0 }));
+    expect(resolution.state).toEqual({ phase: 'waiting', targetId: 'round-b' });
+
+    resolution = resolveRoundSwap(resolution.state, swappingFromAToB({ loadedRoundId: 'round-b', visibilityProgress: 0 }));
+    expect(resolution.state).toEqual({ phase: 'preparing', targetId: 'round-b', spinnerVisible: true });
+
+    resolution = resolveRoundSwap(
+      resolution.state,
+      swappingFromAToB({ presentedRoundId: 'round-b', loadedRoundId: 'round-b', visibilityProgress: 0, prepared: true }),
+    );
+    expect(resolution).toMatchObject({ state: { phase: 'fading-in' }, visibilityTarget: 1 });
+  });
+
+  it('대상 회차 로드가 실패하면 기존 회차를 복구하고 스피너를 내린다', () => {
+    const resolution = resolveRoundSwap(
+      { phase: 'waiting', targetId: 'round-b' },
+      swappingFromAToB({ visibilityProgress: 0, failed: true }),
+    );
+
+    expect(resolution).toEqual({
+      state: { phase: 'fading-in', targetId: 'round-a' },
+      replacePresented: false,
+      restoreSelection: true,
+      visibilityTarget: 1,
+    });
+  });
+
+  it('실패 복구가 반영되기 전 다시 계산되어도 같은 fading-in 상태를 유지한다', () => {
+    const restoring = { phase: 'fading-in', targetId: 'round-a' } as const;
+    const resolution = resolveRoundSwap(restoring, swappingFromAToB({ visibilityProgress: 0, failed: true }));
+
+    expect(resolution.state).toBe(restoring);
+    expect(resolution.restoreSelection).toBe(false);
+  });
+
+  it('fade-out 중 원래 회차를 다시 고르면 현재 진행률에서 되돌린다', () => {
+    const resolution = resolveRoundSwap(
+      { phase: 'fading-out', targetId: 'round-b' },
+      swappingFromAToB({ selectedRoundId: 'round-a', visibilityProgress: 0.4 }),
+    );
+
+    expect(resolution).toMatchObject({ state: { phase: 'fading-in', targetId: 'round-a' }, visibilityTarget: 1 });
+  });
+
+  it('스피너를 에디터 visible area의 세로 중앙에 놓는다', () => {
+    expect(visibleAreaCenterY(100, 600, { topInset: 80, bottomInset: 40 })).toBe(420);
+    expect(visibleAreaCenterY(100, 600, { topInset: 0, bottomInset: 0 })).toBe(400);
   });
 });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/margin-motion.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/margin-motion.ts
@@ -17,9 +17,6 @@ export const lanePresentation = (progress: number): { opacity: number; scale: nu
   };
 };
 
-export const resolvePresentedRoundId = (selectedRoundId: string | null, lastRoundId: string | null, progress: number): string | null =>
-  selectedRoundId ?? (clampProgress(progress) > 0 ? lastRoundId : null);
-
 export const nextMarginReserved = (current: boolean, selectedRoundId: string | null, ready: boolean): boolean =>
   selectedRoundId === null ? false : ready ? true : current;
 
@@ -27,6 +24,95 @@ export const marginMotionTarget = (mode: MarginMode, idle: boolean, reserved: bo
   mode === 'column' && !idle && reserved && prepared ? 1 : 0;
 
 export const marginMotionDuration = (reduceMotion: boolean): number => (reduceMotion ? 0 : PRISM_VISIBILITY_MOTION.duration);
+
+export type RoundSwapState =
+  | { phase: 'idle' }
+  | { phase: 'fading-out'; targetId: string }
+  | { phase: 'waiting'; targetId: string }
+  | { phase: 'preparing'; targetId: string; spinnerVisible: boolean }
+  | { phase: 'fading-in'; targetId: string };
+
+type RoundSwapInput = {
+  selectedRoundId: string | null;
+  presentedRoundId: string | null;
+  loadedRoundId: string | null;
+  visibilityProgress: number;
+  prepared: boolean;
+  failed: boolean;
+};
+
+type RoundSwapResolution = {
+  state: RoundSwapState;
+  replacePresented: boolean;
+  restoreSelection: boolean;
+  visibilityTarget: 0 | 1;
+};
+
+const resolve = (
+  state: RoundSwapState,
+  visibilityTarget: 0 | 1,
+  replacePresented = false,
+  restoreSelection = false,
+): RoundSwapResolution => ({ state, visibilityTarget, replacePresented, restoreSelection });
+
+const resolveIdle = (state: RoundSwapState): RoundSwapResolution => resolve(state.phase === 'idle' ? state : { phase: 'idle' }, 1);
+
+export const resolveRoundSwap = (state: RoundSwapState, input: RoundSwapInput): RoundSwapResolution => {
+  const { selectedRoundId, presentedRoundId, loadedRoundId, prepared, failed } = input;
+  const visibility = clampProgress(input.visibilityProgress);
+
+  // 첫 표시와 완전 닫힘은 컬럼 자체의 presentation이 소유한다. 이 상태는 보이는 회차끼리의 교체만 맡는다.
+  if (selectedRoundId === null || presentedRoundId === null) return resolveIdle(state);
+
+  if (presentedRoundId === selectedRoundId && state.phase === 'preparing' && state.targetId === selectedRoundId) {
+    if (prepared) return resolve({ phase: 'fading-in', targetId: selectedRoundId }, 1);
+    return resolve(state, 0);
+  }
+
+  if (presentedRoundId === selectedRoundId && state.phase === 'fading-in' && state.targetId === selectedRoundId) {
+    if (visibility === 1) return resolveIdle(state);
+    return resolve(state, 1);
+  }
+
+  // fade-out 중 원래 회차를 다시 고른 경우를 포함해, 현재 표시 회차가 목표면 그 자리에서 되돌린다.
+  if (selectedRoundId === presentedRoundId) {
+    if (visibility === 1) return resolveIdle(state);
+    return resolve({ phase: 'fading-in', targetId: presentedRoundId }, 1);
+  }
+
+  // 실패한 결과로 표시 회차를 교체하지 않는다. 호출자는 선택만 기존 회차로 되돌리면 된다.
+  if (failed && loadedRoundId !== selectedRoundId) {
+    if (state.phase === 'fading-in' && state.targetId === presentedRoundId) return resolve(state, 1);
+    return resolve({ phase: 'fading-in', targetId: presentedRoundId }, 1, false, true);
+  }
+
+  if (visibility > 0) {
+    if (state.phase === 'fading-out' && state.targetId === selectedRoundId) return resolve(state, 0);
+    return resolve({ phase: 'fading-out', targetId: selectedRoundId }, 0);
+  }
+
+  if (loadedRoundId !== selectedRoundId) {
+    if (state.phase === 'waiting' && state.targetId === selectedRoundId) return resolve(state, 0);
+    return resolve({ phase: 'waiting', targetId: selectedRoundId }, 0);
+  }
+
+  const spinnerVisible = state.phase === 'waiting' || (state.phase === 'preparing' && state.spinnerVisible);
+  const next =
+    state.phase === 'preparing' && state.targetId === selectedRoundId && state.spinnerVisible === spinnerVisible
+      ? state
+      : { phase: 'preparing' as const, targetId: selectedRoundId, spinnerVisible };
+  return resolve(next, 0, presentedRoundId !== selectedRoundId);
+};
+
+export const visibleAreaCenterY = (
+  viewportTop: number,
+  viewportHeight: number,
+  visibleArea: { topInset: number; bottomInset: number },
+): number => {
+  const topInset = Math.max(0, visibleArea.topInset);
+  const visibleHeight = Math.max(0, viewportHeight - topInset - Math.max(0, visibleArea.bottomInset));
+  return viewportTop + topInset + visibleHeight / 2;
+};
 
 export const contentMotionOffset = (target: 0 | 1, progress: number, shift: number): number => (target - clampProgress(progress)) * shift;
 


### PR DESCRIPTION
- 리뷰 회차를 바꾸면 기존 하이라이트·카드·레일·룰러를 함께 fade-out하고, 새 회차가 준비된 뒤 fade-in합니다.
- 준비가 늦어지면 에디터 표시 영역 중앙에 ring spinner를 보여주고, 전환 중에는 기존 리뷰 조작을 막습니다.
- 회차별 리뷰 데이터를 `roundId`로 구분해 cache-first 조회가 이전 회차의 데이터를 재사용하지 않도록 했습니다.
- 빠른 연속 전환, 로드 실패, reduced motion 환경에서도 전환 상태가 안정적으로 정리되도록 했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>