### PR TITLE
pane 포커스 표시와 헤더 공간 배분 개선

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/HomePane.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/HomePane.svelte
@@ -262,6 +262,7 @@
       <EditorBreadcrumbNavigation
         ancestors={[]}
         current={{ kind: 'home' }}
+        {focused}
         isOwner
         onNavigate={(target) => {
           if (target.kind === 'entity') paneGroup.replacePane(pane.id, { kind: 'entity', slug: target.slug });

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneHeader.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/PaneHeader.svelte
@@ -31,6 +31,7 @@
   const paneGroup = getPaneGroup();
   const paneChrome = getZenModePaneChrome();
   const dragPaneProps = $derived({ paneGroup, paneId: pane.id });
+  const focused = $derived(paneGroup.state.current.focusedPaneId === pane.id);
   const prismPanelOpen = $derived(app.preference.current.prismPanelOpen);
   const sidebarHidden = $derived(app.preference.current.sidebarHidden);
   const zenModeEnabled = $derived(app.preference.current.zenModeEnabled);
@@ -125,8 +126,8 @@
           position: 'relative',
           alignItems: 'center',
           gap: '4px',
-          flexBasis: zenModeEnabled ? undefined : '0',
-          flexGrow: zenModeEnabled ? undefined : '1',
+          flexBasis: zenModeEnabled ? undefined : focused ? '0' : '[auto]',
+          flexGrow: zenModeEnabled ? undefined : focused ? '1' : '0',
           flexShrink: '1',
           minWidth: placement.topLeft ? '[32px]' : '0',
           height: 'full',
@@ -181,10 +182,13 @@
         position: 'relative',
         alignItems: 'center',
         gap: '4px',
+        flexBasis: !zenModeEnabled && !focused ? '0' : undefined,
+        flexGrow: !zenModeEnabled && !focused ? '1' : undefined,
         flexShrink: '1',
-        minWidth: '0',
+        minWidth: !zenModeEnabled && !focused ? '[min-content]' : '0',
         height: 'full',
         overflowX: 'hidden',
+        paddingLeft: '8px',
         paddingRight: '8px',
       })}
       active={zenModeEnabled}
@@ -193,19 +197,37 @@
       register={registerActions}
       segment="actions"
     >
