### PR TITLE
앱에서 터치/펜 입력만 selection handle 표시하고 paragraph break mark rect를 line right까지 확장

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/EditorView.kt
@@ -30,6 +30,7 @@ import co.typie.editor.ffi.ThemeVariant
 import co.typie.editor.ffi.Viewport
 import co.typie.editor.input.LocalEditorIncomingContentHandler
 import co.typie.editor.input.editorInput
+import co.typie.editor.interaction.LocalEditorInteractionScope
 import co.typie.editor.overlay.EditorCursorOverlay
 import co.typie.editor.overlay.EditorPageLineHighlightOverlay
 import co.typie.editor.runtime.LocalEditorRuntime
@@ -40,6 +41,7 @@ import co.typie.editor.surface.editorPagePositionTracker
 import co.typie.editor.sync.DocumentEditorLoad
 import co.typie.platform.PlatformModule
 import co.typie.storage.Preference
+import co.typie.ui.input.LocalDirectTouchInteractionState
 import kotlinx.coroutines.CancellationException
 
 @Composable
@@ -59,6 +61,8 @@ internal fun EditorView(
   val uiState = LocalEditorUiState.current
   val bringIntoViewRequests = LocalEditorBringIntoViewRequests.current
   val incomingContentHandler = LocalEditorIncomingContentHandler.current
+  val interactionScope = LocalEditorInteractionScope.current
+  val directTouchInteractionState = LocalDirectTouchInteractionState.current
   val zoomController = LocalEditorZoomController.current
   val displayZoom = zoomController.displayZoom
   val themeVariant = currentEditorThemeVariant()
@@ -180,6 +184,10 @@ internal fun EditorView(
             suppressSoftwareKeyboard = suppressSoftwareKeyboard,
             clipboard = PlatformModule.clipboard,
             incomingContentHandler = incomingContentHandler,
+            onHardwareKeyInteraction = {
+              directTouchInteractionState.recordKeyboardInteraction()
+              interactionScope.controller.updateDirectTouchInteraction(false)
+            },
           )
           .focusable()
       } else {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/body/EditorBody.kt
@@ -41,6 +41,7 @@ import co.typie.screen.editor.editor.overlay.EditorSelectionHandleOverlay
 import co.typie.screen.editor.editor.overlay.EditorTableCellSelectionOverlay
 import co.typie.screen.editor.editor.overlay.EditorTableColumnResizeOverlay
 import co.typie.storage.Preference
+import co.typie.ui.input.LocalDirectTouchInteractionState
 
 private val DebugTopPaddingColor = Color(0x22FF5ACD)
 private val DebugBottomPaddingColor = Color(0x22FF8A00)
@@ -66,6 +67,7 @@ internal fun EditorBody(
   val editor = LocalEditorRuntime.current.editor
   val uiState = LocalEditorUiState.current
   val interactionScope = LocalEditorInteractionScope.current
+  val directTouchInteractionState = LocalDirectTouchInteractionState.current
   var bodyContentHeight by remember { mutableFloatStateOf(0f) }
   val presentedBundle = publishedBundle
   val presentedState = presentedBundle?.snapshot ?: EditorState.Initial
@@ -193,6 +195,7 @@ internal fun EditorBody(
           uiState = uiState,
           density = density.density,
           pagePresented = { page -> presentedBundle?.frames?.containsKey(page) == true },
+          directTouchInteraction = directTouchInteractionState.isDirectTouchInteraction,
         )
       }
     }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorInput.kt
