### PR TITLE
더블/트리플 클릭 드래그-선택 지원

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorMouseGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/gestures/EditorMouseGesture.kt
@@ -110,16 +110,16 @@ internal class EditorMouseGesture {
     if (!context.readOnly && (context.editing || context.effects.requestEditing(editor))) {
       context.effects.requestFocus(editor)
     }
+    val unit =
+      when (count) {
+        2 -> SelectionPointUnit.Word
+        3 -> SelectionPointUnit.Paragraph
+        else -> null
+      }
     val original = editor.appliedState.selection
     val op =
       when {
-        count > 1 ->
-          SelectionOp.SelectUnitAt(
-            point.page,
-            point.x,
-            point.y,
-            if (count == 2) SelectionPointUnit.Word else SelectionPointUnit.Paragraph,
-          )
+        unit != null -> SelectionOp.SelectUnitAt(point.page, point.x, point.y, unit)
         modifiers.shift && original != null ->
           SelectionOp.ExtendTo(
             anchor = original.anchor,
@@ -140,7 +140,8 @@ internal class EditorMouseGesture {
         anchor =
           if (count == 1 && modifiers.shift && original != null) original.anchor
           else selected.anchor,
-        baseSelection = selected.takeIf { count > 1 && !it.isCollapsed() },
+        baseSelection = selected.takeIf { unit != null && !it.isCollapsed() },
+        unit = unit,
       )
     context.reduceMode(EditorInteractionEvent.MouseSelectionStart)
     if (!context.readOnly) context.effects.requestPointerSelectionHead(applied.version)
@@ -231,6 +232,7 @@ internal class EditorMouseGesture {
         headX = point.x,
         headY = point.y,
         baseSelection = current.baseSelection,
+        unit = current.unit,
         allowCollapse = current.baseSelection == null,
       ),
     ) != null
@@ -241,6 +243,7 @@ internal class EditorMouseGesture {
     val down: Offset,
     val anchor: Position,
     val baseSelection: Selection?,
+    val unit: SelectionPointUnit?,
     var moved: Boolean = false,
     var pendingPosition: Offset? = null,
     var framePending: Boolean = false,

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -432,6 +432,40 @@ class EditorInteractionControllerTest {
   }
 
   @Test
+  fun `mouse unit drag keeps its unit through movement release and the next single click`() =
+    runTest {
+      for ((count, unit) in
+        listOf(2 to SelectionPointUnit.Word, 3 to SelectionPointUnit.Paragraph)) {
+        val fixture = MouseFixture(this)
+        repeat(count - 1) { index ->
+          fixture.down(time = index * 100L)
+          fixture.controller.onPointerUp(1L, Offset(10f, 20f), index * 100L + 10L)
+        }
+        val base =
+          Selection(
+            Position("text", 0, Affinity.Downstream),
+            Position("text", 4, Affinity.Downstream),
+          )
+        fixture.selection = base
+        fixture.down(time = (count - 1) * 100L)
+        fixture.controller.onPointerMove(1L, Offset(70f, 20f), count * 100L)
+        runCurrent()
+        fixture.host.sendFrame()
+        runCurrent()
+        fixture.controller.onPointerUp(1L, Offset(90f, 20f), count * 100L + 10L)
+        val extensions = fixture.selections().filterIsInstance<SelectionOp.ExtendTo>()
+        assertEquals(listOf(70f, 90f), extensions.map { it.headX })
+        assertTrue(
+          extensions.all { it.unit == unit && it.baseSelection == base && !it.allowCollapse }
+        )
+        fixture.selection = Selection(base.anchor, base.anchor)
+        fixture.down(time = count * 100L + 20L)
+        fixture.controller.onPointerUp(1L, Offset(70f, 20f), count * 100L + 30L)
+        assertNull((fixture.selections().last() as SelectionOp.ExtendTo).unit)
+      }
+    }
+
+  @Test
   fun `mouse double and triple click select units and drag retains the selected unit`() = runTest {
     val fixture = MouseFixture(this)
     fixture.down()
@@ -455,6 +489,7 @@ class EditorInteractionControllerTest {
     runCurrent()
     val extension = fixture.selections().last() as SelectionOp.ExtendTo
     assertEquals(fixture.selection, extension.baseSelection)
+    assertEquals(SelectionPointUnit.Paragraph, extension.unit)
     assertFalse(extension.allowCollapse)
     fixture.controller.onPointerUp(1L, Offset(70f, 20f), 230L)
     fixture.down(time = 250L)

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.test.ts
@@ -447,10 +447,55 @@ describe('pointer native drag admission', () => {
         head_x: 30,
         head_y: 20,
         base_selection: undefined,
+        unit: undefined,
         allow_collapse: true,
       },
     });
     vi.unstubAllGlobals();
+  });
+
+  it.each([
+    [2, 'word'],
+    [3, 'paragraph'],
+  ] as const)('keeps click count %i selection at %s granularity through drag and release', (count, unit) => {
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    try {
+      const editor = createEditor({ selection: rangeSelection, isSelectionCollapsed: false });
+      const target = createPointerTarget({ captured: true });
+      editor.clientToLocal = vi.fn((x: number, y: number) => ({ page: 0, x, y }));
+      for (let index = 0; index < count; index++) {
+        handlePointerDown(editor, createPointerEvent({ target, timeStamp: 1000 + index * 100 }));
+        if (index < count - 1) handlePointerUp(editor, createPointerEvent({ target }));
+      }
+      expect(editor.enqueue).toHaveBeenLastCalledWith({
+        type: 'selection',
+        op: { type: 'select_unit_at', page: 0, x: 110, y: 220, unit },
+      });
+      editor.enqueue.mockClear();
+      handlePointerMove(editor, createPointerEvent({ target, clientX: 150 }));
+      frames.shift()?.(0);
+      handlePointerMove(editor, createPointerEvent({ target, clientX: 90 }));
+      handlePointerUp(editor, createPointerEvent({ target, clientX: 110 }));
+      const extensions = editor.enqueue.mock.calls.map(([message]) => message.op);
+      expect(extensions.map((op) => op.head_x)).toEqual([150, 90, 110]);
+      for (const op of extensions) {
+        expect(op).toMatchObject({ type: 'extend_to', unit, base_selection: rangeSelection, allow_collapse: false });
+      }
+      expect(editor.beginNativeDragAdmission).not.toHaveBeenCalled();
+      handlePointerDown(editor, createPointerEvent({ target, timeStamp: 1000 + count * 100 }));
+      expect(editor.enqueue).toHaveBeenLastCalledWith({
+        type: 'selection',
+        op: { type: 'set_at', page: 0, x: 110, y: 220 },
+      });
+      handlePointerUp(editor, createPointerEvent({ target }));
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('bases a new drag on the exact applied selection when publication is still stale', () => {
@@ -520,6 +565,7 @@ describe('pointer native drag admission', () => {
           head_x: 30,
           head_y: 40,
           base_selection: undefined,
+          unit: undefined,
           allow_collapse: true,
         },
       });

--- a/apps/website/src/lib/editor-ffi/handlers/pointer.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/pointer.ts
@@ -1,6 +1,6 @@
 import { EditorEdgeAutoScroll } from '../edge-auto-scroll';
 import { isSelectionCollapsed } from '../geometry';
-import type { InputModifiers, InteractiveHit, Position, Rect, Selection } from '@typie/editor-ffi/browser';
+import type { InputModifiers, InteractiveHit, Position, Rect, Selection, SelectionPointUnit } from '@typie/editor-ffi/browser';
 import type { Editor } from '../editor.svelte';
 import type { SelectionHandleKind } from '../gesture.svelte';
 import type { EditorEventHandler } from '../types';
@@ -121,7 +121,16 @@ export const handlePointerDown: EditorEventHandler<HTMLElement, PointerEvent> = 
       editor.scrollIntoView({ target: { type: 'current_selection_head' }, policy: 'pointer_cursor_guard' });
     }
   }
-  state.markPointerDown(e.pointerId, !nativeDragCandidate, { page, x, y }, count, modifiers, nativeDragCandidate, interactionSelection);
+  state.markPointerDown(
+    e.pointerId,
+    !nativeDragCandidate,
+    { page, x, y },
+    count,
+    modifiers,
+    nativeDragCandidate,
+    interactionSelection,
+    e.pointerType === 'mouse' && count > 1 ? (count === 2 ? 'word' : 'paragraph') : undefined,
+  );
   if (!nativeDragCandidate) {
     editor.suspendToolbarSync();
   }
@@ -239,6 +248,7 @@ class PointerState {
     down: LocalPoint;
     anchor: Position | null;
     baseSelection: Selection | undefined;
+    unit: SelectionPointUnit | undefined;
     nativeDragCandidate: boolean;
     nativeDragStarted: boolean;
     dragging: boolean;
@@ -279,6 +289,7 @@ class PointerState {
     }
 
     this.#session.dragging = true;
+    this.#clickCount = 0;
     editor.enqueue({
       type: 'selection',
       op: {
@@ -288,6 +299,7 @@ class PointerState {
         head_x: point.x,
         head_y: point.y,
         base_selection: this.#session.baseSelection,
+        unit: this.#session.unit,
         allow_collapse: this.#session.baseSelection === undefined,
       },
     });
@@ -332,6 +344,7 @@ class PointerState {
     modifiers: InputModifiers,
     nativeDragCandidate: boolean,
     selection: Selection | undefined,
+    unit: SelectionPointUnit | undefined,
   ) {
     const selectionCollapsed = isSelectionCollapsed(selection);
     const canExtend = !nativeDragCandidate && (count > 1 ? selection !== undefined : modifiers.shift || selectionCollapsed);
@@ -341,6 +354,7 @@ class PointerState {
       down,
       anchor: canExtend ? (selection?.anchor ?? null) : null,
       baseSelection: selection && !selectionCollapsed && count > 1 ? selection : undefined,
+      unit,
       nativeDragCandidate,
       nativeDragStarted: false,
       dragging: false,

--- a/crates/editor-core/src/handle/selection.rs
+++ b/crates/editor-core/src/handle/selection.rs
@@ -202,6 +202,7 @@ pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), E
             head_x,
             head_y,
             base_selection,
+            unit,
             allow_collapse,
         } => {
             let selection = resolve_extend_to_selection(
@@ -211,6 +212,7 @@ pub fn handle_selection_op(editor: &mut Editor, op: SelectionOp) -> Result<(), E
                 head_x,
                 head_y,
                 base_selection,
+                unit,
                 allow_collapse,
             );
             editor.transact(|tr| {
@@ -284,20 +286,28 @@ fn resolve_select_unit_at_selection(
     let layout_state = editor.view.layout_state()?;
     let layout_view = layout_state.view();
     let hit = editor.view.hit_test(page, x, y)?;
-    let selection = match unit {
+    let selection = expand_selection_unit(editor, &layout_view, hit, unit);
+    remap_layout_selection(editor, selection)
+}
+
+fn expand_selection_unit(
+    editor: &Editor,
+    view: &DocView,
+    selection: Selection,
+    unit: SelectionPointUnit,
+) -> Selection {
+    match unit {
         SelectionPointUnit::Word => {
             let resource = editor.resource.lock().unwrap();
-            resolve_word_selection_expansion(&hit, &layout_view, &resource).unwrap_or(hit)
+            resolve_word_selection_expansion(&selection, view, &resource)
         }
         SelectionPointUnit::Sentence => {
             let resource = editor.resource.lock().unwrap();
-            resolve_sentence_selection_expansion(&hit, &layout_view, &resource).unwrap_or(hit)
+            resolve_sentence_selection_expansion(&selection, view, &resource)
         }
-        SelectionPointUnit::Paragraph => {
-            resolve_paragraph_selection_expansion(&hit, &layout_view).unwrap_or(hit)
-        }
-    };
-    remap_layout_selection(editor, selection)
+        SelectionPointUnit::Paragraph => resolve_paragraph_selection_expansion(&selection, view),
+    }
+    .unwrap_or(selection)
 }
 
 fn resolve_extend_to_selection(
@@ -307,6 +317,7 @@ fn resolve_extend_to_selection(
     head_x: f32,
     head_y: f32,
     base_selection: Option<Selection>,
+    unit: Option<SelectionPointUnit>,
     allow_collapse: bool,
 ) -> Option<Selection> {
     let mut input_state = editor.view.layout_state()?.clone();
@@ -348,11 +359,15 @@ fn resolve_extend_to_selection(
         }
     }
 
+    let head_selection = match unit {
+        Some(unit) => expand_selection_unit(editor, &view, head_hit.selection, unit),
+        None => head_hit.selection,
+    };
     let base_selection = base_selection.or_else(|| expand_unit_at(&anchor, &view));
     let selection = if let Some(base_selection) = base_selection {
-        extend_base_selection(&view, base_selection, head_hit.selection)?
+        extend_base_selection(&view, base_selection, head_selection)?
     } else {
-        extend_drag_hit(&view, anchor, head_hit.selection)?
+        extend_drag_hit(&view, anchor, head_selection)?
     };
     let selection = selection.normalize(&view).unwrap_or(selection);
 
@@ -986,6 +1001,7 @@ mod tests {
                 head_x: 9999.0,
                 head_y: 30.0,
                 base_selection: Some(initial),
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -999,6 +1015,190 @@ mod tests {
             sel
         );
         assert!(!editor.undo_history.can_undo());
+    }
+
+    fn extend_unit_to_position(
+        editor: &mut Editor,
+        base: Selection,
+        target: Position,
+        unit: SelectionPointUnit,
+    ) {
+        let metrics = editor.view.cursor_metrics(&editor.state, &target).unwrap();
+        editor.apply(Message::Selection {
+            op: SelectionOp::ExtendTo {
+                anchor: base.anchor,
+                head_page: metrics.page_idx,
+                head_x: metrics.caret.x,
+                head_y: metrics.line.y + metrics.line.height / 2.0,
+                base_selection: Some(base),
+                unit: Some(unit),
+                allow_collapse: false,
+            },
+        });
+    }
+
+    #[test]
+    fn extend_to_word_expands_shrinks_and_reverses_around_initial_word() {
+        let (english, english_p) = state! {
+            doc { root { p: paragraph { text("alpha beta gamma delta") } } }
+            selection: (p, 6) -> (p, 10)
+        };
+        let (korean, korean_p) = state! {
+            doc { root { p: paragraph { text("하나 둘셋 넷다섯 여섯") } } }
+            selection: (p, 3) -> (p, 5)
+        };
+        for (state, p, steps) in [
+            (
+                english,
+                english_p,
+                vec![
+                    (13, 6, 16),
+                    (19, 6, 22),
+                    (13, 6, 16),
+                    (8, 6, 10),
+                    (2, 10, 0),
+                    (13, 6, 16),
+                ],
+            ),
+            (
+                korean,
+                korean_p,
+                vec![
+                    (7, 3, 9),
+                    (11, 3, 12),
+                    (7, 3, 9),
+                    (4, 3, 5),
+                    (1, 5, 0),
+                    (7, 3, 9),
+                ],
+            ),
+        ] {
+            let mut editor = Editor::new_test(state);
+            let base = editor.state.selection.unwrap();
+            for (offset, anchor, head) in steps {
+                extend_unit_to_position(
+                    &mut editor,
+                    base,
+                    Position::new(p, offset),
+                    SelectionPointUnit::Word,
+                );
+                let selection = editor.state.selection.unwrap();
+                assert_eq!((selection.anchor.node, selection.head.node), (p, p));
+                assert_eq!(
+                    (selection.anchor.offset, selection.head.offset),
+                    (anchor, head),
+                    "hit {offset}"
+                );
+            }
+            assert!(!editor.undo_history.can_undo());
+        }
+    }
+
+    #[test]
+    fn extend_to_paragraph_expands_shrinks_and_reverses_around_initial_paragraph() {
+        let (state, first, middle, last) = state! {
+            doc { root {
+                first: paragraph { text("first paragraph") }
+                middle: paragraph { text("middle paragraph") }
+                last: paragraph { text("last paragraph") }
+            } }
+            selection: (middle, 0) -> (middle, 16)
+        };
+        let mut editor = Editor::new_test(state);
+        let base = editor.state.selection.unwrap();
+        for (target, anchor, head, end) in [
+            (last, middle, last, 14),
+            (middle, middle, middle, 16),
+            (first, middle, first, 0),
+            (last, middle, last, 14),
+        ] {
+            extend_unit_to_position(
+                &mut editor,
+                base,
+                Position::new(target, 4),
+                SelectionPointUnit::Paragraph,
+            );
+            let selection = editor.state.selection.unwrap();
+            assert_eq!((selection.anchor.node, selection.head.node), (anchor, head));
+            assert_eq!(
+                selection.anchor.offset,
+                if target == first { 16 } else { 0 }
+            );
+            assert_eq!(selection.head.offset, end);
+        }
+    }
+
+    #[test]
+    fn extend_to_paragraph_includes_an_empty_paragraph_and_can_return_to_base() {
+        let (state, first, empty, last) = state! {
+            doc { root {
+                first: paragraph { text("first") }
+                empty: paragraph {}
+                last: paragraph { text("last") }
+            } }
+            selection: (first, 0) -> (first, 5)
+        };
+        let mut editor = Editor::new_test(state);
+        let base = editor.state.selection.unwrap();
+        extend_unit_to_position(
+            &mut editor,
+            base,
+            Position::new(empty, 0),
+            SelectionPointUnit::Paragraph,
+        );
+        let selection = editor.state.selection.unwrap();
+        assert_eq!((selection.anchor.node, selection.anchor.offset), (first, 0));
+        assert_eq!((selection.head.node, selection.head.offset), (last, 0));
+        extend_unit_to_position(
+            &mut editor,
+            base,
+            Position::new(first, 2),
+            SelectionPointUnit::Paragraph,
+        );
+        let selection = editor.state.selection.unwrap();
+        assert_eq!((selection.anchor.node, selection.head.node), (first, first));
+        assert_eq!((selection.anchor.offset, selection.head.offset), (0, 5));
+    }
+
+    #[test]
+    fn extend_to_unit_across_table_cells_keeps_cell_selection() {
+        for unit in [SelectionPointUnit::Word, SelectionPointUnit::Paragraph] {
+            let (state, c1, _p1, c2, p2) = state! {
+                doc { root {
+                    table {
+                        table_row {
+                            c1: table_cell { p1: paragraph { text("first word") } }
+                            c2: table_cell { p2: paragraph { text("other word") } }
+                        }
+                        table_row {
+                            table_cell { paragraph { text("below") } }
+                            table_cell { paragraph { text("below") } }
+                        }
+                    }
+                    paragraph {}
+                } }
+                selection: (p1, 0) -> (p1, 5)
+            };
+            let mut editor = Editor::new_test(state);
+            editor.view.layout(&editor.state);
+            let base = editor.state.selection.unwrap();
+            extend_unit_to_position(&mut editor, base, Position::new(p2, 2), unit);
+            let view = editor.state.view();
+            let rect = editor
+                .state
+                .selection
+                .unwrap()
+                .resolve(&view)
+                .unwrap()
+                .as_cell_rect()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "expected cell range for {unit:?}, got {:?}",
+                        editor.state.selection
+                    )
+                });
+            assert_eq!((rect.anchor_cell.id(), rect.head_cell.id()), (c1, c2));
+        }
     }
 
     #[test]
@@ -1046,6 +1246,7 @@ mod tests {
                 head_x,
                 head_y,
                 base_selection: None,
+                unit: None,
                 allow_collapse: true,
             },
         });
@@ -1086,6 +1287,7 @@ mod tests {
                 head_x: target_metrics.caret.x,
                 head_y: target_metrics.line.y + target_metrics.line.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: true,
             },
         });
@@ -1123,6 +1325,7 @@ mod tests {
                 head_x: text_rect.x + 1.0,
                 head_y: text_rect.y + text_rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: true,
             },
         });
@@ -1161,6 +1364,7 @@ mod tests {
                 head_x: rect.x + rect.width / 2.0,
                 head_y: rect.y + 4.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: true,
             },
         });
