### PR TITLE
데스크톱 앱 확대/축소 지원

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,7 +12,7 @@ import { TabManager } from './tab-manager';
 import { readStoredTheme } from './theme';
 import { Updater } from './updater';
 import { WindowManager } from './window-manager';
-import type { TabIcon } from '@typie/lib/desktop';
+import type { DesktopZoomAction, TabIcon } from '@typie/lib/desktop';
 import type { ContextMenuRequest } from './context-menu';
 import type { ThemePayload } from './theme';
 import type { WindowState } from './window-manager';
@@ -39,6 +39,15 @@ let menuTabsKey = '';
 const menuTabs = () => (tabManager?.tabs ?? []).map((tab) => ({ title: tab.title, active: tab.id === tabManager?.activeTab?.id }));
 const tabsKey = (tabs: { title: string; active: boolean }[]) =>
   `${tabManager?.canReopen ? '+' : '-'}\n${tabs.map((tab) => `${tab.active ? '*' : ''}${tab.title}`).join('\n')}`;
+const setDesktopZoom = (action: DesktopZoomAction) => {
+  if (!tabManager) return;
+  const zoomLevel = tabManager.zoom(action);
+  if (zoomLevel !== null) store.save({ zoomLevel });
+};
+const handleDesktopZoomMenu = (action: DesktopZoomAction, triggeredByAccelerator: boolean) => {
+  if (triggeredByAccelerator) tabManager?.activeTab?.view.webContents.send(IPC.bridgeZoomShortcut, action);
+  else setDesktopZoom(action);
+};
 const singleInstance = app.requestSingleInstanceLock();
 
 if (singleInstance) {
@@ -124,7 +133,7 @@ const createWindow = async () => {
     onLogout: () => auth.logout().catch(() => null),
     onOpenTab: (url, background, opener) => tabManager?.openFrom(opener, url, background),
   });
-  tabManager = new TabManager(windowManager, policy);
+  tabManager = new TabManager(windowManager, policy, store.data.zoomLevel);
   const chrome = windowManager.chrome.webContents;
 
   let lastActiveId: string | null = null;
@@ -210,6 +219,10 @@ ipcMain.handle(IPC.bridgeOpenExternal, (_event, url: string) => {
   const kind = policy?.classify(url);
   if (kind !== 'blocked') return shell.openExternal(url);
 });