@@ -67,6 +67,7 @@ internal fun Modifier.editorInput(
   suppressSoftwareKeyboard: Boolean,
   clipboard: Clipboard,
   incomingContentHandler: EditorIncomingContentHandler = NoopEditorIncomingContentHandler,
+  onHardwareKeyInteraction: () -> Unit = {},
 ): Modifier =
   this then
     EditorInputElement(
@@ -78,6 +79,7 @@ internal fun Modifier.editorInput(
       suppressSoftwareKeyboard = suppressSoftwareKeyboard,
       clipboard = clipboard,
       incomingContentHandler = incomingContentHandler,
+      onHardwareKeyInteraction = onHardwareKeyInteraction,
     )
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -153,6 +155,7 @@ private data class EditorInputElement(
   private val suppressSoftwareKeyboard: Boolean,
   private val clipboard: Clipboard,
   private val incomingContentHandler: EditorIncomingContentHandler,
+  private val onHardwareKeyInteraction: () -> Unit,
 ) : ModifierNodeElement<EditorInputNode>() {
   override fun create(): EditorInputNode =
     EditorInputNode(
@@ -164,6 +167,7 @@ private data class EditorInputElement(
       suppressSoftwareKeyboard = suppressSoftwareKeyboard,
       clipboard = clipboard,
       incomingContentHandler = incomingContentHandler,
+      onHardwareKeyInteraction = onHardwareKeyInteraction,
     )
 
   override fun update(node: EditorInputNode) {
@@ -174,6 +178,7 @@ private data class EditorInputElement(
     node.bringIntoViewRequests = bringIntoViewRequests
     node.clipboard = clipboard
     node.incomingContentHandler = incomingContentHandler
+    node.onHardwareKeyInteraction = onHardwareKeyInteraction
     node.updateInputPolicy(enabled = enabled, suppressSoftwareKeyboard = suppressSoftwareKeyboard)
     if (node.session.editor !== previousEditor) {
       node.bindImeResync()
@@ -191,6 +196,7 @@ internal class EditorInputNode(
   suppressSoftwareKeyboard: Boolean,
   var clipboard: Clipboard,
   var incomingContentHandler: EditorIncomingContentHandler,
+  var onHardwareKeyInteraction: () -> Unit = {},
 ) : Modifier.Node(), FocusEventModifierNode, PlatformTextInputModifierNode, KeyInputModifierNode {
   private var focusedJob: Job? = null
   private var focused = false
@@ -448,6 +454,7 @@ internal class EditorInputNode(
 
   override fun onKeyEvent(event: KeyEvent): Boolean {
     if (!enabled || event.type != KeyEventType.KeyDown) return false
+    onHardwareKeyInteraction()
     val binding = bindings.find { matchesKeyBinding(it, platform, event) }
     if (binding != null) {
       val composing = editor.appliedState.ime?.composing != null
@@ -547,6 +554,7 @@ internal class EditorInputNode(
 
   override fun onPreKeyEvent(event: KeyEvent): Boolean {
     if (!enabled || event.type != KeyEventType.KeyDown) return false
+    onHardwareKeyInteraction()
     val binding = bindings.find { matchesKeyBinding(it, platform, event) } ?: return false
     if (editor.appliedState.ime?.composing != null && !binding.commitCompositionBeforeDispatch) {
       recordHardwareKey(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -9,11 +9,14 @@ import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.EditorZoomLandmark
 import co.typie.editor.ffi.InputModifiers
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.ViewOp
 import co.typie.editor.interaction.gestures.EditorPanGestureDriver
 import co.typie.editor.interaction.semantics.EditorTableColumnResizePlacement
 import co.typie.editor.interaction.semantics.EditorTableColumnResizePresentation
 import co.typie.editor.runtime.EditorUiState
 import co.typie.platform.Platform
+import co.typie.ui.input.isDirectTouchInteraction
 
 internal class EditorInteractionController(
   private val editorProvider: () -> Editor?,
@@ -36,6 +39,9 @@ internal class EditorInteractionController(
 
   override var mode by mutableStateOf(EditorInteractionMode.Idle)
     private set
+
+  private var syncedDirectTouchInteractionEditor: Editor? = null
+  private var syncedDirectTouchInteraction: Boolean? = null
 
   override val isFocused: Boolean
     get() = uiStateProvider().focused
@@ -85,6 +91,9 @@ internal class EditorInteractionController(
     touchPanDriver: EditorPanGestureDriver? = null,
   ): Boolean =
     if (ensurePointerInputEnabled()) {
+      if (position != null) {
+        updateDirectTouchInteraction(change.type.isDirectTouchInteraction())
+      }
       gestures.handlePointerDown(
         change = change,
         positionInEditor = position,
@@ -97,6 +106,26 @@ internal class EditorInteractionController(
     } else {
       false
     }
+
+  fun syncDirectTouchInteraction(direct: Boolean) {
+    val editor = editorProvider()
+    if (syncedDirectTouchInteractionEditor === editor && syncedDirectTouchInteraction == direct) {
+      return
+    }
+    syncedDirectTouchInteractionEditor = editor
+    syncedDirectTouchInteraction = direct
+    editor?.runCallback {
+      editor.enqueue(Message.View(ViewOp.SetDirectTouchInteraction(direct = direct)))
+    }
+  }
+
+  fun updateDirectTouchInteraction(direct: Boolean) {
+    val editor = editorProvider()
+    if (syncedDirectTouchInteractionEditor !== editor || syncedDirectTouchInteraction == null) {
+      return
+    }
+    syncDirectTouchInteraction(direct)
+  }
 
   fun onPointerMove(
     change: PointerInputChange,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -25,6 +25,7 @@ import co.typie.editor.interaction.gestures.start
 import co.typie.editor.interaction.gestures.trackPointerMove
 import co.typie.editor.interaction.gestures.update
 import co.typie.editor.interaction.sessions.EditorDoubleTapDragSession
+import co.typie.ui.input.isDirectTouchInteraction
 
 internal class EditorInteractionGestures(
   contextProvider: () -> EditorGestureContext,
@@ -108,7 +109,9 @@ internal class EditorInteractionGestures(
     val columnResizePlacement = tableColumnResize.hitTest(position = position, context = context)
     val tableHandleHit = columnResizePlacement == null && tableHandle.hitTest(position)
     val selectionHandleType =
-      if (columnResizePlacement == null && !tableHandleHit) {
+      if (
+        change.type.isDirectTouchInteraction() && columnResizePlacement == null && !tableHandleHit
+      ) {
         selectionHandle.hitTest(position)
       } else {
         null

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -77,6 +77,7 @@ internal class EditorInteractionScope(
 
   fun update(
     editor: Editor?,
+    directTouchInteraction: Boolean,
     bringIntoViewRequests: EditorBringIntoViewRequests,
     uiState: EditorUiState,
     visibleArea: EditorVisibleArea,
@@ -110,6 +111,7 @@ internal class EditorInteractionScope(
       }
     }
     this.editor = editor
+    controller.syncDirectTouchInteraction(directTouchInteraction)
     this.bringIntoViewRequests = bringIntoViewRequests
     this.uiState = uiState
     this.visibleArea = visibleArea

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -222,6 +223,7 @@ import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.ToastType
 import co.typie.ui.component.topbar.ProvideTopBar
 import co.typie.ui.component.topbar.TopBarCenterAppearance
+import co.typie.ui.input.LocalDirectTouchInteractionState
 import co.typie.ui.input.PointerInputModeState
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.LocalHazeState
@@ -273,6 +275,8 @@ fun EditorScreen(entityId: String) {
   val sheet = LocalSheet.current
   val popoverOverlayState = LocalPopoverOverlayState.current
   val toast = LocalToast.current
+  val directTouchInteractionState = LocalDirectTouchInteractionState.current
+  val directTouchInteraction = directTouchInteractionState.isDirectTouchInteraction
   val model = viewModel { EditorViewModel(entityId) }
   val scope = rememberCoroutineScope()
   val focusReturnSession = remember(entityId) { EditorFocusReturnSession(scope = scope) }
@@ -1776,6 +1780,7 @@ fun EditorScreen(entityId: String) {
         )
       interactionScope.update(
         editor = editor,
+        directTouchInteraction = directTouchInteraction,
         bringIntoViewRequests = bringIntoViewRequests,
         uiState = uiState,
         visibleArea = visibleArea,
@@ -1863,7 +1868,11 @@ fun EditorScreen(entityId: String) {
         viewportAnchorState = viewportAnchorState,
         viewportScrollReconcileMode = viewportScrollReconcileMode,
         pointerInputModeState = pointerInputModeState,
-        onViewportIndirectInput = { uiState.contextMenu.hide() },
+        onViewportIndirectInput = {
+          directTouchInteractionState.recordPointerInteraction(PointerType.Mouse)
+          interactionScope.controller.updateDirectTouchInteraction(false)
+          uiState.contextMenu.hide()
+        },
         onViewportPointerEnter = {
           zoomIndicatorState.onPanePointerEnter(zoomController.resolveLandmark())
         },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlay.kt
@@ -27,8 +27,13 @@ internal fun EditorSelectionHandleOverlay(
   uiState: EditorUiState,
   density: Float,
   pagePresented: (Int) -> Boolean,
+  directTouchInteraction: Boolean,
 ) {
-  if (state.selection.isCollapsed() || resolveTableCellSelections(state).isNotEmpty()) {
+  if (
+    !directTouchInteraction ||
+      state.selection.isCollapsed() ||
+      resolveTableCellSelections(state).isNotEmpty()
+  ) {
     return
   }
 
@@ -47,6 +52,7 @@ internal fun EditorSelectionHandleOverlay(
         editorRectInOverlay = editorRect,
         density = density,
         pagePresented = pagePresented,
+        directTouchInteraction = directTouchInteraction,
       ) ?: return@Canvas
     placements.forEach { placement ->
       val geometry = resolveSelectionHandleOverlayGeometry(placement, density)
@@ -89,9 +95,13 @@ internal fun resolveSelectionHandleOverlayPlacements(
   editorRectInOverlay: Rect,
   density: Float,
   pagePresented: (Int) -> Boolean = { true },
+  directTouchInteraction: Boolean,
 ): List<EditorSelectionHandleOverlayPlacement>? {
   if (
-    density <= 0f || state.selection.isCollapsed() || resolveTableCellSelections(state).isNotEmpty()
+    !directTouchInteraction ||
+      density <= 0f ||
+      state.selection.isCollapsed() ||
+      resolveTableCellSelections(state).isNotEmpty()
   ) {
     return null
   }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/RootShell.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/shell/RootShell.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.FrameRateCategory
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.preferredFrameRate
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -61,6 +63,9 @@ import co.typie.ui.component.sheet.SheetOverlay
 import co.typie.ui.component.toast.LocalToast
 import co.typie.ui.component.toast.Toast
 import co.typie.ui.component.toast.ToastOverlay
+import co.typie.ui.input.DirectTouchInteractionState
+import co.typie.ui.input.LocalDirectTouchInteractionState
+import co.typie.ui.input.trackDirectTouchInteraction
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.LocalHazeState
 import dev.chrisbanes.haze.hazeSource
@@ -158,6 +163,12 @@ fun RootShell() {
   val dialog = remember { Dialog() }
   val popover = remember { PopoverOverlayState() }
   val statusBarAppearanceState = remember { NavigationStatusBarAppearanceState() }
+  val inputModeManager = LocalInputModeManager.current
+  val directTouchInteractionState = remember {
+    DirectTouchInteractionState(
+      initialDirectTouchInteraction = inputModeManager.inputMode == InputMode.Touch
+    )
+  }
 
   // 등록 실패 안내는 루트에서 수집한다 — 미완료 트랜잭션 재시도는 화면 밖(앱 실행 시 복구)에서도 일어나므로
   // 구매 화면에서만 들으면 조용히 버려진다.
@@ -196,10 +207,12 @@ fun RootShell() {
     LocalToast provides toast,
     LocalLoader provides loader,
     LocalPopoverOverlayState provides popover,
+    LocalDirectTouchInteractionState provides directTouchInteractionState,
   ) {
     Box(
       Modifier.fillMaxSize()
         .preferredFrameRate(FrameRateCategory.High)
+        .trackDirectTouchInteraction(directTouchInteractionState)
         .popoverOutsideTapHost(state = popover)
     ) {
       Crossfade(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/input/DirectTouchInteractionState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/input/DirectTouchInteractionState.kt
@@ -1,0 +1,66 @@
+package co.typie.ui.input
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.pointerInput
+
+@Stable
+internal class DirectTouchInteractionState(initialDirectTouchInteraction: Boolean) {
+  var isDirectTouchInteraction by mutableStateOf(initialDirectTouchInteraction)
+    private set
+
+  fun recordPointerInteraction(type: PointerType) {
+    isDirectTouchInteraction = type.isDirectTouchInteraction()
+  }
+
+  fun recordKeyboardInteraction() {
+    isDirectTouchInteraction = false
+  }
+}
+
+internal fun PointerType.isDirectTouchInteraction(): Boolean =
+  this == PointerType.Touch || this == PointerType.Stylus || this == PointerType.Eraser
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun Modifier.trackDirectTouchInteraction(state: DirectTouchInteractionState): Modifier =
+  pointerInput(state) {
+      awaitPointerEventScope {
+        while (true) {
+          val event = awaitPointerEvent(PointerEventPass.Initial)
+          when (event.type) {
+            PointerEventType.Press ->
+              event.changes
+                .lastOrNull { change -> change.pressed && !change.previousPressed }
+                ?.let { change -> state.recordPointerInteraction(change.type) }
+            PointerEventType.Scroll,
+            PointerEventType.PanStart,
+            PointerEventType.PanMove,
+            PointerEventType.ScaleStart,
+            PointerEventType.ScaleChange -> state.recordPointerInteraction(PointerType.Mouse)
+            else -> Unit
+          }
+        }
+      }
+    }
+    .onPreviewKeyEvent { event ->
+      if (event.type == KeyEventType.KeyDown) {
+        state.recordKeyboardInteraction()
+      }
+      false
+    }
+
+internal val LocalDirectTouchInteractionState =
+  staticCompositionLocalOf<DirectTouchInteractionState> {
+    error("No DirectTouchInteractionState provided")
+  }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.geometry.Size as ComposeSize
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.Velocity
 import co.typie.editor.Editor
@@ -75,9 +76,17 @@ private fun EditorInteractionController.onPointerDown(
   inputModifiers: InputModifiers = InputModifiers(),
   positionInRoot: Offset = requireNotNull(position),
   touchPanDriver: EditorPanGestureDriver? = null,
+  type: PointerType = PointerType.Touch,
 ): Boolean =
   onPointerDown(
-    change = testPointerInputChange(pointerId, nowMillis, pressed = true, previousPressed = false),
+    change =
+      testPointerInputChange(
+        pointerId,
+        nowMillis,
+        pressed = true,
+        previousPressed = false,
+        type = type,
+      ),
     position = position,
     tapEnabled = tapEnabled,
     inputModifiers = inputModifiers,
@@ -124,6 +133,7 @@ private fun testPointerInputChange(
   pressed: Boolean,
   previousPressed: Boolean,
   consumed: Boolean = false,
+  type: PointerType = PointerType.Touch,
 ): PointerInputChange =
   // The public test constructor does not expose originalEventPosition. Keeping its local position
   // at the origin lets the production root-space offset carry the synthetic test position.
@@ -136,6 +146,7 @@ private fun testPointerInputChange(
     previousPosition = Offset.Zero,
     previousPressed = previousPressed,
     isInitiallyConsumed = consumed,
+    type = type,
   )
 
 private fun Editor.deliverLatestFrame(fake: FakeFfiEditor, surface: SurfaceSessionHandle) {
@@ -162,6 +173,86 @@ private fun EditorInteractionController.presentAppliedState(
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorInteractionControllerTest {
+  @Test
+  fun `direct pointer type controls touch selection presentation`() =
+    runTest(StandardTestDispatcher()) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+
+      controller.syncDirectTouchInteraction(direct = false)
+      fake.enqueued.clear()
+      controller.onPointerDown(
+        pointerId = 1L,
+        position = Offset(10f, 20f),
+        nowMillis = 0L,
+        type = PointerType.Touch,
+      )
+
+      assertEquals(
+        listOf<Message>(Message.View(ViewOp.SetDirectTouchInteraction(direct = true))),
+        fake.enqueued.filterIsInstance<Message.View>(),
+      )
+
+      controller.cancel()
+      fake.enqueued.clear()
+      controller.onPointerDown(
+        pointerId = 2L,
+        position = Offset(10f, 20f),
+        nowMillis = 100L,
+        type = PointerType.Mouse,
+      )
+
+      assertEquals(
+        listOf<Message>(Message.View(ViewOp.SetDirectTouchInteraction(direct = false))),
+        fake.enqueued.filterIsInstance<Message.View>(),
+      )
+    }
+
+  @Test
+  fun `app direct touch changes continue to update the attached editor`() =
+    runTest(StandardTestDispatcher()) {
+      val firstFake = FakeFfiEditor()
+      val firstEditor = Editor(firstFake, this, StandardTestDispatcher(testScheduler))
+      val secondFake = FakeFfiEditor()
+      val secondEditor = Editor(secondFake, this, StandardTestDispatcher(testScheduler))
+      var currentEditor: Editor? = firstEditor
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { currentEditor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+
+      controller.syncDirectTouchInteraction(direct = true)
+      controller.syncDirectTouchInteraction(direct = false)
+
+      assertEquals(
+        listOf<Message>(
+          Message.View(ViewOp.SetDirectTouchInteraction(direct = true)),
+          Message.View(ViewOp.SetDirectTouchInteraction(direct = false)),
+        ),
+        firstFake.enqueued,
+      )
+
+      currentEditor = secondEditor
+      controller.syncDirectTouchInteraction(direct = false)
+
+      assertEquals(
+        listOf<Message>(Message.View(ViewOp.SetDirectTouchInteraction(direct = false))),
+        secondFake.enqueued,
+      )
+    }
+
   @Test
   fun `pinch sample uses the complete pair of physical root positions`() {
     val sample = resolveEditorPinchSample(listOf(Offset(100f, 200f), Offset(500f, 500f)))
@@ -2151,49 +2242,63 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `editor pointer stream starts selection handle drag from handle hit target`() =
+  fun `selection handle hit target accepts touch drags but ignores mouse drags`() =
     runTest(StandardTestDispatcher()) {
-      val selection =
-        Selection(
-          anchor = Position("text", 0, Affinity.Downstream),
-          head = Position("text", 5, Affinity.Downstream),
-        )
-      val endpoints = selectionEndpoints()
-      val fake =
-        FakeFfiEditor(selectionProvider = { selection }, selectionEndpointsProvider = { endpoints })
-      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
-      fake.publishSnapshot(editor)
-      val host = TestHost(this)
-      val controller =
-        EditorInteractionController(
-          editorProvider = { editor },
-          effects = host,
-          geometry = host,
-          uiStateProvider = { host.uiState },
-        )
-      controller.updateTapSlop(8f)
-      val down = Offset(42f, 30f)
+      for (type in listOf(PointerType.Touch, PointerType.Mouse)) {
+        val selection =
+          Selection(
+            anchor = Position("text", 0, Affinity.Downstream),
+            head = Position("text", 5, Affinity.Downstream),
+          )
+        val endpoints = selectionEndpoints()
+        val fake =
+          FakeFfiEditor(
+            selectionProvider = { selection },
+            selectionEndpointsProvider = { endpoints },
+          )
+        val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+        fake.publishSnapshot(editor)
+        val host = TestHost(this)
+        val controller =
+          EditorInteractionController(
+            editorProvider = { editor },
+            effects = host,
+            geometry = host,
+            uiStateProvider = { host.uiState },
+          )
+        controller.updateTapSlop(8f)
+        val down = Offset(42f, 30f)
 
-      assertTrue(controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L))
-      assertTrue(
+        controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L, type = type)
         controller.onPointerMove(pointerId = 1L, position = Offset(52f, 50f), nowMillis = 20L)
-      )
 
-      val extend =
-        fake.enqueued.filterIsInstance<Message.Selection>().single().op as SelectionOp.ExtendTo
-      assertEquals(endpoints.fromPosition, extend.anchor)
-      assertEquals(50f, extend.headX)
-      assertEquals(44f, extend.headY)
-      assertNull(extend.baseSelection)
-      assertFalse(extend.allowCollapse)
-      assertEquals(EditorInteractionMode.SelectionHandleDragging, controller.interactionMode)
-      assertEquals(Offset(50f, 44f), controller.magnifierPosition)
+        if (type == PointerType.Mouse) {
+          assertTrue(controller.interactionMode != EditorInteractionMode.SelectionHandleDragging)
+          assertTrue(
+            fake.enqueued.filterIsInstance<Message.Selection>().none {
+              it.op is SelectionOp.ExtendTo
+            }
+          )
+          controller.cancel()
+          continue
+        }
 
-      assertTrue(
-        controller.onPointerUp(pointerId = 1L, position = Offset(52f, 50f), nowMillis = 40L)
-      )
-      assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
-      assertFalse(host.scrollGestureLockActive)
+        val extend =
+          fake.enqueued.filterIsInstance<Message.Selection>().single().op as SelectionOp.ExtendTo
+        assertEquals(endpoints.fromPosition, extend.anchor)
+        assertEquals(50f, extend.headX)
+        assertEquals(44f, extend.headY)
+        assertNull(extend.baseSelection)
+        assertFalse(extend.allowCollapse)
+        assertEquals(EditorInteractionMode.SelectionHandleDragging, controller.interactionMode)
+        assertEquals(Offset(50f, 44f), controller.magnifierPosition)
+
+        assertTrue(
+          controller.onPointerUp(pointerId = 1L, position = Offset(52f, 50f), nowMillis = 40L)
+        )
+        assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+        assertFalse(host.scrollGestureLockActive)
+      }
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionScopeTest.kt
@@ -18,6 +18,7 @@ import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.Size
 import co.typie.editor.ffi.StateField
+import co.typie.editor.ffi.ViewOp
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.EditorBringIntoViewRequests
 import co.typie.editor.scroll.EditorVisibleArea
@@ -38,6 +39,29 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorInteractionScopeTest {
+  @Test
+  fun `app direct touch changes sync with the attached editor`() =
+    runTest(StandardTestDispatcher()) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      val scope = EditorInteractionScope(coroutineScope = this)
+
+      updateScope(scope = scope, editor = editor, editing = { true }, directTouchInteraction = true)
+      fake.enqueued.clear()
+
+      updateScope(
+        scope = scope,
+        editor = editor,
+        editing = { true },
+        directTouchInteraction = false,
+      )
+
+      assertEquals(
+        listOf<Message>(Message.View(ViewOp.SetDirectTouchInteraction(false))),
+        fake.enqueued,
+      )
+    }
+
   @Test
   fun `interaction effect contains an editor-owned failure`() =
     runTest(StandardTestDispatcher()) {
@@ -212,14 +236,22 @@ class EditorInteractionScopeTest {
         EditorInteractionScope(coroutineScope = this, platformProvider = { Platform.Desktop })
       var editing = false
       updateScope(scope = scope, editor = editor, editing = { editing }, uiState = uiState)
+      fake.enqueued.clear()
 
       scope.controller.onPointerDown(
         change = pointerDown(id = 1L, uptimeMillis = 0L),
         position = Offset(10f, 20f),
       )
+      fake.enqueued.clear()
 
       editing = true
-      updateScope(scope = scope, editor = editor, editing = { editing }, uiState = uiState)
+      updateScope(
+        scope = scope,
+        editor = editor,
+        editing = { editing },
+        directTouchInteraction = true,
+        uiState = uiState,
+      )
 
       assertTrue(
         scope.controller.onPointerUp(
@@ -398,6 +430,7 @@ class EditorInteractionScopeTest {
 
       scope.update(
         editor = null,
+        directTouchInteraction = false,
         bringIntoViewRequests = EditorBringIntoViewRequests(),
         uiState = EditorUiState(),
         density = 1f,
@@ -419,6 +452,7 @@ class EditorInteractionScopeTest {
 
       scope.update(
         editor = null,
+        directTouchInteraction = false,
         bringIntoViewRequests = EditorBringIntoViewRequests(),
         uiState = EditorUiState(),
         density = 1f,
@@ -450,6 +484,7 @@ class EditorInteractionScopeTest {
       val scope = EditorInteractionScope(coroutineScope = this)
       scope.update(
         editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler)),
+        directTouchInteraction = false,
         bringIntoViewRequests = EditorBringIntoViewRequests(),
         uiState = uiState,
         density = 1f,
@@ -511,6 +546,7 @@ class EditorInteractionScopeTest {
 
       scope.update(
         editor = editor,
+        directTouchInteraction = false,
         bringIntoViewRequests = EditorBringIntoViewRequests(),
         uiState = uiState,
         density = 1f,
@@ -526,6 +562,7 @@ class EditorInteractionScopeTest {
 
       scope.update(
         editor = editor,
+        directTouchInteraction = false,
         bringIntoViewRequests = EditorBringIntoViewRequests(),
         uiState = uiState,
         density = 1f,
@@ -552,11 +589,13 @@ class EditorInteractionScopeTest {
     scope: EditorInteractionScope,
     editor: Editor,
     editing: () -> Boolean,
+    directTouchInteraction: Boolean = false,
     uiState: EditorUiState = EditorUiState(),
     onRequestEditing: (Editor) -> Boolean = { false },
   ) {
     scope.update(
       editor = editor,
+      directTouchInteraction = directTouchInteraction,
       bringIntoViewRequests = EditorBringIntoViewRequests(),
       uiState = uiState,
       density = 1f,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlayTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/screen/editor/editor/overlay/EditorSelectionHandleOverlayTest.kt
@@ -88,6 +88,7 @@ class EditorSelectionHandleOverlayTest {
           editorRectInOverlay = ComposeRect.Zero,
           density = 1f,
           pagePresented = { true },
+          directTouchInteraction = true,
         )
         ?.size,
     )
@@ -99,6 +100,7 @@ class EditorSelectionHandleOverlayTest {
           editorRectInOverlay = ComposeRect.Zero,
           density = 1f,
           pagePresented = { page -> page == 0 },
+          directTouchInteraction = true,
         )
       )
     assertEquals(listOf(EditorSelectionHandleType.From), firstPageOnly.map { it.type })
@@ -109,6 +111,38 @@ class EditorSelectionHandleOverlayTest {
         editorRectInOverlay = ComposeRect.Zero,
         density = 1f,
         pagePresented = { false },
+        directTouchInteraction = true,
+      )
+    )
+  }
+
+  @Test
+  fun `selection handles are hidden outside direct touch interaction`() {
+    val selection =
+      Selection(
+        anchor = Position("text", 0, Affinity.Downstream),
+        head = Position("text", 5, Affinity.Downstream),
+      )
+    val state =
+      EditorState.Initial.copy(
+        selection = selection,
+        selectionEndpoints =
+          SelectionEndpoints(
+            from = PageRect(pageIdx = 0, rect = Rect(x = 10f, y = 20f, width = 0f, height = 8f)),
+            to = PageRect(pageIdx = 0, rect = Rect(x = 40f, y = 20f, width = 0f, height = 8f)),
+            fromPosition = selection.anchor,
+            toPosition = selection.head,
+          ),
+        pageSizes = listOf(Size(width = 100f, height = 100f)),
+      )
+
+    assertNull(
+      resolveSelectionHandleOverlayPlacements(
+        state = state,
+        uiState = EditorUiState(),
+        editorRectInOverlay = ComposeRect.Zero,
+        density = 1f,
+        directTouchInteraction = false,
       )
     )
   }

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/input/DirectTouchInteractionStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/ui/input/DirectTouchInteractionStateTest.kt
@@ -1,0 +1,26 @@
+package co.typie.ui.input
+
+import androidx.compose.ui.input.pointer.PointerType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DirectTouchInteractionStateTest {
+  @Test
+  fun `pointer and keyboard interactions update the app input state`() {
+    val state = DirectTouchInteractionState(initialDirectTouchInteraction = false)
+
+    state.recordPointerInteraction(PointerType.Touch)
+    assertTrue(state.isDirectTouchInteraction)
+
+    state.recordPointerInteraction(PointerType.Stylus)
+    assertTrue(state.isDirectTouchInteraction)
+
+    state.recordPointerInteraction(PointerType.Mouse)
+    assertFalse(state.isDirectTouchInteraction)
+
+    state.recordPointerInteraction(PointerType.Touch)
+    state.recordKeyboardInteraction()
+    assertFalse(state.isDirectTouchInteraction)
+  }
+}

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/EditorFrameSyncDesktopTest.kt
@@ -63,6 +63,8 @@ import co.typie.screen.editor.editor.layout.rememberCommittedEditorRenderZoom
 import co.typie.screen.editor.editor.overlay.resolveSelectionHandleOverlayGeometry
 import co.typie.screen.editor.editor.overlay.resolveSelectionHandleOverlayPlacements
 import co.typie.screen.editor.editor.state.EditorScreenState
+import co.typie.ui.input.DirectTouchInteractionState
+import co.typie.ui.input.LocalDirectTouchInteractionState
 import co.typie.ui.theme.LightAppShadows
 import co.typie.ui.theme.LightColors
 import co.typie.ui.theme.LocalAppColors
@@ -434,6 +436,7 @@ class EditorFrameSyncDesktopTest {
             uiState = fixture.uiState,
             editorRectInOverlay = editorRect,
             density = 1f,
+            directTouchInteraction = true,
           )
         )
       val pixels = onNodeWithTag(RootTag).captureToImage().toPixelMap()
@@ -1526,10 +1529,14 @@ class EditorFrameSyncDesktopTest {
           val consumed = fixture.viewportState.consumePan(Offset(x = -delta.x, y = -delta.y))
           Offset(x = -consumed.x, y = -consumed.y)
         }
+        val directTouchInteractionState = remember {
+          DirectTouchInteractionState(initialDirectTouchInteraction = false)
+        }
 
         SideEffect {
           interactionScope.update(
             editor = fixture.editor,
+            directTouchInteraction = false,
             bringIntoViewRequests = fixture.bringIntoViewRequests,
             uiState = fixture.uiState,
             visibleArea = fixture.visibleArea,
@@ -1553,6 +1560,7 @@ class EditorFrameSyncDesktopTest {
           LocalEditorZoomController provides zoomController,
           LocalEditorBringIntoViewRequests provides fixture.bringIntoViewRequests,
           LocalEditorInteractionScope provides interactionScope,
+          LocalDirectTouchInteractionState provides directTouchInteractionState,
         ) {
           EditorSurfaceHost(
             editor = fixture.editor,

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/layout/EditorScreenLayoutDesktopTest.kt
@@ -1504,6 +1504,7 @@ class EditorScreenLayoutDesktopTest {
       SideEffect {
         interactionScope.update(
           editor = fixture.editor,
+          directTouchInteraction = false,
           bringIntoViewRequests = bringIntoViewRequests,
           uiState = fixture.uiState,
           visibleArea = fixture.visibleArea,

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorDocumentManipulationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorDocumentManipulationDesktopTest.kt
@@ -1285,6 +1285,7 @@ class EditorDocumentManipulationDesktopTest {
         onInteractionScope(interactionScope)
         interactionScope.update(
           editor = editor,
+          directTouchInteraction = false,
           bringIntoViewRequests = bringIntoViewRequests,
           uiState = uiState,
           visibleArea = visibleArea,
@@ -1347,6 +1348,7 @@ class EditorDocumentManipulationDesktopTest {
               uiState = uiState,
               density = 1f,
               pagePresented = { page -> editor.publishedBundle?.frames?.containsKey(page) == true },
+              directTouchInteraction = true,
             )
           }
         }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/screen/editor/editor/overlay/EditorOverlayLayoutSynchronizationDesktopTest.kt
@@ -438,6 +438,7 @@ class EditorOverlayLayoutSynchronizationDesktopTest {
               uiState = uiState,
               density = 1f,
               pagePresented = { true },
+              directTouchInteraction = true,
             )
           }
         }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/input/DirectTouchInteractionDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/input/DirectTouchInteractionDesktopTest.kt
@@ -1,0 +1,45 @@
+package co.typie.ui.input
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class, InternalComposeUiApi::class)
+class DirectTouchInteractionDesktopTest {
+  @Test
+  fun indirectPointerInputReplacesTouchWithoutAPress() = runComposeUiTest {
+    val state = DirectTouchInteractionState(initialDirectTouchInteraction = false)
+    setContent { Box(Modifier.size(100.dp).testTag("input").trackDirectTouchInteraction(state)) }
+    val scene = (this as SkikoComposeUiTest).scene
+    for (eventType in
+      listOf(PointerEventType.Scroll, PointerEventType.PanStart, PointerEventType.ScaleStart)) {
+      onNodeWithTag("input").performTouchInput {
+        down(center)
+        up()
+      }
+      runOnIdle { assertTrue(state.isDirectTouchInteraction) }
+      runOnUiThread {
+        scene.sendPointerEvent(
+          eventType = eventType,
+          position = Offset(50f, 50f),
+          scrollDelta = Offset(0f, 10f),
+        )
+      }
+      runOnIdle { assertFalse(state.isDirectTouchInteraction) }
+    }
+  }
+}

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -2292,6 +2292,18 @@ impl Editor {
         self.toggle_fold(id)
     }
 
+    pub(crate) fn set_direct_touch_interaction(&mut self, direct: bool) -> bool {
+        if !self.view.set_direct_touch_interaction(direct) {
+            return false;
+        }
+        *self.selection_mark_rects_cache.lock().unwrap() = None;
+        self.push_event(EditorEvent::StateChanged {
+            fields: vec![StateField::Cursor],
+        });
+        self.push_event(EditorEvent::RenderInvalidated);
+        true
+    }
+
     pub(crate) fn fold_expanded(&self, id: Dot) -> bool {
         self.view.fold_expanded(id)
     }

--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -1391,6 +1391,172 @@ mod tests {
     }
 
     #[test]
+    fn direct_touch_extend_selects_paragraph_break_only_after_crossing_line_bottom() {
+        for layout_mode in [
+            editor_model::LayoutMode::Continuous { max_width: 400 },
+            editor_model::LayoutMode::Paginated {
+                page_width: 400,
+                page_height: 80,
+                page_margin_top: 20,
+                page_margin_bottom: 20,
+                page_margin_left: 20,
+                page_margin_right: 20,
+            },
+        ] {
+            let (state, p1, _p2) = state! {
+                doc {
+                    root (layout_mode: layout_mode) [block_gap(200)] {
+                        p1: paragraph { text("aa") }
+                        p2: paragraph { text("bb") }
+                    }
+                }
+                selection: (p1, 0)
+            };
+            let mut editor = Editor::new_test(state);
+            editor.view.layout(&editor.state);
+            editor.apply(Message::View {
+                op: ViewOp::SetDirectTouchInteraction { direct: true },
+            });
+            let (paragraph_break, rect) = {
+                let view = editor.state.view();
+                let paragraph_break =
+                    editor_state::paragraph_break_at_end(&Position::new(p1, 2), &view)
+                        .expect("P -> P has PB");
+                let resolved = paragraph_break
+                    .resolve(&view)
+                    .expect("paragraph break resolves");
+                let rect = editor
+                    .view
+                    .selection_rects(&resolved)
+                    .into_iter()
+                    .find(|rect| rect.meta == editor_view::SelectionRectKind::ParagraphBreak)
+                    .expect("paragraph break rect exists");
+                (paragraph_break, rect)
+            };
+
+            let extend = |editor: &mut Editor, head_x: f32, head_y: f32| {
+                editor.apply(Message::Selection {
+                    op: SelectionOp::ExtendTo {
+                        anchor: Position::new(p1, 0),
+                        head_page: rect.page_idx,
+                        head_x,
+                        head_y,
+                        base_selection: None,
+                        allow_collapse: false,
+                    },
+                });
+            };
+
+            extend(
+                &mut editor,
+                rect.rect.right() + 20.0,
+                rect.rect.y + rect.rect.height / 2.0,
+            );
+            {
+                let view = editor.state().view();
+                let resolved = editor.state().selection.unwrap().resolve(&view).unwrap();
+                assert!(!resolved.contains_range(paragraph_break));
+            }
+
+            for head_x in [rect.rect.right() + 20.0, 500.0] {
+                editor.apply(Message::Selection {
+                    op: SelectionOp::Set {
+                        selection: Selection::collapsed(Position::new(p1, 0)),
+                    },
+                });
+                extend(&mut editor, head_x, rect.rect.bottom() + 1.0);
+                {
+                    let view = editor.state().view();
+                    let resolved = editor.state().selection.unwrap().resolve(&view).unwrap();
+                    assert!(resolved.contains_range(paragraph_break));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn reverse_direct_touch_extend_selects_paragraph_break_at_left_or_top_line_edge() {
+        let (state, p1, p2) = state! {
+            doc {
+                root [block_gap(200)] {
+                    p1: paragraph { text("aa") }
+                    p2: paragraph { text("bb") }
+                }
+            }
+            selection: (p2, 1)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.view.layout(&editor.state);
+        editor.apply(Message::View {
+            op: ViewOp::SetDirectTouchInteraction { direct: true },
+        });
+        let (paragraph_break, rect) = {
+            let view = editor.state.view();
+            let paragraph_break =
+                editor_state::paragraph_break_at_end(&Position::new(p1, 2), &view)
+                    .expect("P -> P has PB");
+            let resolved = paragraph_break
+                .resolve(&view)
+                .expect("paragraph break resolves");
+            let rect = editor
+                .view
+                .selection_rects(&resolved)
+                .into_iter()
+                .find(|rect| rect.meta == editor_view::SelectionRectKind::ParagraphBreak)
+                .expect("paragraph break rect exists");
+            (paragraph_break, rect)
+        };
+
+        let extend = |editor: &mut Editor, head_x: f32, head_y: f32| {
+            editor.apply(Message::Selection {
+                op: SelectionOp::ExtendTo {
+                    anchor: Position::new(p2, 1),
+                    head_page: rect.page_idx,
+                    head_x,
+                    head_y,
+                    base_selection: None,
+                    allow_collapse: false,
+                },
+            });
+        };
+        let includes_paragraph_break = |editor: &Editor| {
+            let view = editor.state().view();
+            editor
+                .state()
+                .selection
+                .unwrap()
+                .resolve(&view)
+                .unwrap()
+                .contains_range(paragraph_break)
+        };
+
+        for head_x in [rect.rect.x, 900.0] {
+            extend(&mut editor, head_x, rect.rect.y + rect.rect.height / 2.0);
+            assert!(!includes_paragraph_break(&editor));
+        }
+
+        editor.apply(Message::Selection {
+            op: SelectionOp::Set {
+                selection: Selection::collapsed(Position::new(p2, 1)),
+            },
+        });
+        extend(
+            &mut editor,
+            rect.rect.x - 1.0,
+            rect.rect.y + rect.rect.height / 2.0,
+        );
+        assert!(includes_paragraph_break(&editor));
+
+        editor.apply(Message::Selection {
+            op: SelectionOp::Set {
+                selection: Selection::collapsed(Position::new(p2, 1)),
+            },
+        });
+        extend(&mut editor, rect.rect.right() + 20.0, rect.rect.y - 1.0);
+        assert!(includes_paragraph_break(&editor));
+    }
+
+    #[test]
     fn extend_to_visual_removable_empty_paragraph_break_stops_before_next_block() {
         let (state, p1, empty) = state! {
             doc {

--- a/crates/editor-core/src/handle/view.rs
+++ b/crates/editor-core/src/handle/view.rs
@@ -45,6 +45,10 @@ pub fn handle_view_op(editor: &mut Editor, op: ViewOp) -> Result<(), EditorError
             editor.expand_folds(folds);
             Ok(())
         }
+        ViewOp::SetDirectTouchInteraction { direct } => {
+            editor.set_direct_touch_interaction(direct);
+            Ok(())
+        }
     }
 }
 
@@ -176,6 +180,63 @@ mod tests {
         });
 
         assert!(!editor.fold_expanded(f1), "folds load collapsed by default");
+    }
+
+    #[test]
+    fn direct_touch_changes_only_active_selection_presentation() {
+        let (initial, p1, p2) = state! {
+            doc { root {
+                p1: paragraph { text("abc") }
+                p2: paragraph { text("def") }
+            } }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.view.layout(&editor.state);
+        let paragraph_break =
+            editor_state::paragraph_break_at_end(&Position::new(p1, 3), &editor.state().view())
+                .expect("paragraph break");
+        editor.apply(Message::Selection {
+            op: SelectionOp::Set {
+                selection: Selection::new(Position::new(p1, 0), paragraph_break.head),
+            },
+        });
+
+        let general_before = {
+            let doc = editor.state().view();
+            let resolved = editor.state().selection.unwrap().resolve(&doc).unwrap();
+            editor.view.selection_rects(&resolved)
+        };
+        let compact_marks = editor.cell_selection_rects_for_test();
+
+        let events = editor.apply(Message::View {
+            op: ViewOp::SetDirectTouchInteraction { direct: true },
+        });
+
+        let general_after = {
+            let doc = editor.state().view();
+            let resolved = editor.state().selection.unwrap().resolve(&doc).unwrap();
+            editor.view.selection_rects(&resolved)
+        };
+        let touch_marks = editor.cell_selection_rects_for_test();
+        let endpoints = editor.selection_endpoints().expect("selection endpoints");
+
+        assert_eq!(general_after, general_before);
+        assert_eq!(compact_marks.len(), 1);
+        assert_eq!(touch_marks.len(), 1);
+        assert!(touch_marks[0].rect.right() > compact_marks[0].rect.right());
+        assert_eq!(endpoints.to.rect.x, touch_marks[0].rect.right());
+        assert!(events.iter().any(|event| matches!(
+            event,
+            EditorEvent::StateChanged { fields } if fields == &[StateField::Cursor]
+        )));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, EditorEvent::RenderInvalidated))
+        );
+        assert_eq!(editor.state().selection.unwrap().head, paragraph_break.head);
+        assert_eq!(p2, paragraph_break.head.node);
     }
 
     #[test]

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -305,6 +305,7 @@ pub enum ViewOp {
     ToggleFold { id: Dot },
     ExpandFoldsForSelection,
     ExpandFoldsForTrackedRange { id: String },
+    SetDirectTouchInteraction { direct: bool },
 }
 
 #[ffi]

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -755,7 +755,7 @@ export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type
 
 export type UnderlineStyle = "solid" | "dashed" | "wavy";
 
-export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_selection" } | { type: "expand_folds_for_tracked_range"; id: string };
+export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_selection" } | { type: "expand_folds_for_tracked_range"; id: string } | { type: "set_direct_touch_interaction"; direct: boolean };
 
 export type ViewportAnchor = { type: "position"; stable: StableSelection; original_node: Dot; geometry: ViewportAnchorPositionGeometry } | { type: "node"; node: Dot; offset_x: number; offset_y: number };
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -905,7 +905,7 @@ export type Tri<T> = { type: "absent" } | { type: "uniform"; value: T } | { type
 
 export type UnderlineStyle = "solid" | "dashed" | "wavy";
 
-export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_selection" } | { type: "expand_folds_for_tracked_range"; id: string };
+export type ViewOp = { type: "toggle_fold"; id: Dot } | { type: "expand_folds_for_selection" } | { type: "expand_folds_for_tracked_range"; id: string } | { type: "set_direct_touch_interaction"; direct: boolean };
 
 export type ViewportAnchor = { type: "position"; stable: StableSelection; original_node: Dot; geometry: ViewportAnchorPositionGeometry } | { type: "node"; node: Dot; offset_x: number; offset_y: number };
 

--- a/crates/editor-state/src/lib.rs
+++ b/crates/editor-state/src/lib.rs
@@ -75,6 +75,7 @@ pub use normalize::{
 };
 pub use paragraph_break::{
     before_or_same, closest_empty_paragraph_break_end_between, paragraph_break_at_end,
+    paragraph_break_ending_at,
 };
 pub use pending_modifier::*;
 pub use plain_text::doc_plain_text;

--- a/crates/editor-state/src/paragraph_break.rs
+++ b/crates/editor-state/src/paragraph_break.rs
@@ -96,6 +96,27 @@ pub fn paragraph_break_at_end(pos: &Position, view: &DocView) -> Option<Selectio
     trailing_break_for_paragraph(&para, view)
 }
 
+pub fn paragraph_break_ending_at(pos: &Position, view: &DocView) -> Option<Selection> {
+    let previous = if let Some(paragraph) = paragraph_owner(pos, view)
+        && same_boundary(pos, &paragraph_start_boundary(&paragraph)?, view)
+    {
+        paragraph
+            .index()?
+            .checked_sub(1)
+            .and_then(|index| paragraph.parent()?.child_at(index))?
+    } else {
+        let parent = view.node(pos.node)?;
+        pos.offset
+            .checked_sub(1)
+            .and_then(|index| parent.child_at(index))?
+    };
+    let ChildView::Block(previous) = previous else {
+        return None;
+    };
+    let paragraph_break = trailing_break_for_paragraph(&previous, view)?;
+    same_boundary(pos, &paragraph_break.head, view).then_some(paragraph_break)
+}
+
 fn same_boundary(a: &Position, b: &Position, view: &DocView) -> bool {
     matches!((a.resolve(view), b.resolve(view)), (Some(ra), Some(rb)) if ra.path() == rb.path())
 }
@@ -500,6 +521,19 @@ mod tests {
         assert_eq!(result, sel, "paragraph-break span preserved (reversed)");
     }
 
+    #[test]
+    fn test_paragraph_break_ending_at_next_paragraph_start() {
+        let (pd, _root, p1, _p2) = two_paras();
+        let view = DocView::new(&pd);
+        let paragraph_break = paragraph_break_at_end(&pos_aff(p1, 2, Affinity::Downstream), &view)
+            .expect("paragraph break");
+
+        assert_eq!(
+            paragraph_break_ending_at(&paragraph_break.head, &view),
+            Some(paragraph_break),
+        );
+    }
+
     // ── §4.2b paragraph→non-paragraph (callout) — NOT a break ────────────────
 
     #[test]
@@ -554,6 +588,7 @@ mod tests {
         assert_eq!(anchor.offset, 0);
         assert_eq!(anchor.affinity, Affinity::Downstream);
         assert_eq!(head.affinity, Affinity::Upstream);
+        assert_eq!(paragraph_break_ending_at(head, &view), Some(pb));
     }
 
     // ── §4.3 removable empty paragraph with NO next sibling → NO break ────────

--- a/crates/editor-view/src/query/hit_test.rs
+++ b/crates/editor-view/src/query/hit_test.rs
@@ -67,17 +67,32 @@ pub(crate) fn hit_test_extending(
     page_idx: usize,
     x: f32,
     y: f32,
+    direct_touch_interaction: bool,
 ) -> Option<ExtendingHit> {
     let point = layout_index.point(page_idx, x, y)?;
     let anchor = anchor.resolve(view)?;
     let scope = layout_index.container_scope(point);
 
-    drag_exact_selection_at(layout_index, view, &anchor, point, scope)
-        .map(ExtendingHit::exact)
-        .or_else(|| {
-            drag_boundary_fallback(layout_index, view, &anchor, point, scope)
-                .map(ExtendingHit::fallback)
-        })
+    drag_exact_selection_at(
+        layout_index,
+        view,
+        &anchor,
+        point,
+        scope,
+        direct_touch_interaction,
+    )
+    .map(ExtendingHit::exact)
+    .or_else(|| {
+        drag_boundary_fallback(
+            layout_index,
+            view,
+            &anchor,
+            point,
+            scope,
+            direct_touch_interaction,
+        )
+        .map(ExtendingHit::fallback)
+    })
 }
 
 fn drag_exact_selection_at(
@@ -86,6 +101,7 @@ fn drag_exact_selection_at(
     anchor: &ResolvedPosition,
     point: LayoutPoint,
     scope: Option<&LayoutEntry>,
+    direct_touch_interaction: bool,
 ) -> Option<Selection> {
     let is_scoped_drag_exact_hit_entry = |entry: &LayoutEntry, node: &LayoutNode| {
         is_drag_exact_hit_entry(entry, node)
@@ -93,7 +109,14 @@ fn drag_exact_selection_at(
     };
 
     let entry = layout_index.exact_entry(point, is_scoped_drag_exact_hit_entry)?;
-    drag_exact_selection_for_entry(layout_index, view, anchor, entry, point)
+    drag_exact_selection_for_entry(
+        layout_index,
+        view,
+        anchor,
+        entry,
+        point,
+        direct_touch_interaction,
+    )
 }
 
 fn drag_exact_selection_for_entry(
@@ -102,10 +125,18 @@ fn drag_exact_selection_for_entry(
     anchor: &ResolvedPosition,
     entry: &LayoutEntry,
     point: LayoutPoint,
+    direct_touch_interaction: bool,
 ) -> Option<Selection> {
     hard_break::drag_selection_for_entry(layout_index, view, entry, point)
         .or_else(|| {
-            paragraph_break::drag_selection_for_entry(layout_index, view, anchor, entry, point)
+            paragraph_break::drag_selection_for_entry(
+                layout_index,
+                view,
+                anchor,
+                entry,
+                point,
+                direct_touch_interaction,
+            )
         })
         .or_else(|| match entry.content(layout_index)? {
             LayoutContent::Line(_) | LayoutContent::Atom(_) => {
@@ -153,6 +184,7 @@ fn drag_boundary_fallback(
     anchor: &ResolvedPosition,
     point: LayoutPoint,
     scope: Option<&LayoutEntry>,
+    direct_touch_interaction: bool,
 ) -> Option<Selection> {
     let mut inside: Option<DragFallbackCandidate> = None;
     let mut before: Option<DragFallbackCandidate> = None;
@@ -179,31 +211,48 @@ fn drag_boundary_fallback(
         }
     }
 
-    if let Some(candidate) = inside {
-        return Some(candidate.selection);
+    let candidate = inside.or_else(|| {
+        let prefer_before = after
+            .as_ref()
+            .and_then(|candidate| candidate.start.resolve(view))
+            .is_none_or(|after_start| anchor < &after_start);
+        if prefer_before {
+            before.or(after)
+        } else {
+            after.or(before)
+        }
+    })?;
+    if direct_touch_interaction
+        && let Some(selection) = paragraph_break::drag_selection_for_entry(
+            layout_index,
+            view,
+            anchor,
+            candidate.entry,
+            point,
+            true,
+        )
+    {
+        return Some(selection);
     }
-
-    let prefer_before = after
-        .as_ref()
-        .and_then(|candidate| candidate.start.resolve(view))
-        .is_none_or(|after_start| anchor < &after_start);
-    let candidate = if prefer_before {
-        before.or(after)
-    } else {
-        after.or(before)
-    };
-    candidate.map(|candidate| candidate.selection)
+    Some(candidate.selection)
 }
 
-struct DragFallbackCandidate {
+struct DragFallbackCandidate<'a> {
+    entry: &'a LayoutEntry,
     distance: (f32, f32),
     start: Position,
     selection: Selection,
 }
 
-impl DragFallbackCandidate {
-    fn new(entry: &LayoutEntry, point: LayoutPoint, start: Position, selection: Selection) -> Self {
+impl<'a> DragFallbackCandidate<'a> {
+    fn new(
+        entry: &'a LayoutEntry,
+        point: LayoutPoint,
+        start: Position,
+        selection: Selection,
+    ) -> Self {
         Self {
+            entry,
             distance: distance_key(&entry.rect, point.x, point.y),
             start,
             selection,
@@ -215,11 +264,11 @@ impl DragFallbackCandidate {
     }
 }
 
-fn drag_fallback_candidate(
+fn drag_fallback_candidate<'a>(
     layout_index: &LayoutIndex,
-    entry: &LayoutEntry,
+    entry: &'a LayoutEntry,
     point: LayoutPoint,
-) -> Option<DragFallbackCandidate> {
+) -> Option<DragFallbackCandidate<'a>> {
     match entry.content(layout_index)? {
         LayoutContent::Line(line) => {
             let start = position_in_line(line, &entry.rect, entry.rect.x);
@@ -930,7 +979,7 @@ mod tests {
             offset: 0,
             affinity: Affinity::Downstream,
         };
-        let result = hit_test_extending(&index, &view, &drag_anchor, 0, click_x, page_y);
+        let result = hit_test_extending(&index, &view, &drag_anchor, 0, click_x, page_y, false);
 
         assert!(
             result.is_some(),
@@ -972,7 +1021,7 @@ mod tests {
         let x = cell_rect.x + cell_rect.width / 2.0;
         let page_y = (cell_rect.y + line_entry.rect.y) / 2.0 - index.pages()[0].y_start;
 
-        let hit = hit_test_extending(&index, &view, &anchor, 0, x, page_y)
+        let hit = hit_test_extending(&index, &view, &anchor, 0, x, page_y, false)
             .expect("cell padding must still produce an extending hit");
 
         assert_eq!(hit.source, ExtendingHitSource::Fallback);
@@ -1018,9 +1067,9 @@ mod tests {
         };
 
         let sel_with_before_anchor =
-            hit_test_extending(&index, &view, &anchor_before, 0, x, gap_mid_y_page);
+            hit_test_extending(&index, &view, &anchor_before, 0, x, gap_mid_y_page, false);
         let sel_with_after_anchor =
-            hit_test_extending(&index, &view, &anchor_after, 0, x, gap_mid_y_page);
+            hit_test_extending(&index, &view, &anchor_after, 0, x, gap_mid_y_page, false);
 
         assert!(
             sel_with_before_anchor.is_some(),

--- a/crates/editor-view/src/query/paragraph_break.rs
+++ b/crates/editor-view/src/query/paragraph_break.rs
@@ -9,7 +9,7 @@ use editor_model::{ChildView, DocView, NodeType};
 use editor_state::Affinity;
 use editor_state::{
     Position, ResolvedPosition, Selection, before_or_same, last_cursor_position,
-    paragraph_break_at_end,
+    paragraph_break_at_end, paragraph_break_ending_at,
 };
 
 use crate::page::{LayoutPage, PageRect};
@@ -37,6 +37,16 @@ pub(crate) fn paragraph_break_occurrence_for_node(
     Some(ParagraphBreakOccurrence { range, geometry })
 }
 
+pub(crate) fn paragraph_break_occurrence_ending_at(
+    layout_index: &LayoutIndex,
+    view: &DocView,
+    position: &Position,
+) -> Option<ParagraphBreakOccurrence> {
+    let range = paragraph_break_ending_at(position, view)?;
+    let geometry = geometry(layout_index, range, layout_index.pages())?;
+    Some(ParagraphBreakOccurrence { range, geometry })
+}
+
 fn geometry(
     layout_index: &LayoutIndex,
     paragraph_break_range: Selection,
@@ -56,12 +66,25 @@ pub(crate) fn drag_selection_for_entry(
     anchor: &ResolvedPosition<'_>,
     entry: &LayoutEntry,
     point: LayoutPoint,
+    direct_touch_interaction: bool,
 ) -> Option<Selection> {
     let paragraph_break = paragraph_break_occurrence_for_entry(layout_index, view, entry)?;
     match entry.content(layout_index)? {
         LayoutContent::Line(_) => {
             let rect = paragraph_break.geometry.rect.rect;
             let page_y = point.y - point.page_y_start;
+            if direct_touch_interaction {
+                let resolved = paragraph_break.range.resolve(view)?;
+                let dragging_forward =
+                    before_or_same(&anchor.position(), &resolved.from().position(), view);
+                if dragging_forward {
+                    return (page_y >= rect.bottom()).then_some(paragraph_break.range);
+                }
+                if point.x < rect.x || page_y < rect.y {
+                    return None;
+                }
+                return Some(Selection::collapsed(paragraph_break.range.head));
+            }
             let x_mid = rect.x + rect.width / 2.0;
             if paragraph_break.geometry.rect.page_idx == point.page_idx
                 && page_y >= rect.y
@@ -471,7 +494,8 @@ mod tests {
                 page_y_start: 0.0,
             };
 
-            let result = drag_selection_for_entry(&index, &view, &anchor_rp, gap_entry, point);
+            let result =
+                drag_selection_for_entry(&index, &view, &anchor_rp, gap_entry, point, false);
             assert!(
                 result.is_some(),
                 "drag_selection_for_entry must return Some for gap entry"
@@ -494,7 +518,7 @@ mod tests {
                 .expect("after-anchor must resolve");
 
             let result2 =
-                drag_selection_for_entry(&index, &view, &after_anchor_rp, gap_entry, point);
+                drag_selection_for_entry(&index, &view, &after_anchor_rp, gap_entry, point, false);
             assert!(
                 result2.is_some(),
                 "drag_selection_for_entry after gap must return Some"

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -66,7 +66,13 @@ impl SelectionRectSets {
         self.text_rects.push(rect);
     }
 
-    fn push_paragraph_break(&mut self, rect: SelectionRect, paragraph_rects_start: usize) {
+    fn push_paragraph_break(
+        &mut self,
+        geometry: super::paragraph_break::ParagraphBreakGeometry,
+        paragraph_rects_start: usize,
+        direct_touch_interaction: bool,
+    ) {
+        let rect = paragraph_break_rect(&geometry);
         let extends_text = self.line_box_rects.len() > paragraph_rects_start
             && self.line_box_rects.last().is_some_and(|previous| {
                 previous.meta == SelectionRectKind::Text
@@ -84,10 +90,18 @@ impl SelectionRectSets {
                 .expect("a text line box must have an engine-painted mark");
             debug_assert_eq!(line_box, mark);
             line_box.rect.width += rect.rect.width;
-            mark.rect.width += rect.rect.width;
+            mark.rect.width = if direct_touch_interaction {
+                (geometry.line_right - mark.rect.x).max(0.0)
+            } else {
+                mark.rect.width + rect.rect.width
+            };
         } else {
             self.line_box_rects.push(rect.clone());
-            self.mark_rects.push(rect.clone());
+            let mut mark = rect.clone();
+            if direct_touch_interaction {
+                mark.rect.width = (geometry.line_right - mark.rect.x).max(0.0);
+            }
+            self.mark_rects.push(mark);
         }
         self.text_rects.push(rect);
     }
@@ -129,6 +143,7 @@ struct SelectionWalk<'a, 'doc> {
     to_owner: Option<&'a LayoutEntry>,
     pages: &'a [LayoutPage],
     selection: &'a ResolvedSelection<'doc>,
+    direct_touch_interaction: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,26 +156,34 @@ pub(crate) fn selection_rects(
     layout_index: &LayoutIndex,
     selection: &ResolvedSelection<'_>,
 ) -> Vec<SelectionRect> {
-    selection_rect_sets(layout_index, selection).line_box_rects
+    selection_rect_sets(layout_index, selection, false).line_box_rects
 }
 
 pub(crate) fn selection_mark_rects(
     layout_index: &LayoutIndex,
     selection: &ResolvedSelection<'_>,
 ) -> Vec<SelectionRect> {
-    selection_rect_sets(layout_index, selection).mark_rects
+    selection_rect_sets(layout_index, selection, false).mark_rects
+}
+
+pub(crate) fn selection_mark_rects_for_direct_touch(
+    layout_index: &LayoutIndex,
+    selection: &ResolvedSelection<'_>,
+) -> Vec<SelectionRect> {
+    selection_rect_sets(layout_index, selection, true).mark_rects
 }
 
 pub(crate) fn selection_text_rects(
     layout_index: &LayoutIndex,
     selection: &ResolvedSelection<'_>,
 ) -> Vec<SelectionRect> {
-    selection_rect_sets(layout_index, selection).text_rects
+    selection_rect_sets(layout_index, selection, false).text_rects
 }
 
 fn selection_rect_sets(
     layout_index: &LayoutIndex,
     selection: &ResolvedSelection<'_>,
+    direct_touch_interaction: bool,
 ) -> SelectionRectSets {
     if selection.is_collapsed() {
         return SelectionRectSets::empty();
@@ -198,6 +221,7 @@ fn selection_rect_sets(
         to_owner,
         pages,
         selection,
+        direct_touch_interaction,
     };
 
     visit_node(&layout_index.tree().root, &walk, &mut phase, &mut rects);
@@ -212,9 +236,14 @@ fn hard_break_rect(geometry: super::hard_break::HardBreakGeometry) -> SelectionR
     PageRect::with_meta(rect.page_idx, rect.rect, SelectionRectKind::Text)
 }
 
-fn paragraph_break_rect(geometry: super::paragraph_break::ParagraphBreakGeometry) -> SelectionRect {
-    let rect = geometry.rect;
-    PageRect::with_meta(rect.page_idx, rect.rect, SelectionRectKind::ParagraphBreak)
+fn paragraph_break_rect(
+    geometry: &super::paragraph_break::ParagraphBreakGeometry,
+) -> SelectionRect {
+    PageRect::with_meta(
+        geometry.rect.page_idx,
+        geometry.rect.rect,
+        SelectionRectKind::ParagraphBreak,
+    )
 }
 
 pub(crate) fn block_selection_rects(
@@ -243,6 +272,21 @@ pub(crate) fn selection_endpoints(
     layout_index: &LayoutIndex,
     selection: &ResolvedSelection<'_>,
 ) -> Option<SelectionEndpoints> {
+    selection_endpoints_with_direct_touch(layout_index, selection, false)
+}
+
+pub(crate) fn selection_endpoints_for_direct_touch(
+    layout_index: &LayoutIndex,
+    selection: &ResolvedSelection<'_>,
+) -> Option<SelectionEndpoints> {
+    selection_endpoints_with_direct_touch(layout_index, selection, true)
+}
+
+fn selection_endpoints_with_direct_touch(
+    layout_index: &LayoutIndex,
+    selection: &ResolvedSelection<'_>,
+    direct_touch_interaction: bool,
+) -> Option<SelectionEndpoints> {
     if selection.is_collapsed() {
         return None;
     }
@@ -250,7 +294,12 @@ pub(crate) fn selection_endpoints(
     let from_position = selection.from().position();
     let to_position = selection.to().position();
     let direct_from = selection_endpoint_for_position(layout_index, &from_position);
-    let direct_to = selection_endpoint_for_position(layout_index, &to_position);
+    let direct_to = if direct_touch_interaction {
+        direct_touch_paragraph_break_endpoint(layout_index, selection.view(), &to_position)
+            .or_else(|| selection_endpoint_for_position(layout_index, &to_position))
+    } else {
+        selection_endpoint_for_position(layout_index, &to_position)
+    };
     let (from, to) = match (direct_from, direct_to) {
         (Some(from), Some(to)) if selection.as_cell_rect().is_none() => (from, to),
         (direct_from, direct_to) => {
@@ -267,6 +316,25 @@ pub(crate) fn selection_endpoints(
         from_position,
         to_position,
     })
+}
+
+fn direct_touch_paragraph_break_endpoint(
+    layout_index: &LayoutIndex,
+    view: &DocView,
+    position: &Position,
+) -> Option<PageRect> {
+    let paragraph_break =
+        super::paragraph_break::paragraph_break_occurrence_ending_at(layout_index, view, position)?;
+    let rect = paragraph_break.geometry.rect;
+    Some(PageRect::new(
+        rect.page_idx,
+        Rect::from_xywh(
+            paragraph_break.geometry.line_right.max(rect.rect.x),
+            rect.rect.y,
+            0.0,
+            rect.rect.height,
+        ),
+    ))
 }
 
 fn selection_rect_endpoints(rects: &[SelectionRect]) -> Option<(PageRect, PageRect)> {
@@ -626,6 +694,7 @@ fn visit_line(
         to_owner,
         pages,
         selection,
+        ..
     } = *walk;
     let contains_from = from_owner.is_some_and(|entry| entry.is_node(layout_index, node));
     let contains_to = to_owner.is_some_and(|entry| entry.is_node(layout_index, node));
@@ -754,6 +823,7 @@ fn visit_box(
         to_owner,
         pages,
         selection,
+        ..
     } = *walk;
     let from_at_box_level = from.node == bx.node && from_owner.is_none();
     let to_at_box_level = to.node == bx.node && to_owner.is_none();
@@ -798,8 +868,9 @@ fn visit_box(
         && selection.contains_range(paragraph_break.range)
     {
         rects.push_paragraph_break(
-            paragraph_break_rect(paragraph_break.geometry),
+            paragraph_break.geometry,
             line_box_rects_before,
+            walk.direct_touch_interaction,
         );
     }
 
@@ -1219,6 +1290,39 @@ mod tests {
             );
             assert_eq!(rects[1].meta, SelectionRectKind::Text);
         }
+    }
+
+    #[test]
+    fn direct_touch_extends_only_active_paragraph_break_presentation_to_line_end() {
+        let (doc, _root, first_para, _second_para) = two_para_doc("abc", "def");
+        let (pd, index) = build_index(&doc, 400.0);
+        let view = DocView::new(&pd);
+        let paragraph_break =
+            editor_state::paragraph_break_at_end(&Position::new(first_para, 3), &view)
+                .expect("paragraph break");
+        let selection = Selection::new(Position::new(first_para, 0), paragraph_break.head);
+        let resolved = selection.resolve(&view).expect("must resolve");
+        let (first_entry, _) =
+            first_line_for_para(&index, &first_para).expect("must find first line");
+
+        let general = selection_rects(&index, &resolved);
+        let compact_mark = selection_mark_rects(&index, &resolved);
+        let direct_touch_mark = selection_mark_rects_for_direct_touch(&index, &resolved);
+        let direct_touch_endpoints =
+            selection_endpoints_for_direct_touch(&index, &resolved).expect("must have endpoints");
+
+        assert_eq!(general, compact_mark, "general geometry stays compact");
+        assert_eq!(direct_touch_mark.len(), 1);
+        assert_close(
+            direct_touch_mark[0].rect.right(),
+            first_entry.rect.right(),
+            "direct-touch mark right",
+        );
+        assert_close(
+            direct_touch_endpoints.to.rect.x,
+            first_entry.rect.right(),
+            "direct-touch trailing handle x",
+        );
     }
 
     #[test]

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -631,6 +631,7 @@ impl View {
             page_idx,
             x,
             y,
+            self.view_state.direct_touch_interaction,
         )
     }
 
@@ -826,7 +827,14 @@ impl View {
         let Some(result) = self.layout.as_ref() else {
             return Vec::new();
         };
-        crate::query::selection::selection_mark_rects(&result.layout_index, selection)
+        if self.view_state.direct_touch_interaction {
+            crate::query::selection::selection_mark_rects_for_direct_touch(
+                &result.layout_index,
+                selection,
+            )
+        } else {
+            crate::query::selection::selection_mark_rects(&result.layout_index, selection)
+        }
     }
 
     pub fn selection_text_rects(
@@ -844,7 +852,14 @@ impl View {
         selection: &ResolvedSelection,
     ) -> Option<crate::query::selection::SelectionEndpoints> {
         let result = self.layout.as_ref()?;
-        crate::query::selection::selection_endpoints(&result.layout_index, selection)
+        if self.view_state.direct_touch_interaction {
+            crate::query::selection::selection_endpoints_for_direct_touch(
+                &result.layout_index,
+                selection,
+            )
+        } else {
+            crate::query::selection::selection_endpoints(&result.layout_index, selection)
+        }
     }
 
     pub fn selection_hit_test(
@@ -1070,6 +1085,14 @@ impl View {
 
     pub fn fold_expanded(&self, node: Dot) -> bool {
         self.view_state.fold_expanded(node)
+    }
+
+    pub fn set_direct_touch_interaction(&mut self, direct: bool) -> bool {
+        if self.view_state.direct_touch_interaction == direct {
+            return false;
+        }
+        self.view_state.direct_touch_interaction = direct;
+        true
     }
 
     pub fn toggle_fold(&mut self, state: &State, node: Dot) -> bool {

--- a/crates/editor-view/src/view_state.rs
+++ b/crates/editor-view/src/view_state.rs
@@ -35,6 +35,7 @@ pub struct ViewState {
     pub pending_overlay: Option<PendingOverlay>,
     pub gap_phantom: Option<GapPhantom>,
     pub tracked_decoration_groups: HashMap<String, GroupDecoration>,
+    pub direct_touch_interaction: bool,
 }
 
 impl ViewState {


### PR DESCRIPTION
문단 끝의 줄바꿈이 선택됐는지 더 명확하게 표시하고, 입력 방식에 맞춰 선택 핸들이 동작하도록 개선했습니다.

- 터치·펜 사용 시 선택된 문단 끝 배경을 줄 오른쪽 끝까지 확장하고, 끝 핸들도 같은 위치에 표시합니다.
- 마우스·트랙패드·하드웨어 키보드 사용 시 선택 핸들을 숨기고, 숨겨진 핸들이 마우스 드래그를 가로채지 않도록 합니다.
- 앱 전체의 마지막 입력 방식을 에디터에 반영해 화면 전환이나 선택 복원 후에도 표시가 일관되게 유지됩니다.
- 문단 끝 드래그 선택을 줄 경계 기준으로 처리해 문단 간격과 페이지 경계에 따른 차이를 줄입니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>