@@ -1223,6 +1427,7 @@ mod tests {
                 head_x,
                 head_y,
                 base_selection: None,
+                unit: None,
                 allow_collapse: true,
             },
         });
@@ -1269,6 +1474,7 @@ mod tests {
                 head_x: text_rect.right() - 1.0,
                 head_y: text_rect.y + text_rect.height / 2.0,
                 base_selection: Some(initial),
+                unit: None,
                 allow_collapse: true,
             },
         });
@@ -1299,6 +1505,7 @@ mod tests {
                 head_x: 9999.0,
                 head_y: 30.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1326,6 +1533,7 @@ mod tests {
                 head_x: 20.0,
                 head_y: -100.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1371,6 +1579,7 @@ mod tests {
                 head_x: rect.rect.right() + 4.0,
                 head_y: rect.rect.y + rect.rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1442,6 +1651,7 @@ mod tests {
                         head_x,
                         head_y,
                         base_selection: None,
+                        unit: None,
                         allow_collapse: false,
                     },
                 });
@@ -1515,6 +1725,7 @@ mod tests {
                     head_x,
                     head_y,
                     base_selection: None,
+                    unit: None,
                     allow_collapse: false,
                 },
             });
@@ -1595,6 +1806,7 @@ mod tests {
                 head_x: rect.rect.right() + 4.0,
                 head_y: rect.rect.y + rect.rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1624,6 +1836,7 @@ mod tests {
                 head_x: 20.0,
                 head_y: -100.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: true,
             },
         });
