### PR TITLE
사이드바 고정/최근 영역 다듬기

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@tree/PinnedEntities.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/PinnedEntities.svelte
@@ -189,7 +189,7 @@
 
 <ul
   bind:this={listElement}
-  class={flex({ flexDirection: 'column', flexShrink: '0', paddingX: '12px', paddingY: '4px', userSelect: 'none' })}
+  class={flex({ flexDirection: 'column', flexShrink: '0', marginX: '12px', paddingY: '4px', userSelect: 'none' })}
   aria-label="고정한 항목"
   data-drop-target="pin"
 >
@@ -215,15 +215,15 @@
         class={flex({
           alignItems: 'center',
           width: 'full',
-          paddingLeft: '50px',
+          paddingLeft: '28px',
           paddingRight: '8px',
           paddingY: '6px',
           fontSize: '14px',
           fontWeight: 'medium',
-          color: 'text.muted',
+          color: 'text.hint',
           textAlign: 'left',
           transition: 'common',
-          _supportHover: { color: 'text.default' },
+          _supportHover: { color: 'text.muted' },
         })}
         onclick={() => (visibleCount += PAGE_SIZE)}
         type="button"

--- a/apps/website/src/routes/website/(dashboard)/@tree/RecentDocuments.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/RecentDocuments.svelte
@@ -226,15 +226,15 @@
         class={flex({
           alignItems: 'center',
           width: 'full',
-          paddingLeft: '50px',
+          paddingLeft: '28px',
           paddingRight: '8px',
           paddingY: '6px',
           fontSize: '14px',
           fontWeight: 'medium',
-          color: 'text.muted',
+          color: 'text.hint',
           textAlign: 'left',
           transition: 'common',
-          _supportHover: { color: 'text.default' },
+          _supportHover: { color: 'text.muted' },
         })}
         disabled={query.loading}
         onclick={showMore}

--- a/apps/website/src/routes/website/(dashboard)/@tree/SidebarSectionHeader.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@tree/SidebarSectionHeader.svelte
@@ -124,11 +124,14 @@
 
       <button
         class={flex({
+          flexGrow: '1',
           flexShrink: '0',
           alignItems: 'center',
-          justifyContent: 'center',
+          justifyContent: 'flex-start',
+          height: 'full',
+          minWidth: '20px',
+          paddingLeft: '4px',
           borderRadius: '4px',
-          size: '20px',
           color: 'text.muted',
           transition: 'common',
           _supportHover: { color: 'text.default' },

--- a/apps/website/src/routes/website/(dashboard)/@tree/sidebar-section-header.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/@tree/sidebar-section-header.browser.test.ts
@@ -80,6 +80,20 @@ describe('sidebar section header tabs', () => {
     expect(output('toggles')).toBe('2');
   });
 
+  it('extends the collapse toggle across the empty header area', async () => {
+    await mountFixture();
+
+    const toggle = chevron();
+    expect(toggle?.getBoundingClientRect().width).toBeGreaterThan(20);
+
+    toggle?.click();
+    await tick();
+
+    expect(output('open')).toBe('false');
+    expect(output('toggles')).toBe('1');
+    expect(output('active-tab')).toBe('RECENT');
+  });
+
   it('renders the actions snippet only while the parent shows it and marks the drop target tab', async () => {
     await mountFixture();
 


### PR DESCRIPTION
- 빈 고정 영역에 dragover할 때 하이라이트에 적절한 여백 적용되도록 함
- 헤더 빈 영역 클릭도 collapse 토글이 됨
- '더 보기' 정렬, 색 조정

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>