### PR TITLE
에디터 breadcrumb 렌더링 일관성 개선

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
@@ -1,21 +1,17 @@
 <script lang="ts">
-  import { css } from '@typie/styled-system/css';
+  import { css, cx } from '@typie/styled-system/css';
   import { flex } from '@typie/styled-system/patterns';
   import { createFloatingActions } from '@typie/ui/actions';
-  import { Icon } from '@typie/ui/components';
   import { prefersReducedMotion } from '@typie/ui/state';
   import { pushEscapeHandler } from '@typie/ui/utils';
   import { onDestroy, tick } from 'svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import { scale } from 'svelte/transition';
-  import ChevronRightIcon from '~icons/lucide/chevron-right';
-  import FolderIcon from '~icons/lucide/folder';
-  import HomeIcon from '~icons/lucide/house';
-  import EntityIcon from '../../../@context-menu/EntityIcon.svelte';
   import { EntityRowDragController } from '../../../@tree/entity-row-drag.svelte';
   import EntityRowDragGhost from '../../../@tree/EntityRowDragGhost.svelte';
   import { getPaneGroup } from '../../@pane/context.svelte';
   import BreadcrumbEntityTree from './BreadcrumbEntityTree.svelte';
+  import EditorBreadcrumbSegment from './EditorBreadcrumbSegment.svelte';
   import type { EntityIcon_entity$key } from '$mearie';
   import type { BreadcrumbContainer } from './BreadcrumbEntityTree.svelte';
 
@@ -57,13 +53,15 @@
 
   const POPUP_HOLD_REASON = 'breadcrumb-popup';
   const HOME_SEGMENT_ID = 'home';
+  const interactiveSegmentClass = css({
+    cursor: 'pointer',
+    transition: 'common',
+    _hover: { backgroundColor: 'surface.muted', color: 'text.default' },
+    _expanded: { backgroundColor: 'surface.muted', color: 'text.default' },
+  });
 
   function pathItemId(pathItem: BreadcrumbPathItem) {
     return pathItem.kind === 'home' ? HOME_SEGMENT_ID : pathItem.id;
-  }
-
-  function pathItemName(pathItem: BreadcrumbPathItem) {
-    return pathItem.kind === 'home' ? '홈' : pathItem.name;
   }
 
   const pathItems = $derived<BreadcrumbPathItem[]>(
@@ -197,67 +195,37 @@
   })}
   aria-label="문서 경로"
 >