-      <div class={flex({ position: 'relative', alignItems: 'center', gap: '4px', minWidth: '0', height: 'full' })}>
+      <div
+        class={flex({
+          position: 'relative',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: '4px',
+          flexGrow: '1',
+          minWidth: '0',
+          height: 'full',
+        })}
+      >
         {#if scrollableActions}
-          <HorizontalScrollLane
-            alignment="start"
-            contentIdentity={pane.id}
-            label="문서 헤더 도구 가로 스크롤"
-            viewportId={scrollableActionsViewportId}
-            viewportName="pane-header-actions"
+          <div
+            class={css(
+              !zenModeEnabled && !focused
+                ? { display: 'flex', justifyContent: 'flex-end', contain: '[inline-size]', flexGrow: '1', minWidth: '0', height: 'full' }
+                : { display: 'contents' },
+            )}
           >
-            <div class={flex({ alignItems: 'center', gap: '4px', minWidth: '[max-content]' })}>
-              {@render scrollableActions()}
-            </div>
-          </HorizontalScrollLane>
+            <HorizontalScrollLane
+              alignment="start"
+              contentIdentity={pane.id}
+              label="문서 헤더 도구 가로 스크롤"
+              viewportId={scrollableActionsViewportId}
+              viewportName="pane-header-actions"
+            >
+              <div class={flex({ alignItems: 'center', gap: '4px', minWidth: '[max-content]' })}>
+                {@render scrollableActions()}
+              </div>
+            </HorizontalScrollLane>
+          </div>
         {/if}
 
         {#if fixedActions}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Panes.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/Panes.svelte
@@ -163,30 +163,6 @@
     {/each}
   {/if}
 
-  {#if context.enabled && !context.draggingPaneId && layout}
-    {@const focusedPaneId = context.state.current.focusedPaneId}
-    {@const focusedRect = layout.panes.get(focusedPaneId ?? '')}
-    {#if focusedRect}
-      {#key focusedPaneId}
-        <div
-          style:left="{focusedRect.left}px"
-          style:top="{focusedRect.top}px"
-          style:width="{focusedRect.width}px"
-          style:height="{focusedRect.height}px"
-          class={css({
-            position: 'absolute',
-            pointerEvents: 'none',
-            boxShadow: '[0 0 0 1px token(colors.border.emphasis)]',
-            zIndex: 'overEditor',
-          })}
-          out:fade|global={{
-            duration: context.enabled && !context.draggingPaneId && context.panes.some((pane) => pane.id === focusedPaneId) ? 150 : 0,
-          }}
-        ></div>
-      {/key}
-    {/if}
-  {/if}
-
   {#if context.draggingPaneId}
     <div class={css({ position: 'absolute', inset: '0', zIndex: 'ghost' })}></div>
   {/if}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-header-test-root.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-header-test-root.svelte
@@ -7,9 +7,9 @@
   import { setupZenModePaneChrome } from './zen-mode-pane-chrome.svelte';
   import type { Pane } from './types';
 
-  type Props = { headerWidth?: number; zenModeEnabled?: boolean };
+  type Props = { focused?: boolean; headerWidth?: number; zenModeEnabled?: boolean };
 
-  let { headerWidth = 420, zenModeEnabled = false }: Props = $props();
+  let { focused = true, headerWidth = 420, zenModeEnabled = false }: Props = $props();
 
   const app = setupAppContext('pane-header-priority-test');
   app.preference.current.sidebarHidden = false;
@@ -27,7 +27,7 @@
     },
   });
   paneGroup.state.current.root = pane;
-  paneGroup.state.current.focusedPaneId = pane.id;
+  paneGroup.state.current.focusedPaneId = focused ? pane.id : null;
   setupPane(pane);
   setupZenModePaneChrome({ active: () => zenModeEnabled, focused: () => true });
 </script>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-header.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/@pane/pane-header.browser.test.ts
@@ -17,6 +17,40 @@ afterEach(async () => {
 });
 
 describe('PaneHeader priority lanes', () => {
+  it('gives inactive breadcrumbs space while keeping fixed actions visible and allowing other actions to fit', async () => {
+    const widths: number[] = [];
+    for (const focused of [true, false]) {
+      component = mount(PaneHeaderTestRoot, { target: document.body, props: { focused } });
+      await tick();
+      const breadcrumb = document.querySelector<HTMLElement>('#pane-header-breadcrumb-test');
+      const actions = document.querySelector<HTMLElement>('#pane-header-actions-pane-header-test');
+      const region = document.querySelector<HTMLElement>('[data-pane-header-test-host] [role="region"]');
+      if (!breadcrumb || !actions || !region) throw new Error('Missing pane header test fixture');
+      widths.push(breadcrumb.clientWidth);
+      expect(actions).not.toBeNull();
+      for (const control of region.querySelectorAll<HTMLElement>('[data-pane-header-fixed-action], [aria-label^="PRISM"]')) {
+        expect(control.getBoundingClientRect().left).toBeGreaterThanOrEqual(actions.getBoundingClientRect().right);
+        expect(control.getBoundingClientRect().right).toBeLessThanOrEqual(region.getBoundingClientRect().right);
+      }
+      await unmount(component);
+      component = undefined;
+      document.body.replaceChildren();
+    }
+    expect(widths[1]).toBeGreaterThan(widths[0]);
+    component = mount(PaneHeaderTestRoot, { target: document.body, props: { focused: false, headerWidth: 1000 } });
+    await tick();
+    const actions = document.querySelector<HTMLElement>('#pane-header-actions-pane-header-test');
+    if (!actions) throw new Error('Missing pane header actions');
+    expect(actions.clientWidth).toBeGreaterThan(0);
+    expect(actions.scrollWidth).toBe(actions.clientWidth);
+    const firstFixed = document.querySelector<HTMLElement>('[data-pane-header-test-host] [data-pane-header-fixed-action]');
+    const prism = document.querySelector<HTMLElement>('[data-pane-header-test-host] [aria-label^="PRISM"]');
+    const region = document.querySelector<HTMLElement>('[data-pane-header-test-host] [role="region"]');
+    if (!firstFixed || !prism || !region) throw new Error('Missing pane header fixed controls');
+    expect(firstFixed.getBoundingClientRect().left - actions.getBoundingClientRect().right).toBeCloseTo(4, 1);
+    expect(region.getBoundingClientRect().right - prism.getBoundingClientRect().right).toBeCloseTo(8, 1);
+  });
+
   it('signals a transient sidebar peek while the top-left control is hovered', async () => {
     component = mount(PaneHeaderTestRoot, { target: document.body });
     await tick();

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbNavigation.svelte
@@ -42,6 +42,7 @@
   type Props = {
     ancestors: readonly EditorBreadcrumbPathEntity[];
     current: EditorBreadcrumbCurrent;
+    focused?: boolean;
     isOwner: boolean;
     onNavigate: (target: EditorBreadcrumbTarget) => void;
     popupId: string;
@@ -49,7 +50,7 @@
     siteId: string | null;
   };
 
-  let { ancestors, current, isOwner, onNavigate, popupId, segment, siteId }: Props = $props();
+  let { ancestors, current, focused, isOwner, onNavigate, popupId, segment, siteId }: Props = $props();
 
   const POPUP_HOLD_REASON = 'breadcrumb-popup';
   const HOME_SEGMENT_ID = 'home';
@@ -67,7 +68,7 @@
   const pathItems = $derived<BreadcrumbPathItem[]>(
     current.kind === 'home' ? [current] : [...ancestors.map((entity) => ({ kind: 'entity' as const, ...entity })), current],
   );
-  const interactive = $derived(isOwner && siteId !== null);
+  const interactive = $derived(focused !== false && isOwner && siteId !== null);
   const segments = $derived.by<BreadcrumbNavigationSegment[]>(() => {
     if (siteId === null) return [];
 
@@ -191,7 +192,7 @@
     paddingRight: '4px',
     fontSize: '12px',
     fontWeight: 'medium',
-    color: 'text.muted',
+    color: focused ? 'text.default' : 'text.muted',
   })}
   aria-label="문서 경로"
 >
@@ -218,11 +219,11 @@
             onclick={(event) => activate(event, itemId)}
             type="button"
           >
-            <EditorBreadcrumbSegment {isCurrent} item={pathItem} />
+            <EditorBreadcrumbSegment {focused} {isCurrent} item={pathItem} />
           </button>
         {:else}
           <span class={segmentClass}>
-            <EditorBreadcrumbSegment {isCurrent} item={pathItem} />
+            <EditorBreadcrumbSegment {focused} {isCurrent} item={pathItem} />
           </span>
         {/if}
       </li>

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbSegment.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/EditorBreadcrumbSegment.svelte
@@ -8,17 +8,32 @@
   import type { EntityIcon_entity$key } from '$mearie';
 
   type Props = {
+    focused?: boolean;
     isCurrent: boolean;
     item: { kind: 'home' } | { kind: 'entity'; name: string; entity$key: EntityIcon_entity$key };
   };
 
-  let { isCurrent, item }: Props = $props();
+  let { focused, isCurrent, item }: Props = $props();
 </script>
 
 {#if item.kind === 'home'}
   <Icon icon={HomeIcon} size={14} />
 {:else}
-  <EntityIcon entity$key={item.entity$key} fallback={isCurrent ? undefined : FolderIcon} size={14} />
+  <span class={css({ display: 'contents', color: 'text.default' })}>
+    <EntityIcon
+      style={focused === false
+        ? css.raw({
+            color: {
+              base: '[color-mix(in oklab, currentColor 73%, token(colors.surface.default))]',
+              _dark: '[color-mix(in oklab, currentColor 82%, token(colors.surface.default))]',
+            },
+          })
+        : undefined}
+      entity$key={item.entity$key}
+      fallback={isCurrent ? undefined : FolderIcon}
+      size={14}
+    />
+  </span>
 {/if}
 <span>{item.kind === 'home' ? '홈' : item.name}</span>
 {#if !isCurrent}

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/DocumentEditor.svelte
@@ -1133,6 +1133,7 @@
                 <EditorBreadcrumbNavigation
                   ancestors={breadcrumbAncestors}
                   current={{ kind: 'entity', id: entity.id, slug: entity.slug, name: localTitle || '(제목 없음)', entity$key: entity }}
+                  {focused}
                   {isOwner}
                   onNavigate={(target) => {
                     paneGroup.replacePane(pane.id, target.kind === 'home' ? { kind: 'home' } : { kind: 'entity', slug: target.slug });
@@ -1145,7 +1146,7 @@
             </EditorBreadcrumb>
             {#if document.locked}
               <span
-                class={center({ flexShrink: '0', color: 'text.muted' })}
+                class={center({ flexShrink: '0', color: focused ? 'text.default' : 'text.muted' })}
                 aria-label="편집이 잠겨있는 문서예요."
                 role="img"
                 use:tooltip={{ message: '편집이 잠겨있는 문서예요.' }}


### PR DESCRIPTION
- 포커스 테두리를 제거하고 breadcrumb·아이콘·자물쇠의 색상으로 활성 pane을 구분합니다.
- 비활성 pane은 breadcrumb 공간을 우선하되, 공간이 충분하면 문서 도구도 모두 표시합니다.
- 더 보기·집중 모드·닫기 버튼은 유지하고, 도구는 오른쪽에 정렬합니다.
- 비활성 breadcrumb는 가로 스크롤할 수 있으며, 첫 클릭은 pane 포커스만 전환합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>