### PR TITLE
앱 에디터의 마우스 및 트랙패드 지원

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorGestureContext.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorGestureContext.kt
@@ -1,5 +1,6 @@
 package co.typie.editor.interaction
 
+import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.Editor
 import co.typie.platform.Platform
 
@@ -9,6 +10,7 @@ internal interface EditorGestureContext {
   val effects: EditorInteractionEffects
   val geometry: EditorInteractionGeometry
   val mode: EditorInteractionMode
+  val pointerType: PointerType
   val isFocused: Boolean
   val readOnly: Boolean
   val editing: Boolean

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -5,12 +5,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.EditorZoomLandmark
 import co.typie.editor.ffi.InputModifiers
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.ViewOp
+import co.typie.editor.interaction.gestures.EditorMouseButton
 import co.typie.editor.interaction.gestures.EditorPanGestureDriver
 import co.typie.editor.interaction.semantics.EditorTableColumnResizePlacement
 import co.typie.editor.interaction.semantics.EditorTableColumnResizePresentation
@@ -38,6 +40,9 @@ internal class EditorInteractionController(
     get() = checkNotNull(editorProvider()) { "Editor interaction scope has no editor" }
 
   override var mode by mutableStateOf(EditorInteractionMode.Idle)
+    private set
+
+  override var pointerType: PointerType = PointerType.Touch
     private set
 
   private var syncedDirectTouchInteractionEditor: Editor? = null
@@ -72,6 +77,10 @@ internal class EditorInteractionController(
   fun resolveTableColumnResizePlacement(): EditorTableColumnResizePlacement? =
     semantics.tableColumnResize.resolvePlacement(editor = editor, geometry = geometry)
 
+  fun updateMouseConfiguration(doubleClickTimeoutMillis: Long, dragSlopPx: Float) {
+    gestures.updateMouseConfiguration(doubleClickTimeoutMillis, dragSlopPx)
+  }
+
   fun updateTapSlop(tapSlopPx: Float) {
     gestures.updateTapSlop(tapSlopPx)
   }
@@ -87,10 +96,12 @@ internal class EditorInteractionController(
     position: Offset?,
     tapEnabled: Boolean = true,
     inputModifiers: InputModifiers = InputModifiers(),
+    button: EditorMouseButton = EditorMouseButton.Primary,
     positionInRoot: Offset = requireNotNull(position),
     touchPanDriver: EditorPanGestureDriver? = null,
   ): Boolean =
     if (ensurePointerInputEnabled()) {
+      pointerType = change.type
       if (position != null) {
         updateDirectTouchInteraction(change.type.isDirectTouchInteraction())
       }
@@ -100,6 +111,7 @@ internal class EditorInteractionController(
         positionInRoot = positionInRoot,
         tapEnabled = tapEnabled && position != null,
         inputModifiers = inputModifiers,
+        button = button,
         touchPanDriver = touchPanDriver,
         context = this,
       )
@@ -235,7 +247,13 @@ internal class EditorInteractionController(
   }
 
   fun onEditorStateChanged(state: EditorState) {
-    semantics.onEditorStateChanged(editor = editor, state = state, mode = mode)
+    semantics.onEditorStateChanged(
+      editor = editor,
+      state = state,
+      mode = mode,
+      directTouchInteraction =
+        syncedDirectTouchInteraction != false && pointerType.isDirectTouchInteraction(),
+    )
     gestures.onPublishedStateChanged(state = state, context = this)
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionGestures.kt
@@ -2,11 +2,14 @@ package co.typie.editor.interaction
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerType
 import co.typie.editor.EditorState
 import co.typie.editor.ffi.InputModifiers
 import co.typie.editor.interaction.gestures.EditorDndGesture
 import co.typie.editor.interaction.gestures.EditorLongPressDispatchDelayMillis
 import co.typie.editor.interaction.gestures.EditorLongPressGesture
+import co.typie.editor.interaction.gestures.EditorMouseButton
+import co.typie.editor.interaction.gestures.EditorMouseGesture
 import co.typie.editor.interaction.gestures.EditorPanGesture
 import co.typie.editor.interaction.gestures.EditorPanGestureDriver
 import co.typie.editor.interaction.gestures.EditorPinchGesture
@@ -46,6 +49,13 @@ internal class EditorInteractionGestures(
       onHandoffToSelectionHandle = ::handoffTableDragToSelectionHandle,
     )
 
+  private val mouse = EditorMouseGesture()
+
+  fun updateMouseConfiguration(doubleClickTimeoutMillis: Long, dragSlopPx: Float) {
+    mouse.doubleClickTimeoutMillis = doubleClickTimeoutMillis
+    mouse.dragSlopPx = dragSlopPx
+  }
+
   val hasPendingHandleGesture: Boolean
     get() = tableColumnResize.pending || tableHandle.pendingDrag || selectionHandle.pendingDrag
 
@@ -69,12 +79,21 @@ internal class EditorInteractionGestures(
     positionInRoot: Offset,
     tapEnabled: Boolean,
     inputModifiers: InputModifiers,
+    button: EditorMouseButton = EditorMouseButton.Primary,
     touchPanDriver: EditorPanGestureDriver? = null,
     context: EditorGestureContext,
   ): Boolean {
     val pointerId = change.id.value
     val nowMillis = change.uptimeMillis
-    if (tap.hasActivePointer) {
+    if (change.type == PointerType.Mouse) context.semantics.pointSelection.cancelPendingSelection()
+    if (
+      tap.hasActivePointer ||
+        mouse.hasActivePointer ||
+        hasPendingHandleGesture ||
+        tableColumnResize.active ||
+        tableHandle.activeDrag ||
+        selectionHandle.activeDrag
+    ) {
       tap.cancelActivePointerStream()
       context.reduceMode(EditorInteractionEvent.PointerCancel)
       pinch.reset()
@@ -85,6 +104,7 @@ internal class EditorInteractionGestures(
       return false
     }
 
+    if (change.type != PointerType.Mouse) mouse.cancel(context)
     longPress.reset()
     doubleTapDrag.resetPointerOwnedState(context = context)
     context.semantics.selectionHandle.cancelPendingContextMenuRequest()
@@ -106,6 +126,14 @@ internal class EditorInteractionGestures(
     }
     val position = positionInEditor
 
+    if (
+      change.type == PointerType.Mouse &&
+        (button != EditorMouseButton.Primary ||
+          mouse.isSecondaryClick(button, inputModifiers, context.platform))
+    ) {
+      return tapEnabled &&
+        mouse.handlePointerDown(change, position, button, inputModifiers, context)
+    }
     val columnResizePlacement = tableColumnResize.hitTest(position = position, context = context)
     val tableHandleHit = columnResizePlacement == null && tableHandle.hitTest(position)
     val selectionHandleType =
@@ -116,6 +144,10 @@ internal class EditorInteractionGestures(
       } else {
         null
       }
+    if (change.type == PointerType.Mouse && columnResizePlacement == null && !tableHandleHit) {
+      return tapEnabled &&
+        mouse.handlePointerDown(change, position, button, inputModifiers, context)
+    }
     val tripleTapOnSelectionHandle =
       tapEnabled &&
         selectionHandleType != null &&
@@ -140,7 +172,7 @@ internal class EditorInteractionGestures(
         pointerId = pointerId,
         position = position,
         nowMillis = nowMillis,
-        tapEnabled = tapEnabled,
+        tapEnabled = tapEnabled && change.type != PointerType.Mouse,
         inputModifiers = inputModifiers,
         doubleTapDrag = doubleTapDrag,
         context = context,
@@ -193,6 +225,7 @@ internal class EditorInteractionGestures(
     positionInRoot: Offset,
     context: EditorGestureContext,
   ): Boolean {
+    if (mouse.hasActivePointer) return mouse.handlePointerMove(change, positionInEditor, context)
     val pointerId = change.id.value
     if (doubleTapDrag.active) {
       val position = positionInEditor ?: return true
@@ -270,6 +303,7 @@ internal class EditorInteractionGestures(
     positionInRoot: Offset,
     context: EditorGestureContext,
   ): Boolean {
+    if (mouse.hasActivePointer) return mouse.handlePointerUp(change, positionInEditor, context)
     val pointerId = change.id.value
     val nowMillis = change.uptimeMillis
     if (positionInEditor == null) {
@@ -393,10 +427,12 @@ internal class EditorInteractionGestures(
   }
 
   fun cancelPendingPointerForIndirectInput(context: EditorGestureContext): Boolean {
-    if (
-      context.mode != EditorInteractionMode.Idle ||
-        (!tap.hasActivePointer && !pan.hasPendingPointer)
-    ) {
+    if (mouse.hasActivePointer) {
+      if (mouse.dragging) return false
+      mouse.cancel(context)
+      return true
+    }
+    if (context.mode != EditorInteractionMode.Idle || hasPendingHandleGesture) {
       return false
     }
     cancel(context = context)
@@ -495,6 +531,7 @@ internal class EditorInteractionGestures(
   }
 
   fun resetPointerOwnedState(context: EditorGestureContext) {
+    mouse.cancel(context)
     context.semantics.selectionHandle.cancelPendingContextMenuRequest()
     tableColumnResize.cancel(context = context)
     tableHandle.resetPointerOwnedState(context = context)
@@ -585,6 +622,7 @@ internal class EditorInteractionGestures(
   }
 
   fun reset() {
+    mouse.reset()
     tap.reset()
     doubleTapDrag.reset()
     longPress.reset()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionMode.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionMode.kt
@@ -10,6 +10,7 @@ internal enum class EditorInteractionMode {
   LongPressSelecting,
   LongPressWordSelecting,
   DoubleTapSelecting,
+  MouseSelecting,
   DndLocal,
   DndExternal,
 }
@@ -29,7 +30,8 @@ internal val EditorInteractionMode.isSelecting: Boolean
       this == EditorInteractionMode.TableCellHandleDragging ||
       this == EditorInteractionMode.LongPressSelecting ||
       this == EditorInteractionMode.LongPressWordSelecting ||
-      this == EditorInteractionMode.DoubleTapSelecting
+      this == EditorInteractionMode.DoubleTapSelecting ||
+      this == EditorInteractionMode.MouseSelecting
 
 internal val EditorInteractionMode.isLongPressing: Boolean
   get() =
@@ -67,6 +69,10 @@ internal sealed interface EditorInteractionEvent {
   data object DoubleTapDragStart : EditorInteractionEvent
 
   data object DoubleTapDragEnd : EditorInteractionEvent
+
+  data object MouseSelectionStart : EditorInteractionEvent
+
+  data object MouseSelectionEnd : EditorInteractionEvent
 
   data object TableHandleDragStart : EditorInteractionEvent
 
@@ -110,6 +116,8 @@ internal fun EditorInteractionMode.canApply(event: EditorInteractionEvent): Bool
       this == EditorInteractionMode.SelectionHandleDragging
     EditorInteractionEvent.DoubleTapDragStart -> this == EditorInteractionMode.Idle
     EditorInteractionEvent.DoubleTapDragEnd -> this == EditorInteractionMode.DoubleTapSelecting
+    EditorInteractionEvent.MouseSelectionStart -> this == EditorInteractionMode.Idle
+    EditorInteractionEvent.MouseSelectionEnd -> this == EditorInteractionMode.MouseSelecting
     EditorInteractionEvent.TableHandleDragStart -> this == EditorInteractionMode.Idle
     EditorInteractionEvent.TableHandleDragEnd ->
       this == EditorInteractionMode.TableCellHandleDragging
@@ -193,6 +201,9 @@ private fun reduceSelection(
     event == EditorInteractionEvent.LongPressWordEnd &&
       mode == EditorInteractionMode.LongPressWordSelecting -> EditorInteractionMode.Idle
     event == EditorInteractionEvent.DoubleTapDragStart -> EditorInteractionMode.DoubleTapSelecting
+    event == EditorInteractionEvent.MouseSelectionStart -> EditorInteractionMode.MouseSelecting
+    event == EditorInteractionEvent.MouseSelectionEnd &&
+      mode == EditorInteractionMode.MouseSelecting -> EditorInteractionMode.Idle
     event == EditorInteractionEvent.DoubleTapDragEnd &&
       mode == EditorInteractionMode.DoubleTapSelecting -> EditorInteractionMode.Idle
     else -> mode

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionSemantics.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionSemantics.kt
@@ -36,12 +36,22 @@ internal class EditorInteractionSemantics(
   val selectionHaptic: EditorSelectionHapticSemantic =
     EditorSelectionHapticSemantic(effects = effects),
 ) {
-  fun onEditorStateChanged(editor: Editor, state: EditorState, mode: EditorInteractionMode) {
+  fun onEditorStateChanged(
+    editor: Editor,
+    state: EditorState,
+    mode: EditorInteractionMode,
+    directTouchInteraction: Boolean = true,
+  ) {
     contextMenu.onEditorStateChanged(editor = editor, state = state)
-    selectionHaptic.onEditorStateChanged(editor = editor, state = state, mode = mode)
+    if (directTouchInteraction) {
+      selectionHaptic.onEditorStateChanged(editor = editor, state = state, mode = mode)
+    } else {
+      selectionHaptic.reset()
+    }
   }
 
   fun reset() {
+    pointSelection.cancelPendingSelection()
     contextMenu.reset()
     selectionHandle.reset()
     selectionExpansion.reset()

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractions.kt
@@ -14,21 +14,26 @@ import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.isAltPressed
 import androidx.compose.ui.input.pointer.isCtrlPressed
 import androidx.compose.ui.input.pointer.isMetaPressed
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.isShiftPressed
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.PointerInputModifierNode
 import androidx.compose.ui.node.SemanticsModifierNode
+import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.node.requireLayoutCoordinates
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.scrollBy
 import androidx.compose.ui.semantics.scrollByOffset
 import androidx.compose.ui.unit.IntSize
 import co.typie.editor.ffi.InputModifiers
+import co.typie.editor.interaction.gestures.EditorMouseButton
 import co.typie.editor.viewport.normalizeEditorViewportWheelZoomDelta
 import co.typie.ext.ScrollGestureLockHandle
 import co.typie.ext.ScrollGestureLockState
 import co.typie.platform.isDirectMousePress
-import co.typie.platform.isTouchDragPointer
 import kotlin.math.abs
 import kotlin.math.min
 import kotlinx.coroutines.Job
@@ -46,6 +51,7 @@ private enum class EditorDirectPointerAdmission {
 private data class EditorDirectPointer(
   val type: PointerType,
   val admission: EditorDirectPointerAdmission,
+  val button: EditorMouseButton,
 )
 
 internal fun Modifier.editorInteractions(
@@ -154,6 +160,7 @@ private class EditorInteractionsNode(
 ) :
   Modifier.Node(),
   PointerInputModifierNode,
+  CompositionLocalConsumerModifierNode,
   SemanticsModifierNode,
   EditorScreenPointerListener,
   EditorPlatformIndirectScaleOwner {
@@ -243,6 +250,10 @@ private class EditorInteractionsNode(
       cancelInteraction(clearSuppression = true)
       return
     }
+    interactionController.updateMouseConfiguration(
+      doubleClickTimeoutMillis = currentValueOf(LocalViewConfiguration).doubleTapTimeoutMillis,
+      dragSlopPx = 5f * density,
+    )
     interactionController.updateTapSlop(tapSlopPx = EditorTapSlopDp * density)
     interactionController.updateColumnResizeSlop(
       dragSlopPx = min(touchSlop, EditorTapSlopDp * density)
@@ -387,12 +398,18 @@ private class EditorInteractionsNode(
           } else {
             EditorDirectPointerAdmission.HeaderViewportOnly
           }
-        pointers[change.id.value] = EditorDirectPointer(type = change.type, admission = admission)
-        if (
-          physicalDragLockHandle == null &&
-            change.type == PointerType.Mouse &&
-            change.type.isTouchDragPointer()
-        ) {
+        pointers[change.id.value] =
+          EditorDirectPointer(
+            type = change.type,
+            admission = admission,
+            button =
+              when {
+                pointerEvent.buttons.isPrimaryPressed -> EditorMouseButton.Primary
+                pointerEvent.buttons.isSecondaryPressed -> EditorMouseButton.Secondary
+                else -> EditorMouseButton.Other
+              },
+          )
+        if (physicalDragLockHandle == null && change.type == PointerType.Mouse) {
           physicalDragLockHandle = scrollGestureLockState.acquire()
         }
       }
@@ -458,8 +475,9 @@ private class EditorInteractionsNode(
             position = editorPosition,
             tapEnabled = tapEnabled,
             inputModifiers = pointerEvent.inputModifiers(),
+            button = pointer.button,
             positionInRoot = rootPosition,
-            touchPanDriver = if (change.type.isTouchDragPointer()) scrollDriver else null,
+            touchPanDriver = if (change.type == PointerType.Touch) scrollDriver else null,
           )
         ) {
           change.consume()
@@ -468,7 +486,10 @@ private class EditorInteractionsNode(
 
     pointerEvent.changes
       .filter { change ->
-        change.pressed && change.previousPressed && change.id.value in singlePointerStreams
+        change.pressed &&
+          change.previousPressed &&
+          change.id.value in singlePointerStreams &&
+          pointerEvent.type != PointerEventType.Release
       }
       .forEach { change ->
         val rootPosition = positionInRoot(change.position)
@@ -492,7 +513,15 @@ private class EditorInteractionsNode(
 
     pointerEvent.changes
       .filter { change ->
-        change.changedToUpIgnoreConsumed() && change.id.value in singlePointerStreams
+        change.id.value in singlePointerStreams &&
+          (change.changedToUpIgnoreConsumed() ||
+            (change.type == PointerType.Mouse &&
+              pointerEvent.type == PointerEventType.Release &&
+              when (pointers[change.id.value]?.button) {
+                EditorMouseButton.Primary -> !pointerEvent.buttons.isPrimaryPressed
+                EditorMouseButton.Secondary -> !pointerEvent.buttons.isSecondaryPressed
+                else -> !change.pressed
+              }))
       }
       .forEach { change ->
         val rootPosition = positionInRoot(change.position)
@@ -551,9 +580,7 @@ private class EditorInteractionsNode(
   }
 
   private fun hasPhysicalDragPointer(): Boolean =
-    pointers.values.any { pointer ->
-      pointer.type == PointerType.Mouse && pointer.type.isTouchDragPointer()
-    }
+    pointers.values.any { pointer -> pointer.type == PointerType.Mouse }
 
   private fun cancelAndSuppress(pointerEvent: PointerEvent) {
     physicalSequenceYieldedToIndirectInput = false

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorMouseGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorMouseGesture.kt
@@ -1,0 +1,251 @@
+package co.typie.editor.interaction.gestures
+
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputChange
+import co.typie.editor.ext.isCollapsed
+import co.typie.editor.ffi.InputModifiers
+import co.typie.editor.ffi.Position
+import co.typie.editor.ffi.Selection
+import co.typie.editor.ffi.SelectionOp
+import co.typie.editor.ffi.SelectionPointUnit
+import co.typie.editor.interaction.EditorGestureContext
+import co.typie.editor.interaction.EditorInteractionEvent
+import co.typie.editor.interaction.EditorInteractionMode
+import co.typie.editor.interaction.semantics.EditorInteractiveTapResult
+import co.typie.platform.Platform
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+
+internal enum class EditorMouseButton {
+  Primary,
+  Secondary,
+  Other,
+}
+
+/** Click recognition and selection dragging; touch recognition and presentation stay separate. */
+internal class EditorMouseGesture {
+  private var drag: Drag? = null
+  private var previousClick: Click? = null
+  var doubleClickTimeoutMillis = 300L
+  var dragSlopPx = 5f
+
+  val hasActivePointer: Boolean
+    get() = drag != null
+
+  val dragging: Boolean
+    get() = drag?.moved == true
+
+  fun isSecondaryClick(
+    button: EditorMouseButton,
+    modifiers: InputModifiers,
+    platform: Platform,
+  ): Boolean =
+    button == EditorMouseButton.Secondary ||
+      (button == EditorMouseButton.Primary && modifiers.ctrl && platform != Platform.Android)
+
+  fun handlePointerDown(
+    change: PointerInputChange,
+    position: Offset,
+    button: EditorMouseButton,
+    modifiers: InputModifiers,
+    context: EditorGestureContext,
+  ): Boolean {
+    val secondary = isSecondaryClick(button, modifiers, context.platform)
+    if (button != EditorMouseButton.Primary && !secondary) return false
+    val point = context.geometry.resolvePoint(position)?.takeIf { it.page >= 0 } ?: return false
+    if (context.mode != EditorInteractionMode.Idle) return false
+    val editor = context.editor
+    context.semantics.contextMenu.hide()
+    context.semantics.magnifier.hide()
+    if (secondary) {
+      previousClick = null
+      val selection = editor.appliedState.selection
+      val op =
+        if (
+          selection != null &&
+            selection == editor.publishedState.selection &&
+            editor.publishedState.selectionHitRects.any { hit ->
+              hit.pageIdx == point.page &&
+                point.x >= hit.rect.x &&
+                point.x <= hit.rect.x + hit.rect.width &&
+                point.y >= hit.rect.y &&
+                point.y <= hit.rect.y + hit.rect.height
+            }
+        ) {
+          // Preserve the hit range after any older selection commands already in the queue.
+          SelectionOp.Set(selection)
+        } else {
+          SelectionOp.SetAt(point.page, point.x, point.y)
+        }
+      val state = context.semantics.pointSelection.applySelection(editor, op) ?: return true
+      context.semantics.contextMenu.requestShowForAppliedSelection(
+        editor = editor,
+        state = state,
+        pointerPosition = point,
+      )
+      return true
+    }
+    val previous = previousClick
+    val count =
+      if (
+        previous != null &&
+          change.uptimeMillis - previous.time in 0..doubleClickTimeoutMillis &&
+          (position - previous.position).getDistance() <= dragSlopPx
+      )
+        previous.count % 3 + 1
+      else 1
+    previousClick = Click(position, change.uptimeMillis, count)
+    if (
+      context.semantics.interactiveHit.handleTap(
+        editor,
+        point,
+        editing = context.editing,
+        readOnly = context.readOnly,
+      ) != EditorInteractiveTapResult.None
+    ) {
+      previousClick = null
+      return true
+    }
+    if (!context.readOnly && (context.editing || context.effects.requestEditing(editor))) {
+      context.effects.requestFocus(editor)
+    }
+    val original = editor.appliedState.selection
+    val op =
+      when {
+        count > 1 ->
+          SelectionOp.SelectUnitAt(
+            point.page,
+            point.x,
+            point.y,
+            if (count == 2) SelectionPointUnit.Word else SelectionPointUnit.Paragraph,
+          )
+        modifiers.shift && original != null ->
+          SelectionOp.ExtendTo(
+            anchor = original.anchor,
+            headPage = point.page,
+            headX = point.x,
+            headY = point.y,
+            baseSelection = null,
+            allowCollapse = true,
+          )
+        else -> SelectionOp.SetAt(point.page, point.x, point.y)
+      }
+    val applied = context.semantics.pointSelection.applySelection(editor, op) ?: return true
+    val selected = applied.selection ?: return true
+    drag =
+      Drag(
+        pointerId = change.id.value,
+        down = position,
+        anchor =
+          if (count == 1 && modifiers.shift && original != null) original.anchor
+          else selected.anchor,
+        baseSelection = selected.takeIf { count > 1 && !it.isCollapsed() },
+      )
+    context.reduceMode(EditorInteractionEvent.MouseSelectionStart)
+    if (!context.readOnly) context.effects.requestPointerSelectionHead(applied.version)
+    return true
+  }
+
+  fun handlePointerMove(
+    change: PointerInputChange,
+    position: Offset?,
+    context: EditorGestureContext,
+  ): Boolean {
+    val current = drag?.takeIf { it.pointerId == change.id.value } ?: return false
+    if (position == null) {
+      cancel(context)
+      return true
+    }
+    if (!current.moved && (position - current.down).getDistance() < dragSlopPx) return true
+    current.moved = true
+    previousClick = null
+    current.pendingPosition = position
+    if (!current.framePending) {
+      current.framePending = true
+      context.effects.launchInteraction {
+        if (drag !== current) return@launchInteraction
+        current.frameJob = currentCoroutineContext()[Job]
+        withFrameNanos {}
+        current.frameJob = null
+        current.framePending = false
+        val latest = current.pendingPosition
+        current.pendingPosition = null
+        if (drag === current && latest != null) {
+          extend(latest, current, context)
+          context.semantics.edgeAutoScroll.trackSelection(
+            edgePosition = latest,
+            dispatchPosition = latest,
+            context = context,
+            dispatch = { scrolled -> extend(scrolled.dispatchPosition, current, context) },
+          )
+        }
+      }
+    }
+    return true
+  }
+
+  fun handlePointerUp(
+    change: PointerInputChange,
+    position: Offset?,
+    context: EditorGestureContext,
+  ): Boolean {
+    val current = drag?.takeIf { it.pointerId == change.id.value } ?: return false
+    if (
+      position != null && (current.moved || (position - current.down).getDistance() >= dragSlopPx)
+    ) {
+      previousClick = null
+      extend(position, current, context)
+    }
+    finish(context)
+    return true
+  }
+
+  fun cancel(context: EditorGestureContext) {
+    previousClick = null
+    finish(context)
+  }
+
+  fun reset() {
+    drag?.frameJob?.cancel()
+    drag = null
+    previousClick = null
+  }
+
+  private fun finish(context: EditorGestureContext) {
+    val current = drag ?: return
+    current.frameJob?.cancel()
+    drag = null
+    context.semantics.edgeAutoScroll.stop()
+    context.reduceMode(EditorInteractionEvent.MouseSelectionEnd)
+  }
+
+  private fun extend(position: Offset, current: Drag, context: EditorGestureContext): Boolean {
+    if (drag !== current || context.mode != EditorInteractionMode.MouseSelecting) return false
+    val point = context.geometry.resolvePoint(position)?.takeIf { it.page >= 0 } ?: return false
+    return context.semantics.pointSelection.applySelection(
+      context.editor,
+      SelectionOp.ExtendTo(
+        anchor = current.anchor,
+        headPage = point.page,
+        headX = point.x,
+        headY = point.y,
+        baseSelection = current.baseSelection,
+        allowCollapse = current.baseSelection == null,
+      ),
+    ) != null
+  }
+
+  private class Drag(
+    val pointerId: Long,
+    val down: Offset,
+    val anchor: Position,
+    val baseSelection: Selection?,
+    var moved: Boolean = false,
+    var pendingPosition: Offset? = null,
+    var framePending: Boolean = false,
+    var frameJob: Job? = null,
+  )
+
+  private data class Click(val position: Offset, val time: Long, val count: Int)
+}

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorSelectionHandleGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorSelectionHandleGesture.kt
@@ -12,6 +12,7 @@ import co.typie.editor.interaction.EditorInteractionMode
 import co.typie.editor.interaction.canApply
 import co.typie.editor.interaction.hasActiveTableCellSelection
 import co.typie.editor.interaction.sessions.EditorSelectionHandleDragSession
+import co.typie.ui.input.isDirectTouchInteraction
 import kotlin.math.max
 
 internal enum class EditorSelectionHandleType {
@@ -302,9 +303,10 @@ internal class EditorSelectionHandleGesture(
       context.reduceMode(EditorInteractionEvent.SelectionHandleDragEnd)
     }
     if (wasDragging) {
-      context.semantics.selectionHandle.requestContextMenuAfterSelection(
+      context.semantics.selectionHandle.finishSelection(
         editor = context.editor,
         terminalExtension = terminalExtension,
+        showContextMenu = context.pointerType.isDirectTouchInteraction(),
       )
     }
     return wasActive

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableHandleGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorTableHandleGesture.kt
@@ -13,6 +13,7 @@ import co.typie.editor.interaction.contains
 import co.typie.editor.interaction.resolveActiveTableCellSelection
 import co.typie.editor.interaction.sessions.EditorTableHandleDragContext
 import co.typie.editor.interaction.sessions.EditorTableHandleDragSession
+import co.typie.ui.input.isDirectTouchInteraction
 
 internal class EditorTableHandleGesture(
   private val contextProvider: () -> EditorGestureContext,
@@ -168,7 +169,8 @@ internal class EditorTableHandleGesture(
       session.selectionPosition(touchPosition = position)
         ?: return EditorTableHandleDragUpdate.NotConsumed
 
-    context.semantics.magnifier.show(selectionPosition)
+    if (context.pointerType.isDirectTouchInteraction())
+      context.semantics.magnifier.show(selectionPosition)
     context.semantics.edgeAutoScroll.trackSelectionHandle(
       edgePosition = position,
       dispatchPosition = selectionPosition,
@@ -216,9 +218,10 @@ internal class EditorTableHandleGesture(
       context.reduceMode(EditorInteractionEvent.TableHandleDragEnd)
     }
     if (wasDragging) {
-      context.semantics.selectionHandle.requestContextMenuAfterSelection(
+      context.semantics.selectionHandle.finishSelection(
         editor = context.editor,
         terminalExtension = terminalExtension,
+        showContextMenu = context.pointerType.isDirectTouchInteraction(),
       )
     }
     return wasActive

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorContextMenuSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorContextMenuSemantic.kt
@@ -2,6 +2,7 @@ package co.typie.editor.interaction.semantics
 
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.PagePoint
 import co.typie.editor.runtime.EditorContextMenuState
 
 internal class EditorContextMenuSemantic(private val stateProvider: () -> EditorContextMenuState) {
@@ -16,8 +17,17 @@ internal class EditorContextMenuSemantic(private val stateProvider: () -> Editor
     stateProvider().hide()
   }
 
-  fun requestShowForAppliedSelection(editor: Editor, state: EditorState) {
-    stateProvider().requestShowForAppliedSelection(editor = editor, state = state)
+  fun requestShowForAppliedSelection(
+    editor: Editor,
+    state: EditorState,
+    pointerPosition: PagePoint? = null,
+  ) {
+    stateProvider()
+      .requestShowForAppliedSelection(
+        editor = editor,
+        state = state,
+        pointerPosition = pointerPosition,
+      )
   }
 
   fun onEditorStateChanged(editor: Editor, state: EditorState) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorEdgeAutoScrollSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorEdgeAutoScrollSemantic.kt
@@ -10,6 +10,7 @@ import co.typie.editor.interaction.EditorGestureContext
 import co.typie.ext.EdgeAutoScrollMaximumFrameDeltaNanos
 import co.typie.ext.EdgeAutoScrollThresholdDp
 import co.typie.ext.computeEdgeAutoScrollPlan
+import co.typie.ui.input.isDirectTouchInteraction
 import kotlin.math.abs
 import kotlin.math.sign
 
@@ -25,7 +26,7 @@ internal class EditorEdgeAutoScrollSemantic {
     baseSelection: Selection? = null,
     context: EditorGestureContext,
   ) {
-    track(
+    trackTouchSelection(
       edgePosition = edgePosition,
       dispatchPosition = dispatchPosition,
       context = context,
@@ -46,7 +47,7 @@ internal class EditorEdgeAutoScrollSemantic {
     context: EditorGestureContext,
     dispatch: (EditorEdgeAutoScrollDispatch) -> Boolean,
   ) {
-    track(
+    trackTouchSelection(
       edgePosition = edgePosition,
       dispatchPosition = dispatchPosition,
       context = context,
@@ -59,7 +60,7 @@ internal class EditorEdgeAutoScrollSemantic {
     dispatchPosition: Offset,
     context: EditorGestureContext,
   ) {
-    track(
+    trackTouchSelection(
       edgePosition = edgePosition,
       dispatchPosition = dispatchPosition,
       context = context,
@@ -79,7 +80,7 @@ internal class EditorEdgeAutoScrollSemantic {
     dispatchPosition: Offset,
     context: EditorGestureContext,
   ) {
-    track(
+    trackTouchSelection(
       edgePosition = edgePosition,
       dispatchPosition = dispatchPosition,
       context = context,
@@ -117,7 +118,21 @@ internal class EditorEdgeAutoScrollSemantic {
     }
   }
 
-  private fun track(
+  private fun trackTouchSelection(
+    edgePosition: Offset,
+    dispatchPosition: Offset,
+    context: EditorGestureContext,
+    dispatch: (EditorEdgeAutoScrollDispatch) -> Boolean,
+  ) {
+    trackSelection(edgePosition, dispatchPosition, context) { scrolled ->
+      dispatch(scrolled).also { applied ->
+        if (applied && context.pointerType.isDirectTouchInteraction())
+          context.semantics.magnifier.show(scrolled.dispatchPosition)
+      }
+    }
+  }
+
+  fun trackSelection(
     edgePosition: Offset,
     dispatchPosition: Offset,
     context: EditorGestureContext,
@@ -230,17 +245,13 @@ internal class EditorEdgeAutoScrollSemantic {
       return
     }
     lastDispatchedPoint = point
-    if (
-      dispatch(
-        EditorEdgeAutoScrollDispatch(
-          edgePosition = edgePosition,
-          dispatchPosition = position,
-          point = point,
-        )
+    dispatch(
+      EditorEdgeAutoScrollDispatch(
+        edgePosition = edgePosition,
+        dispatchPosition = position,
+        point = point,
       )
-    ) {
-      context.semantics.magnifier.show(position)
-    }
+    )
   }
 
   private fun planFor(edgePosition: Offset, viewport: EditorEdgeAutoScrollViewport) =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemantic.kt
@@ -9,42 +9,53 @@ import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.SelectionPointUnit
 import co.typie.editor.interaction.EditorInteractionEffects
+import kotlin.concurrent.Volatile
 
 internal class EditorPointSelectionSemantic(private val effects: EditorInteractionEffects) {
+  @Volatile private var pendingSelectionGeneration = 0L
+
+  fun cancelPendingSelection() {
+    pendingSelectionGeneration += 1
+  }
+
+  fun applySelection(editor: Editor, op: SelectionOp): EditorState? {
+    val update = editor.updateNow { enqueue(Message.Selection(op)) } ?: return null
+    if (update.commandOutcomes.any { it is CommandOutcome.Rejected }) return null
+    return update.snapshot
+  }
+
   fun launchSelection(
     editor: Editor,
     op: SelectionOp,
     onApplied: ((EditorState) -> Unit)? = null,
     afterDispatch: (Boolean) -> Unit = {},
-  ) {
-    effects.launchInteraction {
-      afterDispatch(dispatchSelection(editor = editor, op = op, onApplied = onApplied))
-    }
-  }
+  ) = launchSelection(editor, op = { op }, onApplied = onApplied, afterDispatch = afterDispatch)
 
   fun launchCursorMove(
     editor: Editor,
     point: PagePoint,
     onApplied: ((EditorState) -> Unit)? = null,
     afterDispatch: (Boolean) -> Unit = {},
-  ) {
-    effects.launchInteraction {
-      afterDispatch(dispatchCursorMove(editor = editor, point = point, onApplied = onApplied))
-    }
-  }
+  ) =
+    launchSelection(
+      editor = editor,
+      op = SelectionOp.SetAt(page = point.page, x = point.x, y = point.y),
+      onApplied = onApplied,
+      afterDispatch = afterDispatch,
+    )
 
   fun launchSelectionExtension(
     editor: Editor,
     point: PagePoint,
     onApplied: ((EditorState) -> Unit)? = null,
     afterDispatch: (Boolean) -> Unit = {},
-  ) {
-    effects.launchInteraction {
-      afterDispatch(
-        dispatchSelectionExtension(editor = editor, point = point, onApplied = onApplied)
-      )
-    }
-  }
+  ) =
+    launchSelection(
+      editor = editor,
+      op = { point.selectionExtensionOp(currentSelection = editor.appliedState.selection) },
+      onApplied = onApplied,
+      afterDispatch = afterDispatch,
+    )
 
   fun launchSelectionExtension(
     editor: Editor,
@@ -68,13 +79,13 @@ internal class EditorPointSelectionSemantic(private val effects: EditorInteracti
     unit: SelectionPointUnit,
     onApplied: ((EditorState) -> Unit)? = null,
     afterDispatch: (Boolean) -> Unit = {},
-  ) {
-    effects.launchInteraction {
-      afterDispatch(
-        dispatchUnitSelection(editor = editor, point = point, unit = unit, onApplied = onApplied)
-      )
-    }
-  }
+  ) =
+    launchSelection(
+      editor = editor,
+      op = SelectionOp.SelectUnitAt(page = point.page, x = point.x, y = point.y, unit = unit),
+      onApplied = onApplied,
+      afterDispatch = afterDispatch,
+    )
 
   suspend fun dispatchCursorMove(
     editor: Editor,
@@ -119,12 +130,32 @@ internal class EditorPointSelectionSemantic(private val effects: EditorInteracti
     } ?: false
   }
 
+  private fun launchSelection(
+    editor: Editor,
+    op: () -> SelectionOp,
+    onApplied: ((EditorState) -> Unit)?,
+    afterDispatch: (Boolean) -> Unit,
+  ) {
+    // Capture before launching: a synchronous mouse selection can overtake this coroutine.
+    val generation = pendingSelectionGeneration
+    effects.launchInteraction {
+      if (generation != pendingSelectionGeneration) return@launchInteraction
+      val dispatched = dispatchSelection(editor, op(), onApplied, generation)
+      if (generation == pendingSelectionGeneration) afterDispatch(dispatched)
+    }
+  }
+
   private suspend fun dispatchSelection(
     editor: Editor,
     op: SelectionOp,
     onApplied: ((EditorState) -> Unit)?,
+    generation: Long = pendingSelectionGeneration,
   ): Boolean {
-    val update = editor.update { enqueue(Message.Selection(op)) } ?: return false
+    val update =
+      editor.update(admit = { generation == pendingSelectionGeneration }) {
+        enqueue(Message.Selection(op))
+      } ?: return false
+    if (generation != pendingSelectionGeneration) return false
     if (update.commandOutcomes.any { it is CommandOutcome.Rejected }) return false
     onApplied?.invoke(update.snapshot)
     return true

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorSelectionHandleSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorSelectionHandleSemantic.kt
@@ -26,8 +26,16 @@ internal class EditorSelectionHandleSemantic(
     return op
   }
 
-  fun requestContextMenuAfterSelection(editor: Editor, terminalExtension: SelectionOp.ExtendTo?) {
+  fun finishSelection(
+    editor: Editor,
+    terminalExtension: SelectionOp.ExtendTo?,
+    showContextMenu: Boolean,
+  ) {
     cancelPendingContextMenuRequest()
+    if (!showContextMenu) {
+      terminalExtension?.let { pointSelection.applySelection(editor, it) }
+      return
+    }
     if (terminalExtension == null) {
       contextMenu.requestShowForAppliedSelection(editor = editor, state = editor.appliedState)
       return

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorSelectionHandleDragSession.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/sessions/EditorSelectionHandleDragSession.kt
@@ -10,6 +10,7 @@ import co.typie.editor.interaction.contains
 import co.typie.editor.interaction.gestures.EditorSelectionHandleTableCellHandoff
 import co.typie.editor.interaction.gestures.EditorSelectionHandleType
 import co.typie.editor.interaction.resolveActiveTableCellSelection
+import co.typie.ui.input.isDirectTouchInteraction
 
 internal class EditorSelectionHandleDragSession {
   private var pendingContext: EditorPendingSelectionHandleDrag? = null
@@ -166,7 +167,8 @@ internal class EditorSelectionHandleDragSession {
     }
 
     val selectionPosition = drag.selectionPosition(touchPosition = touchPosition)
-    context.semantics.magnifier.show(selectionPosition)
+    if (context.pointerType.isDirectTouchInteraction())
+      context.semantics.magnifier.show(selectionPosition)
     context.semantics.edgeAutoScroll.trackSelectionHandle(
       edgePosition = touchPosition,
       dispatchPosition = selectionPosition,

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorContextMenuState.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/runtime/EditorContextMenuState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
+import co.typie.editor.PagePoint
 import co.typie.editor.ext.isCollapsed
 import co.typie.editor.ffi.Selection
 
@@ -13,10 +14,14 @@ internal class EditorContextMenuState {
     private set
 
   private var shownForSelection: Selection? = null
+  var pointerPosition: PagePoint? by mutableStateOf(null)
+    private set
+
   private var pendingPublicationTarget: PendingPublicationTarget? = null
 
   fun show(state: EditorState) {
     pendingPublicationTarget = null
+    pointerPosition = null
     shownForSelection = state.selection
     visible = true
   }
@@ -30,6 +35,7 @@ internal class EditorContextMenuState {
       pendingPublicationTarget = null
     }
     shownForSelection = null
+    pointerPosition = null
     visible = false
   }
 
@@ -43,14 +49,23 @@ internal class EditorContextMenuState {
 
   fun isVisibleFor(state: EditorState): Boolean = visible && state.selection == shownForSelection
 
-  fun requestShowForAppliedSelection(editor: Editor, state: EditorState) {
+  fun requestShowForAppliedSelection(
+    editor: Editor,
+    state: EditorState,
+    pointerPosition: PagePoint? = null,
+  ) {
     val selection = state.selection
-    if (selection == null || selection.isCollapsed()) {
+    if (selection == null || (selection.isCollapsed() && pointerPosition == null)) {
       pendingPublicationTarget = null
       return
     }
     pendingPublicationTarget =
-      PendingPublicationTarget(editor = editor, version = state.version, selection = selection)
+      PendingPublicationTarget(
+        editor = editor,
+        version = state.version,
+        selection = selection,
+        pointerPosition = pointerPosition,
+      )
     onEditorStateChanged(editor = editor, state = editor.publishedState)
   }
 
@@ -69,8 +84,12 @@ internal class EditorContextMenuState {
       return
     }
     pendingPublicationTarget = null
-    if (state.selection == target.selection && !state.selection.isCollapsed()) {
+    if (
+      state.selection == target.selection &&
+        (!state.selection.isCollapsed() || target.pointerPosition != null)
+    ) {
       show(state)
+      pointerPosition = target.pointerPosition
     }
   }
 
@@ -82,5 +101,6 @@ internal class EditorContextMenuState {
     val editor: Editor,
     val version: Long,
     val selection: Selection,
+    val pointerPosition: PagePoint?,
   )
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/overlay/EditorContextMenuOverlay.kt
@@ -311,6 +311,13 @@ internal fun resolveContextMenuAnchor(
   }
 
   val transform = uiState.resolveViewportTransform(pageSizes = editor.publishedState.pageSizes)
+  uiState.contextMenu.pointerPosition?.let { point ->
+    val position =
+      transform.localToGlobal(page = point.page, x = point.x, y = point.y) ?: return null
+    val x = editorRectInOverlay.left + position.x * density
+    val y = editorRectInOverlay.top + position.y * density
+    return EditorContextMenuAnchor(centerX = x, above = y, below = y)
+  }
   val rangeSelection = editor.publishedState.selection?.takeIf { !it.isCollapsed() }
   val gapPx = ContextMenuGap.value * density
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -46,17 +46,21 @@ import co.typie.editor.ffi.TableOverlayColumn
 import co.typie.editor.ffi.TableOverlayRow
 import co.typie.editor.ffi.ViewOp
 import co.typie.editor.interaction.gestures.EditorConsecutiveTapMaxIntervalMillis
+import co.typie.editor.interaction.gestures.EditorMouseButton
 import co.typie.editor.interaction.gestures.EditorPanGestureDriver
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
 import co.typie.editor.runtime.EditorContextMenuState
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.viewport.EditorViewportState
 import co.typie.platform.Platform
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -77,6 +81,7 @@ private fun EditorInteractionController.onPointerDown(
   positionInRoot: Offset = requireNotNull(position),
   touchPanDriver: EditorPanGestureDriver? = null,
   type: PointerType = PointerType.Touch,
+  button: EditorMouseButton = EditorMouseButton.Primary,
 ): Boolean =
   onPointerDown(
     change =
@@ -90,6 +95,7 @@ private fun EditorInteractionController.onPointerDown(
     position = position,
     tapEnabled = tapEnabled,
     inputModifiers = inputModifiers,
+    button = button,
     positionInRoot = positionInRoot,
     touchPanDriver = touchPanDriver,
   )
@@ -173,6 +179,406 @@ private fun EditorInteractionController.presentAppliedState(
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorInteractionControllerTest {
+  @Test
+  fun `mouse click supersedes touch selection waiting to launch or enter the editor`() = runTest {
+    for (start in listOf(CoroutineStart.DEFAULT, CoroutineStart.UNDISPATCHED)) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      fake.publishSnapshot(editor)
+      val host = TestHost(this)
+      val effects =
+        object : EditorInteractionEffects by host {
+          override fun launchInteraction(block: suspend () -> Unit) {
+            launch(start = start) { block() }
+          }
+        }
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = effects,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      controller.onPointerDown(1L, Offset(10f, 20f), 0L)
+      controller.onPointerUp(1L, Offset(10f, 20f), 10L)
+      controller.onPointerDown(2L, Offset(80f, 20f), 20L, type = PointerType.Mouse)
+      controller.onPointerUp(2L, Offset(80f, 20f), 30L)
+      runCurrent()
+      val selections = fake.enqueued.filterIsInstance<Message.Selection>().map { it.op }
+      controller.cancel()
+      assertEquals(listOf(SelectionOp.SetAt(0, 80f, 20f)), selections, "start=$start")
+    }
+  }
+
+  @Test
+  fun `secondary click preserves selection despite a pending touch cursor move`() = runTest {
+    val fixture = MouseFixture(this)
+    fixture.selection =
+      Selection(Position("text", 0, Affinity.Downstream), Position("text", 4, Affinity.Downstream))
+    fixture.fake.selectionHitRectsProvider = { listOf(PageRect(0, Rect(0f, 0f, 50f, 50f))) }
+    fixture.fake.publishSnapshot(fixture.editor)
+    fixture.controller.onPointerDown(2L, Offset(80f, 20f), 0L)
+    fixture.controller.onPointerUp(2L, Offset(80f, 20f), 10L)
+    fixture.down(time = 20L, button = EditorMouseButton.Secondary)
+    runCurrent()
+    fixture.controller.presentAppliedState(fixture.editor)
+    assertEquals(listOf(SelectionOp.Set(fixture.selection)), fixture.selections())
+    assertTrue(fixture.host.uiState.contextMenu.visible)
+    fixture.controller.cancel()
+  }
+
+  @Test
+  fun `secondary click preserves selection after a touch command has entered the editor queue`() =
+    runTest {
+      val selection =
+        Selection(
+          Position("text", 0, Affinity.Downstream),
+          Position("text", 4, Affinity.Downstream),
+        )
+      val fake =
+        FakeFfiEditor(
+          selectionProvider = { selection },
+          selectionHitRectsProvider = { listOf(PageRect(0, Rect(0f, 0f, 50f, 50f))) },
+        )
+      val queued = ArrayDeque<Runnable>()
+      val dispatcher =
+        object : CoroutineDispatcher() {
+          override fun dispatch(context: CoroutineContext, block: Runnable) {
+            queued.addLast(block)
+          }
+        }
+      val editor = Editor(fake, this, dispatcher)
+      fake.publishSnapshot(editor)
+      val host = TestHost(this)
+      val effects =
+        object : EditorInteractionEffects by host {
+          override fun launchInteraction(block: suspend () -> Unit) {
+            launch(start = CoroutineStart.UNDISPATCHED) { block() }
+          }
+        }
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = effects,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      controller.onPointerDown(1L, Offset(80f, 20f), 0L)
+      controller.onPointerUp(1L, Offset(80f, 20f), 10L)
+      // Admit the touch command, but leave its scheduled tick waiting behind the next UI event.
+      queued.removeFirst().run()
+      assertEquals(SelectionOp.SetAt(0, 80f, 20f), (fake.enqueued.last() as Message.Selection).op)
+      controller.onPointerDown(
+        2L,
+        Offset(10f, 20f),
+        20L,
+        type = PointerType.Mouse,
+        button = EditorMouseButton.Secondary,
+      )
+      while (queued.isNotEmpty()) queued.removeFirst().run()
+      runCurrent()
+      controller.cancel()
+      assertEquals(SelectionOp.Set(selection), (fake.enqueued.last() as Message.Selection).op)
+    }
+
+  @Test
+  fun `second pointer cancels pending and active mouse table handle drags`() = runTest {
+    for (startDrag in listOf(false, true)) {
+      val selection =
+        Selection(
+          Position("cell-text", 0, Affinity.Downstream),
+          Position("cell-text", 0, Affinity.Downstream),
+        )
+      val fake =
+        FakeFfiEditor(
+          selectionProvider = { selection },
+          tableOverlaysProvider = {
+            listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+          },
+        )
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      fake.publishSnapshot(editor)
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+      controller.updateTapSlop(8f)
+      controller.onPointerDown(1L, Offset(60f, 60f), 0L, type = PointerType.Mouse)
+      if (startDrag) {
+        controller.onPointerMove(1L, Offset(100f, 90f), 20L)
+        assertEquals(EditorInteractionMode.TableCellHandleDragging, controller.interactionMode)
+      }
+      val beforeTouch = fake.enqueued.filterIsInstance<Message.Selection>().toList()
+      controller.onPointerDown(2L, Offset(200f, 200f), 30L)
+      controller.onPointerMove(2L, Offset(220f, 210f), 40L)
+      controller.onPointerUp(2L, Offset(220f, 210f), 50L)
+      controller.onPointerMove(1L, Offset(120f, 100f), 60L)
+      controller.onPointerUp(1L, Offset(120f, 100f), 70L)
+      runCurrent()
+      val afterTouch = fake.enqueued.filterIsInstance<Message.Selection>().toList()
+      controller.cancel()
+      assertEquals(beforeTouch, afterTouch, "startDrag=$startDrag")
+      assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+    }
+  }
+
+  @Test
+  fun `mouse moves coalesce per frame and release flushes the terminal point`() = runTest {
+    val fixture = MouseFixture(this)
+    fixture.down()
+    fixture.controller.onPointerMove(1L, Offset(40f, 20f), 10L)
+    fixture.controller.onPointerMove(1L, Offset(60f, 20f), 20L)
+    assertTrue(fixture.selections().filterIsInstance<SelectionOp.ExtendTo>().isEmpty())
+    runCurrent()
+    fixture.host.sendFrame()
+    runCurrent()
+    assertEquals(
+      listOf(60f),
+      fixture.selections().filterIsInstance<SelectionOp.ExtendTo>().map { it.headX },
+    )
+    fixture.controller.onPointerMove(1L, Offset(80f, 20f), 30L)
+    runCurrent()
+    fixture.controller.onPointerUp(1L, Offset(90f, 20f), 40L)
+    fixture.host.sendFrame()
+    runCurrent()
+    assertEquals(
+      listOf(60f, 90f),
+      fixture.selections().filterIsInstance<SelectionOp.ExtendTo>().map { it.headX },
+    )
+  }
+
+  @Test
+  fun `mouse edge auto scroll extends selection without a magnifier and stops on release`() =
+    runTest {
+      val fixture = MouseFixture(this)
+      fixture.host.edgeAutoScrollViewport =
+        testEdgeAutoScrollViewport(ComposeRect(0f, 0f, 100f, 100f))
+      fixture.host.edgeAutoScrollConsumedDelta = Offset(0f, 6f)
+      fixture.down()
+      fixture.controller.onPointerMove(1L, Offset(40f, 110f), 10L)
+      runCurrent()
+      repeat(4) {
+        fixture.host.sendFrame()
+        runCurrent()
+      }
+      assertTrue(fixture.host.edgeAutoScrollDispatchCount > 0)
+      assertTrue(fixture.selections().filterIsInstance<SelectionOp.ExtendTo>().size > 1)
+      assertNull(fixture.controller.magnifierPosition)
+      fixture.controller.onPointerUp(1L, Offset(40f, 110f), 50L)
+      val completed = fixture.selections()
+      repeat(2) {
+        fixture.host.sendFrame()
+        runCurrent()
+      }
+      assertEquals(completed, fixture.selections())
+    }
+
+  @Test
+  fun `mouse drag keeps its initial anchor and cancellation stops further selection`() = runTest {
+    val fixture = MouseFixture(this)
+    fixture.down()
+    fixture.controller.onPointerMove(1L, Offset(70f, 20f), 30L)
+    runCurrent()
+    fixture.host.sendFrame()
+    runCurrent()
+    fixture.controller.onPointerMove(1L, Offset(10f, 20f), 50L)
+    runCurrent()
+    fixture.host.sendFrame()
+    runCurrent()
+    val extensions = fixture.selections().filterIsInstance<SelectionOp.ExtendTo>()
+    assertEquals(listOf(70f, 10f), extensions.map { it.headX })
+    assertTrue(
+      extensions.all {
+        it.anchor == Position("text", 2, Affinity.Downstream) &&
+          it.allowCollapse &&
+          it.baseSelection == null
+      }
+    )
+    assertFalse(fixture.controller.interactionMode.allowsViewportScrollReconcile)
+    assertNull(fixture.controller.magnifierPosition)
+    fixture.controller.cancel()
+    val completed = fixture.selections()
+    fixture.controller.onPointerMove(1L, Offset(90f, 20f), 70L)
+    assertEquals(completed, fixture.selections())
+    assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+  }
+
+  @Test
+  fun `shift click and drag preserve the original selection anchor`() = runTest {
+    val fixture = MouseFixture(this)
+    fixture.selection =
+      Selection(Position("text", 1, Affinity.Downstream), Position("text", 7, Affinity.Downstream))
+    fixture.fake.applySnapshot(fixture.editor)
+    fixture.down(modifiers = InputModifiers(shift = true))
+    fixture.controller.onPointerMove(1L, Offset(80f, 20f), 30L)
+    runCurrent()
+    fixture.host.sendFrame()
+    runCurrent()
+    val extensions = fixture.selections().filterIsInstance<SelectionOp.ExtendTo>()
+    assertEquals(2, extensions.size)
+    assertTrue(
+      extensions.all {
+        it.anchor == Position("text", 1, Affinity.Downstream) &&
+          it.baseSelection == null &&
+          it.allowCollapse
+      }
+    )
+    fixture.controller.onPointerUp(1L, Offset(80f, 20f), 40L)
+    assertFalse(fixture.host.uiState.contextMenu.visible)
+  }
+
+  @Test
+  fun `mouse double and triple click select units and drag retains the selected unit`() = runTest {
+    val fixture = MouseFixture(this)
+    fixture.down()
+    fixture.controller.onPointerUp(1L, Offset(10f, 20f), 10L)
+    fixture.selection =
+      Selection(Position("text", 0, Affinity.Downstream), Position("text", 4, Affinity.Downstream))
+    fixture.down(time = 100L)
+    assertEquals(
+      SelectionPointUnit.Word,
+      (fixture.selections().last() as SelectionOp.SelectUnitAt).unit,
+    )
+    fixture.controller.onPointerUp(1L, Offset(10f, 20f), 110L)
+    fixture.down(time = 200L)
+    assertEquals(
+      SelectionPointUnit.Paragraph,
+      (fixture.selections().last() as SelectionOp.SelectUnitAt).unit,
+    )
+    fixture.controller.onPointerMove(1L, Offset(70f, 20f), 220L)
+    runCurrent()
+    fixture.host.sendFrame()
+    runCurrent()
+    val extension = fixture.selections().last() as SelectionOp.ExtendTo
+    assertEquals(fixture.selection, extension.baseSelection)
+    assertFalse(extension.allowCollapse)
+    fixture.controller.onPointerUp(1L, Offset(70f, 20f), 230L)
+    fixture.down(time = 250L)
+    assertTrue(fixture.selections().last() is SelectionOp.SetAt)
+    fixture.controller.cancel()
+  }
+
+  @Test
+  fun `secondary click preserves a hit selection and otherwise opens at the new cursor after publication`() =
+    runTest {
+      val fixture = MouseFixture(this)
+      fixture.selection =
+        Selection(
+          Position("text", 0, Affinity.Downstream),
+          Position("text", 4, Affinity.Downstream),
+        )
+      fixture.fake.selectionHitRectsProvider = { listOf(PageRect(0, Rect(0f, 0f, 50f, 50f))) }
+      fixture.fake.publishSnapshot(fixture.editor)
+      fixture.fake.selectionHitRectsProvider = { listOf(PageRect(0, Rect(100f, 0f, 50f, 50f))) }
+      fixture.fake.applySnapshot(fixture.editor)
+      fixture.down(button = EditorMouseButton.Secondary)
+      assertEquals(listOf(SelectionOp.Set(fixture.selection)), fixture.selections())
+      fixture.controller.presentAppliedState(fixture.editor)
+      assertTrue(fixture.host.uiState.contextMenu.visible)
+      assertEquals(PagePoint(0, 10f, 20f), fixture.host.uiState.contextMenu.pointerPosition)
+      fixture.host.uiState.contextMenu.hide()
+      fixture.controller.onPointerDown(
+        1L,
+        Offset(80f, 20f),
+        100L,
+        type = PointerType.Mouse,
+        button = EditorMouseButton.Secondary,
+      )
+      assertEquals(SelectionOp.SetAt(0, 80f, 20f), fixture.selections().last())
+      assertFalse(fixture.host.uiState.contextMenu.visible)
+      fixture.controller.presentAppliedState(fixture.editor)
+      assertTrue(fixture.host.uiState.contextMenu.visible)
+      assertEquals(PagePoint(0, 80f, 20f), fixture.host.uiState.contextMenu.pointerPosition)
+      assertEquals(0, fixture.host.softwareKeyboardRequestCount)
+    }
+
+  @Test
+  fun `mouse range selection works in read only documents without requesting editing focus`() =
+    runTest {
+      val fixture = MouseFixture(this, readOnly = true)
+      fixture.down()
+      fixture.controller.onPointerMove(1L, Offset(70f, 20f), 30L)
+      fixture.controller.onPointerUp(1L, Offset(70f, 20f), 40L)
+      assertTrue(fixture.selections().first() is SelectionOp.SetAt)
+      assertTrue(fixture.selections().last() is SelectionOp.ExtendTo)
+      assertFalse(fixture.host.focused)
+      assertNull(fixture.host.scheduledLongPressDispatchAtMillis)
+    }
+
+  private class MouseFixture(scope: TestScope, readOnly: Boolean = false) {
+    var selection =
+      Selection(Position("text", 2, Affinity.Downstream), Position("text", 2, Affinity.Downstream))
+    val fake =
+      FakeFfiEditor(
+        selectionProvider = { selection },
+        onTick = { listOf(EditorEvent.StateChanged(listOf(StateField.Selection))) },
+      )
+    val editor = Editor(fake, scope, StandardTestDispatcher(scope.testScheduler))
+    val host = TestHost(scope)
+    val controller =
+      EditorInteractionController(
+        editorProvider = { editor },
+        effects = host,
+        geometry = host,
+        uiStateProvider = { host.uiState },
+        readOnlyProvider = { readOnly },
+      )
+
+    fun down(
+      time: Long = 0L,
+      modifiers: InputModifiers = InputModifiers(),
+      button: EditorMouseButton = EditorMouseButton.Primary,
+    ) {
+      controller.onPointerDown(
+        1L,
+        Offset(10f, 20f),
+        time,
+        inputModifiers = modifiers,
+        type = PointerType.Mouse,
+        button = button,
+      )
+    }
+
+    fun selections() = fake.enqueued.filterIsInstance<Message.Selection>().map { it.op }
+  }
+
+  @Test
+  fun `mouse press places the cursor without touch timers or software keyboard`() =
+    runTest(StandardTestDispatcher()) {
+      val fake = FakeFfiEditor()
+      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+      val host = TestHost(this)
+      val controller =
+        EditorInteractionController(
+          editorProvider = { editor },
+          effects = host,
+          geometry = host,
+          uiStateProvider = { host.uiState },
+        )
+
+      controller.onPointerDown(
+        pointerId = 1L,
+        position = Offset(10f, 20f),
+        nowMillis = 0L,
+        type = PointerType.Mouse,
+      )
+      runCurrent()
+
+      assertEquals(
+        listOf(Message.Selection(SelectionOp.SetAt(page = 0, x = 10f, y = 20f))),
+        fake.enqueued.filterIsInstance<Message.Selection>(),
+      )
+      assertNull(host.scheduledTapDispatchAtMillis)
+      assertNull(host.scheduledLongPressDispatchAtMillis)
+      assertEquals(0, host.softwareKeyboardRequestCount)
+      assertTrue(host.focused)
+      controller.cancel()
+    }
+
   @Test
   fun `direct pointer type controls touch selection presentation`() =
     runTest(StandardTestDispatcher()) {
@@ -1971,6 +2377,7 @@ class EditorInteractionControllerTest {
         )
       val context =
         object : EditorGestureContext {
+          override val pointerType = PointerType.Touch
           override val editor = testEditor
           override val semantics = semantics
           override val effects = host
@@ -2273,12 +2680,16 @@ class EditorInteractionControllerTest {
         controller.onPointerMove(pointerId = 1L, position = Offset(52f, 50f), nowMillis = 20L)
 
         if (type == PointerType.Mouse) {
+          runCurrent()
+          host.sendFrame()
+          runCurrent()
           assertTrue(controller.interactionMode != EditorInteractionMode.SelectionHandleDragging)
-          assertTrue(
-            fake.enqueued.filterIsInstance<Message.Selection>().none {
-              it.op is SelectionOp.ExtendTo
-            }
-          )
+          val extension =
+            fake.enqueued.filterIsInstance<Message.Selection>().last().op as SelectionOp.ExtendTo
+          assertEquals(52f, extension.headX)
+          assertEquals(50f, extension.headY)
+          assertTrue(extension.allowCollapse)
+          assertNull(controller.magnifierPosition)
           controller.cancel()
           continue
         }
@@ -2443,55 +2854,82 @@ class EditorInteractionControllerTest {
   @Test
   fun `editor pointer stream starts table cell handle drag from table handle hit target`() =
     runTest(StandardTestDispatcher()) {
-      val selection =
-        Selection(
-          anchor = Position("cell-text", 0, Affinity.Downstream),
-          head = Position("cell-text", 0, Affinity.Downstream),
-        )
-      val fake =
-        FakeFfiEditor(
-          selectionProvider = { selection },
-          tableOverlaysProvider = {
-            listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
-          },
-        )
-      val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
-      fake.publishSnapshot(editor)
-      val host = TestHost(this)
-      val controller =
-        EditorInteractionController(
-          editorProvider = { editor },
-          effects = host,
-          geometry = host,
-          uiStateProvider = { host.uiState },
-        )
-      controller.updateTapSlop(8f)
-      val down = Offset(60f, 60f)
+      for (pointerType in listOf(PointerType.Touch, PointerType.Mouse)) {
+        val selection =
+          Selection(
+            anchor = Position("cell-text", 0, Affinity.Downstream),
+            head = Position("cell-text", 0, Affinity.Downstream),
+          )
+        val fake =
+          FakeFfiEditor(
+            selectionProvider = { selection },
+            tableOverlaysProvider = {
+              listOf(tableOverlay(isFocused = true, focusedRowIndex = 0, focusedColIndex = 0))
+            },
+          )
+        val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+        fake.publishSnapshot(editor)
+        val host = TestHost(this)
+        val controller =
+          EditorInteractionController(
+            editorProvider = { editor },
+            effects = host,
+            geometry = host,
+            uiStateProvider = { host.uiState },
+          )
+        controller.updateTapSlop(8f)
+        val down = Offset(60f, 60f)
 
-      assertTrue(controller.onPointerDown(pointerId = 1L, position = down, nowMillis = 0L))
-      assertFalse(controller.tryClaimScrollbarDirectDrag())
-      assertTrue(
-        controller.onPointerMove(pointerId = 1L, position = Offset(100f, 90f), nowMillis = 20L)
-      )
-      assertFalse(controller.tryClaimScrollbarDirectDrag())
+        assertTrue(
+          controller.onPointerDown(
+            pointerId = 1L,
+            position = down,
+            nowMillis = 0L,
+            type = pointerType,
+          )
+        )
+        assertFalse(controller.tryClaimScrollbarDirectDrag())
+        assertTrue(
+          controller.onPointerMove(pointerId = 1L, position = Offset(100f, 90f), nowMillis = 20L)
+        )
+        assertFalse(controller.tryClaimScrollbarDirectDrag())
 
-      val extend =
-        fake.enqueued.filterIsInstance<Message.Selection>().single().op as SelectionOp.ExtendTo
-      assertEquals(selection.anchor, extend.anchor)
-      assertEquals(0, extend.headPage)
-      assertEquals(100f, extend.headX)
-      assertEquals(90f, extend.headY)
-      assertEquals(selection, extend.baseSelection)
-      assertFalse(extend.allowCollapse)
-      assertEquals(EditorInteractionMode.TableCellHandleDragging, controller.interactionMode)
-      assertEquals(Offset(100f, 90f), controller.magnifierPosition)
+        val extend =
+          fake.enqueued.filterIsInstance<Message.Selection>().single().op as SelectionOp.ExtendTo
+        assertEquals(selection.anchor, extend.anchor)
+        assertEquals(0, extend.headPage)
+        assertEquals(100f, extend.headX)
+        assertEquals(90f, extend.headY)
+        assertEquals(selection, extend.baseSelection)
+        assertFalse(extend.allowCollapse)
+        assertEquals(EditorInteractionMode.TableCellHandleDragging, controller.interactionMode)
+        assertEquals(
+          if (pointerType == PointerType.Touch) Offset(100f, 90f) else null,
+          controller.magnifierPosition,
+        )
 
-      assertTrue(
-        controller.onPointerUp(pointerId = 1L, position = Offset(100f, 90f), nowMillis = 40L)
-      )
-      assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
-      assertTrue(controller.tryClaimScrollbarDirectDrag())
-      assertFalse(host.scrollGestureLockActive)
+        assertTrue(
+          controller.onPointerUp(pointerId = 1L, position = Offset(100f, 90f), nowMillis = 40L)
+        )
+        assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+        if (pointerType == PointerType.Mouse) {
+          val selectionCount = fake.enqueued.filterIsInstance<Message.Selection>().size
+          assertTrue(
+            controller.onPointerDown(
+              pointerId = 1L,
+              position = down,
+              nowMillis = 100L,
+              type = PointerType.Mouse,
+              inputModifiers = InputModifiers(ctrl = true),
+            )
+          )
+          val commands = fake.enqueued.filterIsInstance<Message.Selection>().drop(selectionCount)
+          assertEquals(listOf(SelectionOp.SetAt(0, down.x, down.y)), commands.map { it.op })
+          assertEquals(EditorInteractionMode.Idle, controller.interactionMode)
+        }
+        assertTrue(controller.tryClaimScrollbarDirectDrag())
+        assertFalse(host.scrollGestureLockActive)
+      }
     }
 
   @Test

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorContextMenuStateTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/runtime/EditorContextMenuStateTest.kt
@@ -3,16 +3,47 @@ package co.typie.editor.runtime
 import co.typie.editor.Editor
 import co.typie.editor.EditorState
 import co.typie.editor.FakeFfiEditor
+import co.typie.editor.PagePoint
 import co.typie.editor.ffi.Affinity
 import co.typie.editor.ffi.Position
 import co.typie.editor.ffi.Selection
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 
 class EditorContextMenuStateTest {
+  @Test
+  fun `pointer menu can open for a caret only after publication and dismissal cancels it`() =
+    runTest {
+      val editor = Editor(FakeFfiEditor(), this, StandardTestDispatcher(testScheduler))
+      val caret = Position("text", 2, Affinity.Downstream)
+      val target = EditorState.Initial.copy(version = 5L, selection = Selection(caret, caret))
+      val state = EditorContextMenuState()
+      state.requestShowForAppliedSelection(editor, target)
+      state.onEditorStateChanged(editor, target)
+      assertFalse(state.visible)
+      state.requestShowForAppliedSelection(editor, target, PagePoint(0, 20f, 40f))
+      state.onEditorStateChanged(editor, target.copy(version = 4L))
+      assertFalse(state.visible)
+      state.onEditorStateChanged(editor, target)
+      assertTrue(state.visible)
+      assertEquals(PagePoint(0, 20f, 40f), state.pointerPosition)
+      state.hide()
+      assertNull(state.pointerPosition)
+      state.requestShowForAppliedSelection(
+        editor,
+        target.copy(version = 6L),
+        PagePoint(0, 30f, 40f),
+      )
+      state.hide()
+      state.onEditorStateChanged(editor, target.copy(version = 6L))
+      assertFalse(state.visible)
+    }
+
   @Test
   fun `applied target cancels for another editor and otherwise matches version and selection once`() =
     runTest(StandardTestDispatcher()) {

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/interaction/EditorInteractionsDesktopTest.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.MouseButton
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -50,6 +51,8 @@ import co.typie.editor.EditorZoomController
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.PagePoint
 import co.typie.editor.body.EditorDocumentLayoutSpec
+import co.typie.editor.ffi.Message
+import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.Size as PageSize
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemanticConfig
 import co.typie.editor.runtime.EditorUiState
@@ -80,8 +83,64 @@ import kotlinx.coroutines.yield
 @OptIn(ExperimentalTestApi::class)
 class EditorInteractionsDesktopTest {
   @Test
-  fun `desktop trackpad click drag scrolls the viewport like touch`() = runComposeUiTest {
-    val fixture = Fixture()
+  fun `secondary button opens a context menu without starting a selection drag`() =
+    runComposeUiTest {
+      val fixture = Fixture(tapEligible = true)
+      fixture.fake.publishSnapshot(fixture.editor)
+      setEditorContent(fixture)
+      onNodeWithTag(EditorTag).performMouseInput {
+        moveTo(Offset(100f, 100f))
+        press(MouseButton.Secondary)
+        moveTo(Offset(160f, 100f))
+        release(MouseButton.Secondary)
+      }
+      waitForIdle()
+      assertEquals(
+        listOf(SelectionOp.SetAt(0, 100f, 100f)),
+        fixture.fake.enqueued.filterIsInstance<Message.Selection>().map { it.op },
+      )
+      assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+      assertEquals(0, fixture.host.longPressDispatchScheduleCount)
+      assertFalse(fixture.scrollGestureLockState.isLocked)
+      val publication = requireNotNull(fixture.editor.publishIfReady(emptySet()))
+      assertTrue(fixture.editor.acceptPublication(publication))
+      fixture.controller.onEditorStateChanged(publication.snapshot)
+      assertTrue(fixture.uiState.contextMenu.visible)
+      assertEquals(PagePoint(0, 100f, 100f), fixture.uiState.contextMenu.pointerPosition)
+    }
+
+  @Test
+  fun `selection drag ends when its starting button is released with another button held`() =
+    runComposeUiTest {
+      val fixture = Fixture(tapEligible = true)
+      setEditorContent(fixture)
+      val node = onNodeWithTag(EditorTag)
+      node.performMouseInput {
+        moveTo(Offset(100f, 100f))
+        press(MouseButton.Primary)
+        moveTo(Offset(140f, 100f))
+        press(MouseButton.Secondary)
+        release(MouseButton.Secondary)
+      }
+      assertEquals(EditorInteractionMode.MouseSelecting, fixture.controller.interactionMode)
+      node.performMouseInput {
+        press(MouseButton.Secondary)
+        release(MouseButton.Primary)
+      }
+      assertEquals(EditorInteractionMode.Idle, fixture.controller.interactionMode)
+      assertTrue(fixture.scrollGestureLockState.isLocked)
+      val selections = fixture.fake.enqueued.filterIsInstance<Message.Selection>().toList()
+      node.performMouseInput {
+        moveTo(Offset(180f, 100f))
+        release(MouseButton.Secondary)
+      }
+      assertEquals(selections, fixture.fake.enqueued.filterIsInstance<Message.Selection>())
+      assertFalse(fixture.scrollGestureLockState.isLocked)
+    }
+
+  @Test
+  fun `trackpad click drag selects text without touch scrolling`() = runComposeUiTest {
+    val fixture = Fixture(tapEligible = true)
     setEditorContent(fixture)
 
     onNodeWithTag(EditorTag).performTrackpadInput {
@@ -93,7 +152,16 @@ class EditorInteractionsDesktopTest {
     }
     waitForIdle()
 
-    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+    assertTrue(fixture.touchPanDeltas.isEmpty())
+    assertTrue(
+      fixture.fake.enqueued.filterIsInstance<Message.Selection>().any { it.op is SelectionOp.SetAt }
+    )
+    assertTrue(
+      fixture.fake.enqueued.filterIsInstance<Message.Selection>().any {
+        it.op is SelectionOp.ExtendTo
+      }
+    )
+    assertEquals(0, fixture.host.longPressDispatchScheduleCount)
   }
 
   @Test
@@ -141,7 +209,7 @@ class EditorInteractionsDesktopTest {
   @Test
   fun `editor physical click drag owns desktop scroll translation until release`() =
     runComposeUiTest {
-      val fixture = Fixture()
+      val fixture = Fixture(tapEligible = true)
       setEditorContent(fixture)
 
       onNodeWithTag(EditorTag).performTrackpadInput {
@@ -158,7 +226,7 @@ class EditorInteractionsDesktopTest {
       waitForIdle()
 
       assertFalse(fixture.scrollGestureLockState.isLocked)
-      assertTrue(fixture.touchPanDeltas.isNotEmpty())
+      assertTrue(fixture.touchPanDeltas.isEmpty())
     }
 
   @Test
@@ -269,7 +337,7 @@ class EditorInteractionsDesktopTest {
       press()
     }
     waitForIdle()
-    assertEquals(1, fixture.host.longPressDispatchScheduleCount)
+    assertEquals(0, fixture.host.longPressDispatchScheduleCount)
 
     editor.performKeyInput { keyDown(Key.MetaLeft) }
     editor.performMouseInput { scroll(Offset(x = 0f, y = -24f)) }
@@ -497,7 +565,7 @@ class EditorInteractionsDesktopTest {
     }
 
   @Test
-  fun `platform indirect scale cannot take over an active physical pan`() = runComposeUiTest {
+  fun `platform indirect scale cannot take over an active mouse selection`() = runComposeUiTest {
     val fixture = Fixture(tapEligible = true)
     setEditorContent(fixture)
     val editor = onNodeWithTag(EditorTag)
@@ -509,7 +577,7 @@ class EditorInteractionsDesktopTest {
       moveTo(Offset(x = 120f, y = 100f))
     }
     waitForIdle()
-    assertEquals(EditorInteractionMode.Panning, fixture.controller.interactionMode)
+    assertEquals(EditorInteractionMode.MouseSelecting, fixture.controller.interactionMode)
     val panDeltaCountBeforeIndirectInput = fixture.touchPanDeltas.size
 
     editor.performKeyInput { keyDown(Key.MetaLeft) }
@@ -519,7 +587,7 @@ class EditorInteractionsDesktopTest {
       updatePointerTo(Offset(x = 120f, y = 100f))
       pan(Offset(x = -40f, y = 60f))
     }
-    assertEquals(EditorInteractionMode.Panning, fixture.controller.interactionMode)
+    assertEquals(EditorInteractionMode.MouseSelecting, fixture.controller.interactionMode)
     assertEquals(panDeltaCountBeforeIndirectInput, fixture.touchPanDeltas.size)
     runOnIdle { assertFalse(fixture.platformIndirectScaleBridge.begin()) }
 
@@ -613,8 +681,8 @@ class EditorInteractionsDesktopTest {
   }
 
   @Test
-  fun `modified physical click drag remains pan and never zooms`() = runComposeUiTest {
-    val fixture = Fixture()
+  fun `modified physical click drag selects text and never zooms`() = runComposeUiTest {
+    val fixture = Fixture(tapEligible = true)
     setEditorContent(fixture)
     val editor = onNodeWithTag(EditorTag)
     val initialZoom = fixture.zoomController.displayZoom
@@ -629,7 +697,12 @@ class EditorInteractionsDesktopTest {
     editor.performKeyInput { keyUp(Key.MetaLeft) }
     waitForIdle()
 
-    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+    assertTrue(fixture.touchPanDeltas.isEmpty())
+    assertTrue(
+      fixture.fake.enqueued.filterIsInstance<Message.Selection>().any {
+        it.op is SelectionOp.ExtendTo
+      }
+    )
     assertEquals(initialZoom, fixture.zoomController.displayZoom, 0.0001f)
     assertEquals(initialZoom, fixture.zoomController.renderZoom, 0.0001f)
     assertFalse(fixture.scrollGestureLockState.isLocked)
@@ -654,8 +727,8 @@ class EditorInteractionsDesktopTest {
   }
 
   @Test
-  fun `desktop editor scroll owns drag before full-area back swipe`() = runComposeUiTest {
-    val fixture = Fixture()
+  fun `editor text selection owns mouse drag before full-area back swipe`() = runComposeUiTest {
+    val fixture = Fixture(tapEligible = true)
     val navigator = Navigator(Route.Home)
     val touchSlop =
       setNavigationEditorContent(
@@ -681,7 +754,12 @@ class EditorInteractionsDesktopTest {
     editor.performTrackpadInput { moveBy(Offset(x = touchSlop * 3f, y = 0f), delayMillis = 100L) }
     waitForIdle()
 
-    assertTrue(fixture.touchPanDeltas.isNotEmpty())
+    assertTrue(fixture.touchPanDeltas.isEmpty())
+    assertTrue(
+      fixture.fake.enqueued.filterIsInstance<Message.Selection>().any {
+        it.op is SelectionOp.ExtendTo
+      }
+    )
     assertEquals(
       expected = 0f,
       actual = editor.fetchSemanticsNode().boundsInRoot.left,
@@ -730,7 +808,7 @@ class EditorInteractionsDesktopTest {
 
   @Test
   fun `desktop trackpad click drag ignores overlapping scroll signals`() = runComposeUiTest {
-    val fixture = Fixture(scrollConsumer = { Offset.Zero })
+    val fixture = Fixture(scrollConsumer = { Offset.Zero }, tapEligible = true)
     val navigator = Navigator(Route.Home)
     setNavigationEditorContent(fixture = fixture, navigator = navigator)
 
@@ -750,8 +828,13 @@ class EditorInteractionsDesktopTest {
     onNodeWithTag(NavigationEditorTag).performMouseInput { release() }
     waitForIdle()
 
-    assertEquals(Route.Home, navigator.current)
-    onAllNodes(hasTestTag(NavigationEditorTag)).assertCountEquals(0)
+    assertEquals(NavigationEditorRoute, navigator.current)
+    assertTrue(fixture.touchPanDeltas.isEmpty())
+    assertTrue(
+      fixture.fake.enqueued.filterIsInstance<Message.Selection>().any {
+        it.op is SelectionOp.ExtendTo
+      }
+    )
   }
 
   @Test
@@ -1761,7 +1844,9 @@ class EditorInteractionsDesktopTest {
     setContent {
       val nestedScrollDispatcher = remember { NestedScrollDispatcher() }
       val screenPointerSequence = remember { EditorScreenPointerSequence() }
-      onCoroutineScope(rememberCoroutineScope())
+      val interactionScope = rememberCoroutineScope()
+      fixture.host.interactionScope = interactionScope
+      onCoroutineScope(interactionScope)
       Box(
         Modifier.size(400.dp)
           .testTag(RootTag)
@@ -1831,6 +1916,7 @@ class EditorInteractionsDesktopTest {
   ): Float {
     var effectiveTouchSlop = 0f
     setContent {
+      fixture.host.interactionScope = rememberCoroutineScope()
       effectiveTouchSlop =
         if (usePlatformTouchSlop) LocalViewConfiguration.current.touchSlop else 8f
       NavigationStackTestHost(
@@ -1953,14 +2039,15 @@ class EditorInteractionsDesktopTest {
     val zoomController = EditorZoomController()
     val platformIndirectScaleBridge = EditorPlatformIndirectScaleBridge()
     val scrollGestureLockState = ScrollGestureLockState()
-    private val uiState =
+    val uiState =
       EditorUiState().apply {
         updateDisplayZoom(1f)
         updatePageOffset(page = 0, offset = Offset.Zero)
         updateEditorBounds(boundsInRoot = editorBoundsInRoot, density = 1f)
       }
     val host = TestHost(tapEligible = tapEligible, documentDownEligible = documentDownEligible)
-    private val editor = Editor(FakeFfiEditor(), CoroutineScope(Job()), Dispatchers.Unconfined)
+    val fake = FakeFfiEditor()
+    val editor = Editor(fake, CoroutineScope(Job()), Dispatchers.Unconfined)
     private val semantics =
       EditorInteractionSemantics(effects = host, contextMenuStateProvider = { uiState.contextMenu })
         .apply {
@@ -1990,6 +2077,7 @@ class EditorInteractionsDesktopTest {
 
   private class TestHost(private val tapEligible: Boolean, val documentDownEligible: Boolean) :
     EditorInteractionEffects, EditorInteractionGeometry {
+    var interactionScope: CoroutineScope? = null
     var interactionMappingAvailable = tapEligible
     var pointerStreamCancelCount = 0
     var tapDispatchScheduleCount = 0
@@ -2040,7 +2128,9 @@ class EditorInteractionsDesktopTest {
       longPressDispatchCancelCount += 1
     }
 
-    override fun launchInteraction(block: suspend () -> Unit) = Unit
+    override fun launchInteraction(block: suspend () -> Unit) {
+      checkNotNull(interactionScope).launch { block() }
+    }
 
     override fun requestEditing(editor: Editor): Boolean = false
 


### PR DESCRIPTION
앱 에디터에서 마우스와 트랙패드로 데스크톱처럼 커서를 이동하고 텍스트를 선택할 수 있도록 합니다.

- 마우스·트랙패드 입력을 기존 gestures/semantic 시스템 안에서 별도의 클릭·드래그 경로로 처리합니다.
- 클릭으로 커서 이동, Shift+클릭으로 선택 확장, 더블·트리플 클릭으로 단어·문단 선택, 드래그로 범위 선택과 가장자리 자동 스크롤을 지원합니다.
- 보조 클릭으로 컨텍스트 메뉴를 표시합니다. 선택 영역 안에서는 기존 선택을 유지하고, 바깥에서는 클릭 위치로 커서를 옮깁니다.
- 터치·펜 입력에는 기존 선택 핸들·돋보기·길게 누르기 동작을 유지하고, 마우스·트랙패드 선택에는 터치용 동작과 UI가 개입하지 않도록 합니다.
- 클릭·드래그와 트랙패드 스크롤·확대 입력 사이의 충돌 및 터치에서 마우스로 전환할 때의 선택 갱신 순서를 정리합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>