### PR TITLE
깨지는 테스트 수정

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-navigation.browser.test.ts
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@breadcrumb/breadcrumb-navigation.browser.test.ts
@@ -150,7 +150,7 @@ describe('breadcrumb navigation keyboard interaction', () => {
     const row = nextItem?.querySelector<HTMLElement>('[data-breadcrumb-tree-row]');
     const ordinaryRow = treeItem('document-extra-0')?.querySelector<HTMLElement>('[data-breadcrumb-tree-row]');
     if (!nextItem || !row || !ordinaryRow) throw new Error('Missing breadcrumb rows');
-    expect(getComputedStyle(row).backgroundColor).not.toBe(getComputedStyle(ordinaryRow).backgroundColor);
+    await expect.poll(() => getComputedStyle(row).backgroundColor).not.toBe(getComputedStyle(ordinaryRow).backgroundColor);
   });
 
   it('closes on Tab without restoring focus to the segment trigger', async () => {


### PR DESCRIPTION
- 사이드바 리사이저 강조가 안 보이는 문제 해결
- 리사이저 강조를 동일한 스타일로 통일

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>