@@ -1664,6 +1877,7 @@ mod tests {
                 head_x: p1_rect.x + p1_rect.width / 2.0,
                 head_y: (p1_rect.bottom() + p2_rect.y) / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1709,6 +1923,7 @@ mod tests {
                 head_x: p2_rect.x + p2_rect.width / 2.0,
                 head_y: (p1_rect.bottom() + p2_rect.y) / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1749,6 +1964,7 @@ mod tests {
                 head_x: p1_rect.x + p1_rect.width / 2.0,
                 head_y: -100.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1794,6 +2010,7 @@ mod tests {
                 head_x: callout_rect.x + callout_rect.width / 2.0,
                 head_y: (p1_rect.bottom() + p2_rect.y) / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1837,6 +2054,7 @@ mod tests {
                 head_x: p2_metrics.caret.x,
                 head_y: p2_metrics.line.y + p2_metrics.line.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1879,6 +2097,7 @@ mod tests {
                 head_x: line_metrics.caret.x,
                 head_y: line_metrics.line.y + line_metrics.line.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1920,6 +2139,7 @@ mod tests {
                 head_x: callout_rect.x + callout_rect.width / 2.0,
                 head_y: (callout_rect.bottom() + p2_rect.y) / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -1967,6 +2187,7 @@ mod tests {
                 head_x: p2_rect.x + p2_rect.width / 2.0,
                 head_y: (callout_rect.bottom() + p2_rect.y) / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2004,6 +2225,7 @@ mod tests {
                 head_x: cell_rect.x + cell_rect.width / 2.0,
                 head_y: cell_rect.y + cell_rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2056,6 +2278,7 @@ mod tests {
                 head_x: cell_rect.x + cell_rect.width / 2.0,
                 head_y: cell_rect.y + cell_rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2102,6 +2325,7 @@ mod tests {
                 head_x: cell_rect.x + cell_rect.width / 2.0,
                 head_y: cell_rect.y + cell_rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2149,6 +2373,7 @@ mod tests {
                 head_x: cell_rect.x + cell_rect.width / 2.0,
                 head_y: cell_rect.y + cell_rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2196,6 +2421,7 @@ mod tests {
                 head_x,
                 head_y,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2246,6 +2472,7 @@ mod tests {
                 head_x: cell_rect.x + cell_rect.width / 2.0,
                 head_y: cell_rect.y + 4.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2291,6 +2518,7 @@ mod tests {
                 head_x: c01_rect.x + c01_rect.width / 2.0,
                 head_y: c01_rect.y + c01_rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2337,6 +2565,7 @@ mod tests {
                 head_x: table_rect.right() + 1.0,
                 head_y: target_rect.y + target_rect.height / 2.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: true,
             },
         });
@@ -2389,6 +2618,7 @@ mod tests {
                 head_x: table_rect.right() + 1.0,
                 head_y: target_rect.y + target_rect.height / 2.0,
                 base_selection: Some(base_selection),
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2448,6 +2678,7 @@ mod tests {
                 head_x: target_rect.x + target_rect.width / 2.0,
                 head_y: target_rect.y + target_rect.height / 2.0,
                 base_selection: Some(initial),
+                unit: None,
                 allow_collapse: false,
             },
         });
@@ -2488,6 +2719,7 @@ mod tests {
                 head_x: callout_rect.x + callout_rect.width / 2.0,
                 head_y: callout_rect.y + 4.0,
                 base_selection: None,
+                unit: None,
                 allow_collapse: false,
             },
         });

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -186,6 +186,9 @@ pub enum SelectionOp {
         head_x: f32,
         head_y: f32,
         base_selection: Option<Selection>,
+        /// Expand the moving hit to this unit before extending the base range.
+        #[serde(default)]
+        unit: Option<SelectionPointUnit>,
         #[serde(default)]
         allow_collapse: bool,
     },

--- a/crates/editor-core/src/tests/layout_state_input.rs
+++ b/crates/editor-core/src/tests/layout_state_input.rs
@@ -137,6 +137,7 @@ fn extend_to_same_tick_as_remote_structure_tracks_visible_atom_identity() {
             head_x: external.bounds.x + external.bounds.width / 2.0,
             head_y: external.bounds.y + external.bounds.height / 2.0,
             base_selection: None,
+            unit: None,
             allow_collapse: true,
         },
     }]);

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -723,7 +723,7 @@ export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
 export type SelectionKind = "caret" | "unit" | "range";
 
-export type SelectionOp = { type: "set"; selection: Selection } | { type: "set_frozen"; selection: StableSelection } | { type: "unset" } | { type: "set_at"; page: number; x: number; y: number } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor: Position; head_page: number; head_x: number; head_y: number; base_selection: Selection | undefined; allow_collapse?: boolean } | { type: "select_unit_at"; page: number; x: number; y: number; unit: SelectionPointUnit } | { type: "expand"; unit: SelectionExpansionUnit };
+export type SelectionOp = { type: "set"; selection: Selection } | { type: "set_frozen"; selection: StableSelection } | { type: "unset" } | { type: "set_at"; page: number; x: number; y: number } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor: Position; head_page: number; head_x: number; head_y: number; base_selection: Selection | undefined; unit?: SelectionPointUnit | undefined; allow_collapse?: boolean } | { type: "select_unit_at"; page: number; x: number; y: number; unit: SelectionPointUnit } | { type: "expand"; unit: SelectionExpansionUnit };
 
 export type SelectionPointUnit = "word" | "sentence" | "paragraph";
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -873,7 +873,7 @@ export type SelectionExpansionUnit = "word" | "sentence" | "paragraph" | "all";
 
 export type SelectionKind = "caret" | "unit" | "range";
 
-export type SelectionOp = { type: "set"; selection: Selection } | { type: "set_frozen"; selection: StableSelection } | { type: "unset" } | { type: "set_at"; page: number; x: number; y: number } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor: Position; head_page: number; head_x: number; head_y: number; base_selection: Selection | undefined; allow_collapse?: boolean } | { type: "select_unit_at"; page: number; x: number; y: number; unit: SelectionPointUnit } | { type: "expand"; unit: SelectionExpansionUnit };
+export type SelectionOp = { type: "set"; selection: Selection } | { type: "set_frozen"; selection: StableSelection } | { type: "unset" } | { type: "set_at"; page: number; x: number; y: number } | { type: "set_flat"; start: number; end: number } | { type: "extend_to"; anchor: Position; head_page: number; head_x: number; head_y: number; base_selection: Selection | undefined; unit?: SelectionPointUnit | undefined; allow_collapse?: boolean } | { type: "select_unit_at"; page: number; x: number; y: number; unit: SelectionPointUnit } | { type: "expand"; unit: SelectionExpansionUnit };
 
 export type SelectionPointUnit = "word" | "sentence" | "paragraph";
 

--- a/crates/editor-state/src/selection_expansion.rs
+++ b/crates/editor-state/src/selection_expansion.rs
@@ -277,13 +277,17 @@ fn sentence_range_in_text(
 
 fn text_boundaries(text: &str, byte_boundaries: impl Iterator<Item = usize>) -> Vec<usize> {
     let mut boundaries = vec![0];
+    let mut byte_offset = 0;
+    let mut char_offset = 0;
     for boundary in byte_boundaries {
-        let char_boundary = text.nth_byte_char_offset(boundary);
-        if boundaries.last().copied() != Some(char_boundary) {
-            boundaries.push(char_boundary);
+        // Segmenter boundaries are ordered; count each UTF-8 slice only once.
+        char_offset += text[byte_offset..boundary].char_count();
+        byte_offset = boundary;
+        if boundaries.last().copied() != Some(char_offset) {
+            boundaries.push(char_offset);
         }
     }
-    let char_count = text.char_count();
+    let char_count = char_offset + text[byte_offset..].char_count();
     if boundaries.last().copied() != Some(char_count) {
         boundaries.push(char_count);
     }
@@ -320,6 +324,22 @@ mod tests {
     use editor_resource::Resource;
 
     use crate::{Affinity, Position};
+
+    #[test]
+    fn text_boundaries_preserve_unicode_scalar_offsets_and_endpoints() {
+        // ASCII, Hangul, a supplementary-plane emoji, and a combining mark.
+        let text = "a한😀e\u{301}";
+        assert_eq!(
+            text_boundaries(text, [0, 1, 4, 8, 11].into_iter()),
+            vec![0, 1, 2, 3, 5],
+        );
+        assert_eq!(
+            text_boundaries(text, [1, 4, 4, 8].into_iter()),
+            vec![0, 1, 2, 3, 5],
+        );
+        assert_eq!(text_boundaries(text, [].into_iter()), vec![0, 5]);
+        assert_eq!(text_boundaries("", [0, 0].into_iter()), vec![0]);
+    }
 
     fn logs(items: &[(Dot, SeqItem)]) -> DocLogs {
         let mut ev = Vec::new();


### PR DESCRIPTION
웹·앱 에디터에서 마우스·트랙패드로 클릭한 뒤 드래그할 때, 클릭 횟수에 따라 선택 범위를 조절할 수 있도록 합니다.
(macOS나, 여러 에디터에서 기본 동작임)

- 더블 클릭 후 드래그하면 단어 단위로 선택
- 트리플 클릭 후 드래그하면 문단 단위로 선택
- 드래그 방향을 바꾸거나 범위를 줄여도 처음 선택한 단어·문단은 유지
- 단어 경계 계산의 중복 순회를 제거해 긴 문단에서 드래그 성능 개선

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>