-  <ol class={flex({ alignItems: 'center', gap: '2px', listStyle: 'none', whiteSpace: 'nowrap' })}>
+  <ol class={flex({ alignItems: 'center', listStyle: 'none', whiteSpace: 'nowrap' })}>
     {#each pathItems as pathItem, index (pathItemId(pathItem))}
-      {@const currentEntity = index === pathItems.length - 1}
+      {@const isCurrent = index === pathItems.length - 1}
       {@const itemId = pathItemId(pathItem)}
-      <li aria-current={currentEntity ? 'page' : undefined}>
+      {@const segmentClass = flex({
+        alignItems: 'center',
+        gap: '4px',
+        height: '24px',
+        paddingLeft: '4px',
+        paddingRight: isCurrent ? '4px' : '0',
+        borderRadius: '5px',
+      })}
+      <li aria-current={isCurrent ? 'page' : undefined}>
         {#if interactive}
           <button
             id={triggerId(itemId)}
-            class={flex({
-              alignItems: 'center',
-              gap: '4px',
-              height: '24px',
-              paddingX: '4px',
-              borderRadius: '5px',
-              cursor: 'pointer',
-              transition: 'common',
-              _hover: { backgroundColor: 'surface.muted', color: 'text.default' },
-              _expanded: { backgroundColor: 'surface.muted', color: 'text.default' },
-            })}
+            class={cx(segmentClass, interactiveSegmentClass)}
             aria-controls={popupId}
             aria-expanded={activeSegmentId === itemId}
             aria-haspopup="tree"
             onclick={(event) => activate(event, itemId)}
             type="button"
           >
-            {#if pathItem.kind === 'home'}
-              <Icon icon={HomeIcon} size={14} />
-            {:else}
-              <EntityIcon entity$key={pathItem.entity$key} fallback={currentEntity ? undefined : FolderIcon} size={14} />
-            {/if}
-            <span>{pathItemName(pathItem)}</span>
-            {#if !currentEntity}
-              <span class={css({ display: 'grid', placeItems: 'center', color: 'text.faint' })} aria-hidden="true">
-                <Icon icon={ChevronRightIcon} size={14} />
-              </span>
-            {/if}
+            <EditorBreadcrumbSegment {isCurrent} item={pathItem} />
           </button>
         {:else}
-          <span
-            class={flex({
-              alignItems: 'center',
-              gap: '4px',
-              height: pathItem.kind === 'home' ? '24px' : undefined,
-              paddingX: pathItem.kind === 'home' ? '4px' : undefined,
-              borderRadius: pathItem.kind === 'home' ? '5px' : undefined,
-            })}
-          >
-            {#if pathItem.kind === 'home'}
-              <Icon icon={HomeIcon} size={14} />
-            {:else}
-              <EntityIcon entity$key={pathItem.entity$key} fallback={currentEntity ? undefined : FolderIcon} size={14} />
-            {/if}
-            <span>{pathItemName(pathItem)}</span>
+          <span class={segmentClass}>
+            <EditorBreadcrumbSegment {isCurrent} item={pathItem} />
           </span>
         {/if}
       </li>
-      {#if !isOwner && !currentEntity}
-        <li class={css({ display: 'grid', placeItems: 'center', color: 'text.faint' })} aria-hidden="true">
-          <Icon icon={ChevronRightIcon} size={14} />
-        </li>
-      {/if}
     {/each}
   </ol>
 </nav>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbSegment.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbSegment.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { css } from '@typie/styled-system/css';
+  import { Icon } from '@typie/ui/components';
+  import ChevronRightIcon from '~icons/lucide/chevron-right';
+  import FolderIcon from '~icons/lucide/folder';
+  import HomeIcon from '~icons/lucide/house';
+  import EntityIcon from '../../../@context-menu/EntityIcon.svelte';
+  import type { EntityIcon_entity$key } from '$mearie';
+
+  type Props = {
+    isCurrent: boolean;
+    item: { kind: 'home' } | { kind: 'entity'; name: string; entity$key: EntityIcon_entity$key };
+  };
+
+  let { isCurrent, item }: Props = $props();
+</script>
+
+{#if item.kind === 'home'}
+  <Icon icon={HomeIcon} size={14} />
+{:else}
+  <EntityIcon entity$key={item.entity$key} fallback={isCurrent ? undefined : FolderIcon} size={14} />
+{/if}
+<span>{item.kind === 'home' ? '홈' : item.name}</span>
+{#if !isCurrent}
+  <span class={css({ display: 'grid', placeItems: 'center', color: 'text.faint' })} aria-hidden="true">
+    <Icon icon={ChevronRightIcon} size={14} />
+  </span>
+{/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag-test-root.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-document-drag-test-root.svelte
@@ -17,11 +17,12 @@
 
   type Props = {
     currentKind?: 'entity' | 'home';
+    isOwner?: boolean;
     rootQueryLoading?: boolean;
     withSegment?: boolean;
   };
 
-  let { currentKind = 'entity', rootQueryLoading = false, withSegment = true }: Props = $props();
+  let { currentKind = 'entity', isOwner = true, rootQueryLoading = false, withSegment = true }: Props = $props();
 
   const currentDocument = {
     __typename: 'Entity',
@@ -184,7 +185,7 @@
 <EditorBreadcrumbNavigation
   ancestors={currentKind === 'home' ? [] : ancestors}
   {current}
-  isOwner
+  {isOwner}
   onNavigate={(target) => {
     navigationTarget = target;
     navigatedSlug = target.kind === 'entity' ? target.slug : '';

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-navigation.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-navigation.browser.test.ts
@@ -27,6 +27,7 @@ const trigger = (name: string) =>
 
 type FixtureProps = {
   currentKind?: 'entity' | 'home';
+  isOwner?: boolean;
   rootQueryLoading?: boolean;
 };
 
@@ -36,6 +37,48 @@ const mountFixture = async (props: FixtureProps = {}) => {
 };
 
 describe('breadcrumb navigation keyboard interaction', () => {
+  it('keeps the path segment structure and geometry when navigation is non-interactive', async () => {
+    await mountFixture();
+    const interactiveSegment = document.querySelector('nav[aria-label="문서 경로"] > ol > li:first-child > button');
+    if (!(interactiveSegment instanceof HTMLElement)) throw new Error('Missing interactive breadcrumb segment');
+    const interactiveStyle = getComputedStyle(interactiveSegment);
+    const interactiveGeometry = {
+      alignItems: interactiveStyle.alignItems,
+      borderRadius: interactiveStyle.borderRadius,
+      columnGap: interactiveStyle.columnGap,
+      height: interactiveStyle.height,
+      paddingLeft: interactiveStyle.paddingLeft,
+      paddingRight: interactiveStyle.paddingRight,
+    };
+
+    if (!component) throw new Error('Missing mounted breadcrumb fixture');
+    await unmount(component);
+    component = undefined;
+    document.body.replaceChildren();
+
+    await mountFixture({ isOwner: false });
+    const path = document.querySelector('nav[aria-label="문서 경로"] > ol');
+    if (!path) throw new Error('Missing breadcrumb path');
+
+    const segments = [...path.children];
+    expect(segments).toHaveLength(2);
+    expect(segments.every((segment) => segment.matches('li'))).toBe(true);
+    expect(path.querySelector('button')).toBeNull();
+    expect(segments[0]?.querySelector(':scope > span > span[aria-hidden="true"]')).not.toBeNull();
+    expect(segments[1]?.querySelector(':scope > span > span[aria-hidden="true"]')).toBeNull();
+    const passiveSegment = segments[0]?.querySelector(':scope > span');
+    if (!(passiveSegment instanceof HTMLElement)) throw new Error('Missing non-interactive breadcrumb segment');
+    const passiveStyle = getComputedStyle(passiveSegment);
+    expect({
+      alignItems: passiveStyle.alignItems,
+      borderRadius: passiveStyle.borderRadius,
+      columnGap: passiveStyle.columnGap,
+      height: passiveStyle.height,
+      paddingLeft: passiveStyle.paddingLeft,
+      paddingRight: passiveStyle.paddingRight,
+    }).toEqual(interactiveGeometry);
+  });
+
   it('marks the current document after expanding it from an ancestor segment', async () => {
     await mountFixture();
     const folderTrigger = trigger('Folder');


### PR DESCRIPTION
- 문서 경로의 아이콘, 이름, 구분자 렌더링을 공통 세그먼트 컴포넌트로 통합했습니다.
- 상호작용 가능 여부와 관계없이 문서 경로가 같은 크기와 간격으로 표시되도록 했습니다.
- 상호작용할 수 없는 경우에는 버튼 동작만 제거하고 시각 표현은 동일하게 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>