+ipcMain.on(IPC.bridgeZoom, (event, action: DesktopZoomAction) => {
+  if (event.sender !== tabManager?.activeTab?.view.webContents) return;
+  if (action === 'in' || action === 'out' || action === 'reset') setDesktopZoom(action);
+});
 
 const applyMenu = () => {
   menu = buildMenu(
@@ -219,6 +232,7 @@ const applyMenu = () => {
       closeWindow: () => windowManager?.window.close(),
       reopenTab: () => tabManager?.reopenLast(),
       reload: () => tabManager?.reloadActive(),
+      zoom: handleDesktopZoomMenu,
       goBack: () => tabManager?.goBack(),
       goForward: () => tabManager?.goForward(),
       nextTab: () => tabManager?.next(),

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -18,6 +18,8 @@ export const IPC = {
   bridgeOpenExternal: 'bridge:open-external',
   bridgeFocus: 'bridge:focus',
   bridgePreference: 'bridge:preference',
+  bridgeZoom: 'bridge:zoom',
+  bridgeZoomShortcut: 'bridge:zoom-shortcut',
   updateReady: 'update:ready',
   updateRestart: 'update:restart',
   windowFullscreen: 'window:fullscreen',

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -1,4 +1,5 @@
 import { Menu, nativeImage } from 'electron';
+import type { DesktopZoomAction } from '@typie/lib/desktop';
 import type { MenuItemConstructorOptions } from 'electron';
 
 export type MenuActions = {
@@ -7,6 +8,7 @@ export type MenuActions = {
   closeWindow: () => void;
   reopenTab: () => void;
   reload: () => void;
+  zoom: (action: DesktopZoomAction, triggeredByAccelerator: boolean) => void;
   goBack: () => void;
   goForward: () => void;
   nextTab: () => void;
@@ -129,6 +131,25 @@ export const buildMenu = (
       label: '보기',
       submenu: [
         { label: '새로고침', accelerator: 'CmdOrCtrl+R', enabled: hasTabs, click: actions.reload },
+        { type: 'separator' },
+        {
+          label: '확대',
+          accelerator: 'CmdOrCtrl+Plus',
+          enabled: hasTabs,
+          click: (_item, _window, event) => actions.zoom('in', event.triggeredByAccelerator === true),
+        },
+        {
+          label: '축소',
+          accelerator: 'CmdOrCtrl+-',
+          enabled: hasTabs,
+          click: (_item, _window, event) => actions.zoom('out', event.triggeredByAccelerator === true),
+        },
+        {
+          label: '실제 크기',
+          accelerator: 'CmdOrCtrl+0',
+          enabled: hasTabs,
+          click: (_item, _window, event) => actions.zoom('reset', event.triggeredByAccelerator === true),
+        },
         { type: 'separator' },
         { label: '뒤로', accelerator: isMac ? 'Cmd+[' : 'Alt+Left', enabled: hasTabs, click: actions.goBack },
         { label: '앞으로', accelerator: isMac ? 'Cmd+]' : 'Alt+Right', enabled: hasTabs, click: actions.goForward },

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -1,12 +1,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
+import { normalizeZoomLevel } from './zoom';
 import type { WindowState } from './window-manager';
 
 export type TabSession = { urls: string[]; active: number };
-export type StoreData = { window: WindowState; tabs: TabSession | null };
+export type StoreData = { window: WindowState; tabs: TabSession | null; zoomLevel: number };
 
-const DEFAULT: StoreData = { window: {}, tabs: null };
+const DEFAULT: StoreData = { window: {}, tabs: null, zoomLevel: 0 };
 
 const isTabSession = (value: unknown): value is TabSession => {
   if (typeof value !== 'object' || value === null) return false;
@@ -24,6 +25,7 @@ export class Store {
       this.data = {
         window: typeof parsed.window === 'object' && parsed.window !== null ? parsed.window : {},
         tabs: isTabSession(parsed.tabs) ? parsed.tabs : null,
+        zoomLevel: normalizeZoomLevel(parsed.zoomLevel),
       };
     } catch {
       this.data = DEFAULT;

--- a/apps/desktop/src/main/tab-manager.ts
+++ b/apps/desktop/src/main/tab-manager.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { createTabView } from './tab-view';
 import { rendererUrl } from './window-manager';
-import type { TabIcon } from '@typie/lib/desktop';
+import { nextZoomLevel } from './zoom';
+import type { DesktopZoomAction, TabIcon } from '@typie/lib/desktop';
 import type { WebContents, WebContentsView } from 'electron';
 import type { NavigationPolicy } from './navigation-policy';
 import type { TabSession } from './store';
@@ -23,10 +24,12 @@ export class TabManager {
   #onState?: (state: TabsStatePayload) => void;
   #windowManager: WindowManager;
   #policy: NavigationPolicy;
+  #zoomLevel: number;
 
-  constructor(windowManager: WindowManager, policy: NavigationPolicy) {
+  constructor(windowManager: WindowManager, policy: NavigationPolicy, zoomLevel: number) {
     this.#windowManager = windowManager;
     this.#policy = policy;
+    this.#zoomLevel = zoomLevel;
   }
 
   #step(delta: number) {
@@ -79,6 +82,7 @@ export class TabManager {
       view: createTabView({
         onTitle: (title) => this.#setTitle(id, title),
         onNavigate: (nextUrl) => {
+          tab.view.webContents.setZoomLevel(this.#zoomLevel);
           const patch: Partial<TabState> = { title: '', icon: null };
           if (this.#policy.classify(nextUrl) === 'website') patch.url = nextUrl;
           this.#update(id, patch);
@@ -192,6 +196,14 @@ export class TabManager {
 
   setBackground(color: string) {
     for (const tab of this.#tabs) tab.view.setBackgroundColor(color);
+  }
+
+  zoom(action: DesktopZoomAction) {
+    const next = nextZoomLevel(this.#zoomLevel, action);
+    if (next === this.#zoomLevel) return null;
+    this.#zoomLevel = next;
+    for (const tab of this.#tabs) tab.view.webContents.setZoomLevel(next);
+    return next;
   }
 
   setIcon(sender: WebContents, icon: TabIcon) {

--- a/apps/desktop/src/main/window-manager.ts
+++ b/apps/desktop/src/main/window-manager.ts
@@ -58,7 +58,7 @@ export class WindowManager {
     });
 
     this.chrome = new WebContentsView({
-      webPreferences: { preload: preloadPath('chrome'), sandbox: true, contextIsolation: true },
+      webPreferences: { preload: preloadPath('chrome'), sandbox: true, contextIsolation: true, zoomMode: 'isolated' },
     });
     this.chrome.setBackgroundColor(background);
     this.window.contentView.addChildView(this.chrome);

--- a/apps/desktop/src/main/zoom.ts
+++ b/apps/desktop/src/main/zoom.ts
@@ -1,0 +1,17 @@
+import type { DesktopZoomAction } from '@typie/lib/desktop';
+
+// Electron scales zoom as 1.2 ** level, so these integer bounds approximate 50%–300%.
+const MIN_ZOOM_LEVEL = -4;
+const MAX_ZOOM_LEVEL = 6;
+
+export const normalizeZoomLevel = (value: unknown): number => {
+  if (!Number.isSafeInteger(value)) return 0;
+  const level = value as number;
+  return level >= MIN_ZOOM_LEVEL && level <= MAX_ZOOM_LEVEL ? level : 0;
+};
+
+export const nextZoomLevel = (current: number, action: DesktopZoomAction): number => {
+  if (action === 'reset') return 0;
+  const next = current + (action === 'in' ? 1 : -1);
+  return Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, next));
+};

--- a/apps/desktop/src/preload/tab.ts
+++ b/apps/desktop/src/preload/tab.ts
@@ -1,11 +1,13 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import type { TabIcon, TypieDesktopBridge } from '@typie/lib/desktop';
+import type { DesktopBridgeListeners, DesktopZoomAction, TabIcon, TypieDesktopBridge } from '@typie/lib/desktop';
 
 const IPC_THEME_CHANGED = 'theme:changed';
 const IPC_CONTEXT_MENU = 'contextmenu:request';
 const IPC_PAGE_RETRY = 'page:retry';
 const IPC_TAB_ICON = 'tab:icon';
 const IPC_TAB_OPEN = 'tab:open';
+const IPC_BRIDGE_ZOOM = 'bridge:zoom';
+const IPC_BRIDGE_ZOOM_SHORTCUT = 'bridge:zoom-shortcut';
 
 const RENDERER_DEV_PORT = '5300';
 
@@ -55,12 +57,20 @@ window.addEventListener(
 
 const appVersion = process.argv.find((arg) => arg.startsWith('--typie-app-version='))?.split('=')[1] ?? '0.0.0';
 
-const listeners = { focus: new Set<() => void>(), preference: new Set<() => void>() };
+const listeners: { [Event in keyof DesktopBridgeListeners]: Set<DesktopBridgeListeners[Event]> } = {
+  focus: new Set(),
+  preference: new Set(),
+  'zoom-shortcut': new Set(),
+};
 ipcRenderer.on('bridge:focus', () => {
   for (const listener of listeners.focus) listener();
 });
 ipcRenderer.on('bridge:preference', () => {
   for (const listener of listeners.preference) listener();
+});
+ipcRenderer.on(IPC_BRIDGE_ZOOM_SHORTCUT, (_event, action: DesktopZoomAction) => {
+  const handled = [...listeners['zoom-shortcut']].some((listener) => listener(action));
+  if (!handled) ipcRenderer.send(IPC_BRIDGE_ZOOM, action);
 });
 
 contextBridge.exposeInMainWorld(
@@ -69,7 +79,7 @@ contextBridge.exposeInMainWorld(
     version: appVersion,
     platform: process.platform as 'darwin' | 'win32',
     openExternal: (url: string) => ipcRenderer.invoke('bridge:open-external', url) as Promise<void>,
-    on: (event: 'focus' | 'preference', callback: () => void) => {
+    on: <Event extends keyof DesktopBridgeListeners>(event: Event, callback: DesktopBridgeListeners[Event]) => {
       const set = listeners[event];
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       if (!set) return () => {};

--- a/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
+++ b/apps/website/src/lib/editor-ffi/components/ui/EditorZoom.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { desktop } from '$lib/desktop';
   import { IS_MAC } from '$lib/editor-ffi/constants';
   import { computeDocumentZoomBounds, resolveDocumentZoomIndicator, zoomEquals } from '$lib/editor-ffi/zoom';
   import { EditorZoomController } from '../editor-zoom.svelte';
+  import type { DesktopZoomAction } from '@typie/lib/desktop';
   import type { Snippet } from 'svelte';
   import type { Editor } from '$lib/editor-ffi/editor.svelte';
   import type { EditorScrollScope } from '$lib/editor-ffi/scroll.svelte';
@@ -120,33 +122,64 @@
     return event.code === 'Digit0' || event.code === 'Numpad0' || event.key === '0';
   };
 
-  const handleBrowserZoomShortcut = (event: KeyboardEvent): void => {
-    if (!active || !zoomEnabled) return;
+  const ownsZoomTarget = (target: EventTarget | null): boolean => {
+    if (!active || !zoomEnabled) return false;
 
     const editorPane = editor.inputEl?.closest<HTMLElement>('[data-pane-id]');
-    const targetPane = event.target instanceof Element ? event.target.closest<HTMLElement>('[data-pane-id]') : null;
-    if (event.target !== editor.inputEl && (!editorPane || targetPane !== editorPane)) return;
+    const targetPane = target instanceof Element ? target.closest<HTMLElement>('[data-pane-id]') : null;
+    return target === editor.inputEl || (!!editorPane && targetPane === editorPane);
+  };
+
+  const applyZoomAction = (action: DesktopZoomAction): void => {
+    switch (action) {
+      case 'in': {
+        void zoomIn();
+        break;
+      }
+      case 'out': {
+        void zoomOut();
+        break;
+      }
+      case 'reset': {
+        void zoom.resetByKeyboard();
+        break;
+      }
+    }
+  };
+
+  const handleBrowserZoomShortcut = (event: KeyboardEvent): void => {
+    if (!ownsZoomTarget(event.target)) return;
 
     const hasZoomModifier = IS_MAC ? event.metaKey : event.ctrlKey;
     if (!hasZoomModifier || event.altKey) return;
 
     if (isZoomInShortcut(event)) {
       event.preventDefault();
-      void zoomIn();
+      applyZoomAction('in');
       return;
     }
 
     if (isZoomOutShortcut(event)) {
       event.preventDefault();
-      void zoomOut();
+      applyZoomAction('out');
       return;
     }
 
     if (isZoomResetShortcut(event)) {
       event.preventDefault();
-      void zoom.resetByKeyboard();
+      applyZoomAction('reset');
     }
   };
+
+  const handleDesktopZoomShortcut = (action: DesktopZoomAction): boolean => {
+    if (!document.hasFocus() || !ownsZoomTarget(document.activeElement)) return false;
+    applyZoomAction(action);
+    return true;
+  };
+
+  $effect(() => {
+    return desktop?.on('zoom-shortcut', handleDesktopZoomShortcut);
+  });
 
   function isTouchOnPage(touch: PinchContact): boolean {
     return editor.clientToLocal(touch.clientX, touch.clientY) !== null;

--- a/packages/lib/src/desktop.ts
+++ b/packages/lib/src/desktop.ts
@@ -1,10 +1,18 @@
 export type TabIcon = { icon: string; color: string | null };
 
+export type DesktopZoomAction = 'in' | 'out' | 'reset';
+
+export type DesktopBridgeListeners = {
+  focus: () => void;
+  preference: () => void;
+  'zoom-shortcut': (action: DesktopZoomAction) => boolean;
+};
+
 export type TypieDesktopBridge = {
   version: string;
   platform: 'darwin' | 'win32';
   openExternal: (url: string) => Promise<void>;
-  on: (event: 'focus' | 'preference', callback: () => void) => () => void;
+  on: <Event extends keyof DesktopBridgeListeners>(event: Event, callback: DesktopBridgeListeners[Event]) => () => void;
   setTabIcon?: (icon: TabIcon) => void;
   openTab?: (url: string) => void;
 };


### PR DESCRIPTION
## 변경 내용

- 보기 메뉴와 `Cmd/Ctrl + +`, `Cmd/Ctrl + -`, `Cmd/Ctrl + 0` 단축키로 앱 본문을 확대·축소할 수 있도록 했습니다.
- 에디터에 포커스가 있을 때는 기존 문서 확대·축소가 단축키를 우선 처리합니다.
- 설정한 앱 배율을 탭 간에 공유하고 새 탭과 앱 재실행 후에도 복원합니다.
- 커스텀 탭바는 확대·축소 대상에서 제외했습니다.

## 참고

비활성 탭의 가시성 상태를 유지하기 위해, 줌 변경 후 해당 탭을 처음 열 때 이전 배율의 프레임이 잠시 보일 수 있습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>