### PR TITLE
IME 입력 좌표 처리 오류 수정

### DIFF
--- a/apps/mobile/compose/src/androidHostTest/kotlin/co/typie/editor/input/EditorInputConnectionTest.kt
+++ b/apps/mobile/compose/src/androidHostTest/kotlin/co/typie/editor/input/EditorInputConnectionTest.kt
@@ -1,8 +1,13 @@
 package co.typie.editor.input
 
+import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.SetComposingTextCommand
+import androidx.compose.ui.text.input.SetSelectionCommand
 import co.typie.editor.Editor
 import co.typie.editor.FakeFfiEditor
 import co.typie.editor.ffi.FlatImeOp
+import co.typie.editor.ffi.Ime
+import co.typie.editor.ffi.ImeRange
 import co.typie.editor.ffi.Message
 import co.typie.editor.runtime.EditorUiState
 import co.typie.editor.scroll.EditorBringIntoViewRequests
@@ -19,6 +24,57 @@ import kotlinx.coroutines.cancel
 
 class EditorInputConnectionTest {
   @Test
+  fun `composing reach follows text inserted earlier in the batch`() {
+    val ime =
+      Ime(text = "\u2028\u2029", windowStart = 0, selection = ImeRange(1, 1), composing = null)
+    val dispatched = mutableListOf<List<Message>>()
+    val batch = ImeEditBatch(isSessionCurrent = { true }, currentIme = { ime }) { dispatched += it }
+    val text = "a".repeat(100)
+    batch.beginBatchEdit()
+    batch.enqueue(CommitTextCommand(text, 1))
+    batch.setComposingRegion(100, 101)
+    batch.endBatchEdit()
+    assertEquals<List<List<Message>>>(
+      listOf(
+        listOf(
+          Message.TextInput(
+            listOf(FlatImeOp.ReplaceSelection(text), FlatImeOp.SetComposition(100, 101))
+          )
+        )
+      ),
+      dispatched,
+    )
+  }
+
+  @Test
+  fun `selection conversion sees earlier edits in the Android batch`() {
+    val ime =
+      Ime(text = "\u2028\u2029", windowStart = 0, selection = ImeRange(1, 1), composing = null)
+    val dispatched = mutableListOf<List<Message>>()
+    val batch = ImeEditBatch(isSessionCurrent = { true }, currentIme = { ime }) { dispatched += it }
+    batch.beginBatchEdit()
+    batch.enqueue(CommitTextCommand("😀", 1))
+    batch.enqueue(SetSelectionCommand(1, 3))
+    batch.enqueue(CommitTextCommand("X", 1))
+    assertTrue(dispatched.isEmpty())
+    batch.endBatchEdit()
+    assertEquals<List<List<Message>>>(
+      listOf(
+        listOf(
+          Message.TextInput(
+            listOf(
+              FlatImeOp.ReplaceSelection("😀"),
+              FlatImeOp.SetSelection(1, 2),
+              FlatImeOp.ReplaceSelection("X"),
+            )
+          )
+        )
+      ),
+      dispatched,
+    )
+  }
+
+  @Test
   fun `detached input node rejects a pending batch from its old connection`() {
     val fixture = InputNodeFixture()
     val dispatched = mutableListOf<List<Message>>()
@@ -26,7 +82,7 @@ class EditorInputConnectionTest {
 
     try {
       batch.beginBatchEdit()
-      batch.enqueue(FlatImeOp.Compose("한"))
+      batch.enqueue(SetComposingTextCommand("한", 1))
 
       fixture.node.onDetach()
       batch.endBatchEdit()
@@ -45,7 +101,7 @@ class EditorInputConnectionTest {
 
     try {
       batch.beginBatchEdit()
-      batch.enqueue(FlatImeOp.Compose("한"))
+      batch.enqueue(SetComposingTextCommand("한", 1))
 
       fixture.node.updateInputPolicy(enabled = false, suppressSoftwareKeyboard = false)
       batch.endBatchEdit()
@@ -59,11 +115,12 @@ class EditorInputConnectionTest {
   @Test
   fun `stale connection drops pending batch instead of flushing on close`() {
     val dispatched = mutableListOf<List<Message>>()
-    val batch = ImeEditBatch(isSessionCurrent = { false }) { dispatched += it }
+    val batch =
+      ImeEditBatch(isSessionCurrent = { false }, currentIme = { null }) { dispatched += it }
 
     batch.beginBatchEdit()
-    batch.enqueue(FlatImeOp.Compose("한"))
-    batch.closeConnection(hasActiveComposition = true)
+    batch.enqueue(SetComposingTextCommand("한", 1))
+    batch.closeConnection()
 
     assertTrue(dispatched.isEmpty())
   }
@@ -71,11 +128,12 @@ class EditorInputConnectionTest {
   @Test
   fun `current connection still flushes on close`() {
     val dispatched = mutableListOf<List<Message>>()
-    val batch = ImeEditBatch(isSessionCurrent = { true }) { dispatched += it }
+    val batch =
+      ImeEditBatch(isSessionCurrent = { true }, currentIme = { null }) { dispatched += it }
 
     batch.beginBatchEdit()
-    batch.enqueue(FlatImeOp.Compose("한"))
-    batch.closeConnection(hasActiveComposition = true)
+    batch.enqueue(SetComposingTextCommand("한", 1))
+    batch.closeConnection()
 
     assertEquals(1, dispatched.size)
     val ops = (dispatched.single().single() as Message.TextInput).ops
@@ -106,6 +164,7 @@ class EditorInputConnectionTest {
       val generationAtStart = generationField.getInt(node)
       return ImeEditBatch(
         isSessionCurrent = { generationField.getInt(node) == generationAtStart },
+        currentIme = { null },
         dispatch = { dispatched += it },
       )
     }

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -16,8 +16,17 @@ import android.view.inputmethod.SurroundingText
 import android.view.inputmethod.TextAttribute
 import android.view.inputmethod.TextSnapshot
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
+import androidx.compose.ui.text.input.DeleteSurroundingTextInCodePointsCommand
+import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.FinishComposingTextCommand
+import androidx.compose.ui.text.input.SetComposingRegionCommand
+import androidx.compose.ui.text.input.SetComposingTextCommand
+import androidx.compose.ui.text.input.SetSelectionCommand
 import co.typie.editor.Editor
-import co.typie.editor.ffi.FlatImeOp
+import co.typie.editor.ffi.Ime
+import co.typie.editor.ffi.ImeRange
 import co.typie.editor.ffi.Key
 import co.typie.editor.ffi.KeyEvent as FfiKeyEvent
 import co.typie.editor.ffi.Message
@@ -78,7 +87,7 @@ internal class EditorInputConnection(
   private val onIncomingContent: (IncomingContentCandidates) -> Boolean,
 ) : InputConnection {
   private val batch =
-    ImeEditBatch(isSessionCurrent) { messages ->
+    ImeEditBatch(isSessionCurrent, { editor.appliedState.ime }) { messages ->
       val recorder = editor.inputRecorder
       val imeBefore = if (recorder == null) null else editor.appliedState.ime
       val update = editor.runCallback {
@@ -210,55 +219,46 @@ internal class EditorInputConnection(
   override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
     val value = text?.toString() ?: return false
     recordCall("commitText", "text=$value, newCursorPosition=$newCursorPosition")
-    if (value == "\n") {
-      batch.enqueue(Message.Key(FfiKeyEvent(Key.Enter)))
-    } else {
-      batch.commitText(value)
-    }
+    batch.enqueue(CommitTextCommand(value, newCursorPosition))
     return true
   }
 
   override fun setComposingText(text: CharSequence?, newCursorPosition: Int): Boolean {
     val value = text?.toString() ?: return false
     recordCall("setComposingText", "text=$value, newCursorPosition=$newCursorPosition")
-    batch.enqueue(FlatImeOp.Compose(value))
+    batch.enqueue(SetComposingTextCommand(value, newCursorPosition))
     return true
   }
 
   override fun setComposingRegion(start: Int, end: Int): Boolean {
     recordCall("setComposingRegion", "start=$start, end=$end")
-    when (val decision = resolveComposingRegion(editor.appliedState.ime, start, end)) {
-      is ComposingRegionDecision.Set ->
-        batch.enqueue(FlatImeOp.SetComposition(decision.start, decision.end))
-      ComposingRegionDecision.Clear -> batch.enqueue(FlatImeOp.ClearComposition)
-    }
+    batch.setComposingRegion(start, end)
     return true
   }
 
   override fun finishComposingText(): Boolean {
     recordCall("finishComposingText", "")
-    batch.finishComposingText(hasActiveComposition = editor.appliedState.ime?.composing != null)
+    batch.enqueue(FinishComposingTextCommand())
     return true
   }
 
   override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
     recordCall("deleteSurroundingText", "before=$beforeLength, after=$afterLength")
-    batch.enqueue(FlatImeOp.DeleteSurroundingUtf16(beforeLength, afterLength))
+    if (beforeLength < 0 || afterLength < 0) return false
+    batch.enqueue(DeleteSurroundingTextCommand(beforeLength, afterLength))
     return true
   }
 
   override fun deleteSurroundingTextInCodePoints(beforeLength: Int, afterLength: Int): Boolean {
     recordCall("deleteSurroundingTextInCodePoints", "before=$beforeLength, after=$afterLength")
-    batch.enqueue(FlatImeOp.DeleteSurrounding(beforeLength, afterLength))
+    if (beforeLength < 0 || afterLength < 0) return false
+    batch.enqueue(DeleteSurroundingTextInCodePointsCommand(beforeLength, afterLength))
     return true
   }
 
   override fun setSelection(start: Int, end: Int): Boolean {
     recordCall("setSelection", "start=$start, end=$end")
-    val ctx = editor.appliedState.ime ?: return true
-    batch.enqueue(
-      FlatImeOp.SetSelection(ctx.projectWindowUtf16Index(start), ctx.projectWindowUtf16Index(end))
-    )
+    batch.enqueue(SetSelectionCommand(start, end))
     return true
   }
 
@@ -306,7 +306,7 @@ internal class EditorInputConnection(
   override fun closeConnection() {
     recordCall("closeConnection", "")
     extractMonitor.token = null
-    batch.closeConnection(hasActiveComposition = editor.appliedState.ime?.composing != null)
+    batch.closeConnection()
   }
 
   override fun commitContent(
@@ -412,10 +412,12 @@ internal fun ImeExtract.toExtractedText(): ExtractedText =
 
 internal class ImeEditBatch(
   private val isSessionCurrent: () -> Boolean,
+  private val currentIme: () -> Ime?,
   private val dispatch: (List<Message>) -> Unit,
 ) {
   private var batchLevel = 0
-  private val pendingOps = mutableListOf<FlatImeOp>()
+  private var imeBefore: Ime? = null
+  private val pendingCommands = mutableListOf<EditCommand>()
   private val pendingMessages = mutableListOf<Message>()
 
   fun beginBatchEdit(): Boolean {
@@ -429,51 +431,50 @@ internal class ImeEditBatch(
     return batchLevel > 0
   }
 
-  fun finishComposingText(hasActiveComposition: Boolean) {
-    pendingOps.add(
-      if (hasActiveComposition || hasPendingCompositionUpdate()) {
-        FlatImeOp.CommitAsIs
-      } else {
-        FlatImeOp.ClearComposition
-      }
-    )
-    flushIfReady()
-  }
-
-  fun closeConnection(hasActiveComposition: Boolean) {
+  fun closeConnection() {
+    if (pendingCommands.isEmpty()) imeBefore = currentIme()
+    pendingCommands.add(FinishComposingTextCommand())
     batchLevel = 0
-    if ((hasActiveComposition || hasPendingCompositionUpdate()) && !hasPendingCommitAsIs()) {
-      pendingOps.add(FlatImeOp.CommitAsIs)
-    } else if (!hasPendingCommitAsIs()) {
-      pendingOps.add(FlatImeOp.ClearComposition)
-    }
     flush()
   }
 
-  fun commitText(text: String) {
-    // The editor has no inline newline: multi-line commits (e.g. keyboard
-    // clipboard suggestions) become paragraph splits via the enter key path.
-    val segments = text.replace("\r\n", "\n").replace('\r', '\n').split("\n")
-    segments.forEachIndexed { index, segment ->
-      if (index > 0) {
-        flushOpsToPendingMessages()
-        pendingMessages.add(Message.Key(FfiKeyEvent(Key.Enter)))
-      }
-      if (segment.isNotEmpty() || index == 0) {
-        pendingOps.add(FlatImeOp.Compose(segment))
-        pendingOps.add(FlatImeOp.CommitAsIs)
-      }
+  fun setComposingRegion(start: Int, end: Int) {
+    val initial = if (pendingCommands.isEmpty()) currentIme() else imeBefore
+    val ime = initial?.let {
+      val value = it.toEditProcessor().apply(pendingCommands)
+      fun offset(index: Int) = it.windowStart + value.text.codePointOffsetAtUtf16Index(index)
+      Ime(
+        text = value.text,
+        windowStart = it.windowStart,
+        selection = ImeRange(offset(value.selection.min), offset(value.selection.max)),
+        composing =
+          value.composition?.let { range -> ImeRange(offset(range.min), offset(range.max)) },
+      )
     }
-    flushIfReady()
+    // Preserve Android's stale-window guard, but evaluate it against the
+    // buffer after earlier commands in this batch, not the old engine snapshot.
+    val command =
+      when (val region = resolveComposingRegion(ime, start, end)) {
+        ComposingRegionDecision.Clear -> SetComposingRegionCommand(0, 0)
+        is ComposingRegionDecision.Set -> {
+          requireNotNull(ime)
+          SetComposingRegionCommand(
+            ime.text.utf16IndexAtCodePointOffset(region.start - ime.windowStart),
+            ime.text.utf16IndexAtCodePointOffset(region.end - ime.windowStart),
+          )
+        }
+      }
+    enqueue(command)
   }
 
-  fun enqueue(op: FlatImeOp) {
-    pendingOps.add(op)
+  fun enqueue(command: EditCommand) {
+    if (pendingCommands.isEmpty()) imeBefore = currentIme()
+    pendingCommands.add(command)
     flushIfReady()
   }
 
   fun enqueue(message: Message) {
-    flushOpsToPendingMessages()
+    flushCommandsToPendingMessages()
     pendingMessages.add(message)
     flushIfReady()
   }
@@ -483,41 +484,25 @@ internal class ImeEditBatch(
   }
 
   private fun flush() {
-    flushOpsToPendingMessages()
-    if (pendingMessages.isEmpty()) return
-
     if (!isSessionCurrent()) {
+      pendingCommands.clear()
       pendingMessages.clear()
+      imeBefore = null
       return
     }
+
+    flushCommandsToPendingMessages()
+    if (pendingMessages.isEmpty()) return
 
     val messages = pendingMessages.toList()
     pendingMessages.clear()
     dispatch(messages)
   }
 
-  private fun flushOpsToPendingMessages() {
-    if (pendingOps.isEmpty()) return
-    pendingMessages.add(Message.TextInput(pendingOps.toList()))
-    pendingOps.clear()
+  private fun flushCommandsToPendingMessages() {
+    if (pendingCommands.isEmpty()) return
+    pendingMessages.addAll(EditorImeCommandNormalizer.normalize(pendingCommands, imeBefore))
+    pendingCommands.clear()
+    imeBefore = null
   }
-
-  private fun hasPendingCompositionUpdate(): Boolean =
-    pendingOps.any { it.startsOrUpdatesComposition() } ||
-      pendingMessages.any { message ->
-        message is Message.TextInput && message.ops.any { it.startsOrUpdatesComposition() }
-      }
-
-  private fun hasPendingCommitAsIs(): Boolean =
-    pendingOps.any { it == FlatImeOp.CommitAsIs } ||
-      pendingMessages.any { message ->
-        message is Message.TextInput && message.ops.any { it == FlatImeOp.CommitAsIs }
-      }
-
-  private fun FlatImeOp.startsOrUpdatesComposition(): Boolean =
-    when (this) {
-      is FlatImeOp.Compose,
-      is FlatImeOp.SetComposition -> true
-      else -> false
-    }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
 import androidx.compose.ui.text.input.DeleteSurroundingTextInCodePointsCommand
 import androidx.compose.ui.text.input.EditCommand
-import androidx.compose.ui.text.input.EditingBuffer
 import androidx.compose.ui.text.input.FinishComposingTextCommand
 import androidx.compose.ui.text.input.MoveCursorCommand
 import androidx.compose.ui.text.input.SetComposingRegionCommand
@@ -13,8 +12,6 @@ import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.SetSelectionCommand
 import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Ime
-import co.typie.editor.ffi.Key
-import co.typie.editor.ffi.KeyEvent
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.NavigationOp
 import co.typie.editor.ffi.SelectionOp
@@ -34,51 +31,34 @@ internal object EditorImeCommandNormalizer {
       }
     }
 
-    val messages = mutableListOf<Message>()
     val ops = mutableListOf<FlatImeOp>()
     var hasActiveComposition = ime?.composing != null
-    val buffer =
-      ime?.toTextFieldValue()?.let { value ->
-        EditingBuffer(value.annotatedString, value.selection).also { buffer ->
-          value.composition?.let { SetComposingRegionCommand(it.min, it.max).applyTo(buffer) }
-        }
-      }
-    fun flushOps() {
-      if (ops.isEmpty()) return
-      messages += Message.TextInput(ops.toList())
-      ops.clear()
-    }
-
+    val buffer = ime?.toEditProcessor()
     for (command in commands) {
       // Coordinates refer to the text after preceding commands, not the initial IME snapshot.
-      val windowText = buffer?.toString().orEmpty()
-      buffer?.let(command::applyTo)
+      val windowText = buffer?.toTextFieldValue()?.text.orEmpty()
+      val valueAfter = buffer?.apply(listOf(command))
       if (command is CommitTextCommand) {
-        val text = command.text.replace("\r\n", "\n").replace('\r', '\n')
-        if (text == "\n") {
-          flushOps()
-
-          messages += Message.Key(KeyEvent(Key.Enter))
-          continue
+        // Keep the native text (including CR/LF) intact. Later coordinates
+        // address this buffer; only the engine knows the resulting paragraphs.
+        if (hasActiveComposition) {
+          ops += FlatImeOp.Compose(command.text)
+          ops += FlatImeOp.CommitAsIs
+        } else {
+          ops += FlatImeOp.ReplaceSelection(command.text)
         }
-        // The editor has no inline newline: multi-line commits become
-        // paragraph splits via the enter key path.
-        text.split("\n").forEachIndexed { index, segment ->
-          if (index > 0) {
-            flushOps()
-            messages += Message.Key(KeyEvent(Key.Enter))
-          }
-          if (segment.isNotEmpty() || index == 0) {
-            // commitText replaces an active preedit, but otherwise it is a committed
-            // selection replacement and must stay inside the native edit transaction.
-            if (hasActiveComposition) {
-              ops += FlatImeOp.Compose(segment)
-              ops += FlatImeOp.CommitAsIs
-            } else {
-              ops += FlatImeOp.ReplaceSelection(segment)
-            }
-            hasActiveComposition = false
-          }
+        hasActiveComposition = false
+        if (
+          command.newCursorPosition != 1 &&
+            !(command.newCursorPosition == 0 && command.text.isEmpty()) &&
+            valueAfter != null
+        ) {
+          val text = valueAfter.text
+          ops +=
+            FlatImeOp.SetSelection(
+              ime.windowStart + text.codePointOffsetAtUtf16Index(valueAfter.selection.min),
+              ime.windowStart + text.codePointOffsetAtUtf16Index(valueAfter.selection.max),
+            )
         }
         continue
       }
@@ -94,6 +74,16 @@ internal object EditorImeCommandNormalizer {
           command.toFlatImeOp(ime, windowText)
         } ?: continue
       ops += op
+      if (
+        command is SetComposingTextCommand && command.newCursorPosition != 1 && valueAfter != null
+      ) {
+        val text = valueAfter.text
+        ops +=
+          FlatImeOp.SetSelection(
+            ime.windowStart + text.codePointOffsetAtUtf16Index(valueAfter.selection.min),
+            ime.windowStart + text.codePointOffsetAtUtf16Index(valueAfter.selection.max),
+          )
+      }
       hasActiveComposition =
         when (op) {
           is FlatImeOp.Compose,
@@ -104,9 +94,7 @@ internal object EditorImeCommandNormalizer {
         }
     }
 
-    flushOps()
-
-    return messages
+    return if (ops.isEmpty()) emptyList() else listOf(Message.TextInput(ops))
   }
 
   private fun List<EditCommand>.resolveSelectionOnlyMessages(ime: Ime?): List<Message>? {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeTextFieldValue.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeTextFieldValue.kt
@@ -1,8 +1,19 @@
 package co.typie.editor.input
 
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.EditProcessor
+import androidx.compose.ui.text.input.SetComposingRegionCommand
 import androidx.compose.ui.text.input.TextFieldValue
 import co.typie.editor.ffi.Ime
+
+internal fun Ime.toEditProcessor(): EditProcessor {
+  val value = toTextFieldValue()
+  return EditProcessor().also { processor ->
+    // reset intentionally clears composition when replacing its text buffer.
+    processor.reset(value.copy(composition = null), null)
+    value.composition?.let { processor.apply(listOf(SetComposingRegionCommand(it.min, it.max))) }
+  }
+}
 
 internal fun Ime.toTextFieldValue(): TextFieldValue =
   TextFieldValue(

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
@@ -10,8 +10,6 @@ import co.typie.editor.ffi.Direction
 import co.typie.editor.ffi.FlatImeOp
 import co.typie.editor.ffi.Ime
 import co.typie.editor.ffi.ImeRange
-import co.typie.editor.ffi.Key
-import co.typie.editor.ffi.KeyEvent
 import co.typie.editor.ffi.Message
 import co.typie.editor.ffi.Movement
 import co.typie.editor.ffi.NavigationOp
@@ -20,6 +18,29 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class EditorImeCommandNormalizerTest {
+  @Test
+  fun `commit cursor position is retained before a later edit`() {
+    val ime =
+      Ime(text = "\u2028\u2029", windowStart = 0, selection = ImeRange(1, 1), composing = null)
+    val messages =
+      EditorImeCommandNormalizer.normalize(
+        listOf(CommitTextCommand("a\nb", 0), CommitTextCommand("X", 1)),
+        ime,
+      )
+    assertEquals(
+      listOf(
+        Message.TextInput(
+          listOf(
+            FlatImeOp.ReplaceSelection("a\nb"),
+            FlatImeOp.SetSelection(1, 1),
+            FlatImeOp.ReplaceSelection("X"),
+          )
+        )
+      ),
+      messages,
+    )
+  }
+
   @Test
   fun `selection after marked text uses the new text length`() {
     val ime = Ime(text = "", windowStart = 10, selection = ImeRange(10, 10), composing = null)
@@ -127,40 +148,31 @@ class EditorImeCommandNormalizerTest {
   }
 
   @Test
-  fun `newline commit normalizes to enter key`() {
+  fun `newline commit remains inside the input batch`() {
     val messages =
       EditorImeCommandNormalizer.normalize(listOf(CommitTextCommand("\n", 1)), ime = null)
 
-    assertEquals(listOf(Message.Key(KeyEvent(Key.Enter))), messages)
+    assertEquals(listOf(Message.TextInput(listOf(FlatImeOp.ReplaceSelection("\n")))), messages)
   }
 
   @Test
-  fun `multi-line commit splits into paragraphs via enter keys`() {
+  fun `multi-line commit preserves the input text for the engine`() {
     val messages =
       EditorImeCommandNormalizer.normalize(listOf(CommitTextCommand("foo\nbar", 1)), ime = null)
 
     assertEquals(
-      listOf(
-        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("foo"))),
-        Message.Key(KeyEvent(Key.Enter)),
-        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("bar"))),
-      ),
+      listOf(Message.TextInput(listOf(FlatImeOp.ReplaceSelection("foo\nbar")))),
       messages,
     )
   }
 
   @Test
-  fun `multi-line commit normalizes carriage returns and keeps empty lines`() {
+  fun `multi-line commit keeps carriage returns in the coordinate buffer`() {
     val messages =
       EditorImeCommandNormalizer.normalize(listOf(CommitTextCommand("a\r\n\rb", 1)), ime = null)
 
     assertEquals(
-      listOf(
-        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("a"))),
-        Message.Key(KeyEvent(Key.Enter)),
-        Message.Key(KeyEvent(Key.Enter)),
-        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("b"))),
-      ),
+      listOf(Message.TextInput(listOf(FlatImeOp.ReplaceSelection("a\r\n\rb")))),
       messages,
     )
   }
@@ -173,11 +185,7 @@ class EditorImeCommandNormalizerTest {
       EditorImeCommandNormalizer.normalize(listOf(CommitTextCommand("\nfoo", 1)), ime = ime)
 
     assertEquals(
-      listOf(
-        Message.TextInput(listOf(FlatImeOp.Compose(""), FlatImeOp.CommitAsIs)),
-        Message.Key(KeyEvent(Key.Enter)),
-        Message.TextInput(listOf(FlatImeOp.ReplaceSelection("foo"))),
-      ),
+      listOf(Message.TextInput(listOf(FlatImeOp.Compose("\nfoo"), FlatImeOp.CommitAsIs))),
       messages,
     )
   }

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorImeCoordinateContractTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorImeCoordinateContractTest.kt
@@ -1,0 +1,27 @@
+package co.typie.editor.input
+
+import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.SetSelectionCommand
+import co.typie.editor.ffi.Ime
+import co.typie.editor.ffi.ImeRange
+import co.typie.editor.ffi.Message
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+
+class EditorImeCoordinateContractTest {
+  @Test
+  fun `multiline selection messages match the Rust integration fixture`() {
+    val ime =
+      Ime(text = "\u2028\u2029", windowStart = 0, selection = ImeRange(1, 1), composing = null)
+    val messages =
+      EditorImeCommandNormalizer.normalize(
+        listOf(CommitTextCommand("a\nb", 1), SetSelectionCommand(4, 4), CommitTextCommand("X", 1)),
+        ime,
+      )
+    val fixture =
+      File("../../../crates/editor-core/src/tests/fixtures/ime-multiline-selection.json").readText()
+    assertEquals(Json.decodeFromString<List<Message>>(fixture), messages)
+  }
+}

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
@@ -82,7 +82,7 @@ describe('ImeInputAdapter', () => {
     ]);
   });
 
-  it('splits a multi-line text insertion into paragraph splits via enter keys', () => {
+  it('keeps a multi-line text insertion in one input-coordinate batch', () => {
     const harness = createImeHarness(context(''));
 
     harness.beforeTextInput('a\nb');
@@ -93,18 +93,13 @@ describe('ImeInputAdapter', () => {
         type: 'text_input',
         ops: [
           { type: 'set_selection', start: 20, end: 20 },
-          { type: 'replace_selection', text: 'a' },
+          { type: 'replace_selection', text: 'a\nb' },
         ],
-      },
-      { type: 'key', event: { key: 'enter' } },
-      {
-        type: 'text_input',
-        ops: [{ type: 'replace_selection', text: 'b' }],
       },
     ]);
   });
 
-  it('normalizes carriage returns and keeps empty lines in multi-line insertions', () => {
+  it('uses the textarea-normalized newlines as its coordinate buffer', () => {
     const harness = createImeHarness(context(''));
 
     harness.beforeTextInput('a\r\n\rb');
@@ -115,14 +110,8 @@ describe('ImeInputAdapter', () => {
         type: 'text_input',
         ops: [
           { type: 'set_selection', start: 20, end: 20 },
-          { type: 'replace_selection', text: 'a' },
+          { type: 'replace_selection', text: 'a\n\nb' },
         ],
-      },
-      { type: 'key', event: { key: 'enter' } },
-      { type: 'key', event: { key: 'enter' } },
-      {
-        type: 'text_input',
-        ops: [{ type: 'replace_selection', text: 'b' }],
       },
     ]);
   });

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
@@ -321,19 +321,12 @@ export class ImeInputAdapter {
       isCollapsedRange(intent.replacementCandidate)
         ? intent.replacementCandidate
         : { start: diff.start, end: diff.end };
-    // The editor has no inline newline: multi-line insertions become
-    // paragraph splits via the enter key path.
-    const segments = diff.insertedText.replaceAll('\r\n', '\n').replaceAll('\r', '\n').split('\n');
+    // Coordinates refer to the input buffer. Paragraph creation and CR/LF
+    // normalization belong to the engine that applies the replacement.
     const messages = textInputMessage([
       { type: 'set_selection', start: replacement.start, end: replacement.end },
-      { type: 'replace_selection', text: segments[0] },
+      { type: 'replace_selection', text: diff.insertedText },
     ]);
-    for (const segment of segments.slice(1)) {
-      messages.push({ type: 'key', event: { key: 'enter' } });
-      if (segment.length > 0) {
-        messages.push(...textInputMessage([{ type: 'replace_selection', text: segment }]));
-      }
-    }
     this.#deps.enqueue(messages);
     this.#context = updateContextFromInputElement(context, input, null);
   }

--- a/apps/website/src/lib/editor-ffi/input/ime-text-replacement.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-text-replacement.browser.test.ts
@@ -30,10 +30,10 @@ describe('web IME text replacement', () => {
   let editor: Editor | undefined;
   let mounted: Record<string, unknown> | undefined;
 
-  const mountEditor = async (): Promise<{ editor: Editor; input: HTMLTextAreaElement }> => {
+  const mountEditor = async (initialDoc = doc(''), position = 1): Promise<{ editor: Editor; input: HTMLTextAreaElement }> => {
     const host = await initWasm();
     host.set_text_replacement_rules([{ id: 'cry-to-laugh', matchPattern: 'ㅠㅠ', substitute: '하하하', regex: false }]);
-    const mountedEditor = await Editor.createFromDoc(doc(''), { width: 320, height: 180, scale_factor: 1 });
+    const mountedEditor = await Editor.createFromDoc(initialDoc, { width: 320, height: 180, scale_factor: 1 });
     editor = mountedEditor;
 
     const target = document.createElement('div');
@@ -44,7 +44,7 @@ describe('web IME text replacement', () => {
     });
     await tick();
     mountedEditor.updateNow(() => {
-      mountedEditor.enqueue({ type: 'selection', op: { type: 'set_flat', start: 1, end: 1 } });
+      mountedEditor.enqueue({ type: 'selection', op: { type: 'set_flat', start: position, end: position } });
       mountedEditor.enqueue({ type: 'system', event: { type: 'set_focused', focused: true } });
     });
     await tick();
@@ -56,6 +56,16 @@ describe('web IME text replacement', () => {
   };
 
   const imeEvents = (input: HTMLTextAreaElement) => ({
+    insertText: (text: string) => {
+      const accepted = input.dispatchEvent(
+        new InputEvent('beforeinput', { inputType: 'insertText', data: text, bubbles: true, cancelable: true }),
+      );
+      expect(accepted).toBe(true);
+      // Synthetic beforeinput does not perform the native textarea mutation.
+      // The production input handler and WASM engine remain responsible for the edit.
+      input.setRangeText(text, input.selectionStart, input.selectionEnd, 'end');
+      input.dispatchEvent(new InputEvent('input', { inputType: 'insertText', data: text, bubbles: true }));
+    },
     composition: (type: 'compositionstart' | 'compositionupdate' | 'compositionend', data: string) =>
       input.dispatchEvent(new CompositionEvent(type, { data, bubbles: true })),
     beforeCompositionInput: (data: string) =>
@@ -95,6 +105,128 @@ describe('web IME text replacement', () => {
     const host = await initWasm();
     host.set_text_replacement_rules([]);
     document.body.replaceChildren();
+  });
+
+  it.each([
+    // Prose export separates paragraphs with a blank line; IME text preserves every block boundary.
+    { text: 'a\nb', prose: 'a\n\nb', buffer: '\u{2028}a\u{2029}\u{2028}b\u{2029}', caret: 5 },
+    { text: 'a\r\n\r😀b', prose: 'a\n\n😀b', buffer: '\u{2028}a\u{2029}\u{2028}\u{2029}\u{2028}😀b\u{2029}', caret: 8 },
+  ])('syncs paragraph coordinates after native insertion of $text', async ({ text, prose, buffer, caret }) => {
+    const { editor, input } = await mountEditor();
+    const events = imeEvents(input);
+
+    events.insertText(text);
+    await tick();
+
+    expect(editor.proseText()).toBe(prose);
+    expect(editor.ime(100, 100)).toMatchObject({ text: buffer, selection: { start: caret, end: caret } });
+    expect(input.value).toBe(buffer);
+    expect(input.selectionStart).toBe(buffer.length - 1);
+    expect(input.selectionEnd).toBe(buffer.length - 1);
+
+    events.insertText('X');
+    await tick();
+
+    expect(editor.proseText()).toBe(`${prose}X`);
+    expect(editor.ime(100, 100)?.selection).toEqual({ start: caret + 1, end: caret + 1 });
+    expect(input.value).toBe(`${buffer.slice(0, -1)}X\u{2029}`);
+  });
+
+  it('composes and converts Japanese in the paragraph created by a native multiline insertion', async () => {
+    const { editor, input } = await mountEditor();
+    const events = imeEvents(input);
+
+    events.insertText('a\nb');
+    await tick();
+    events.composition('compositionstart', '');
+    events.composition('compositionupdate', 'に');
+    events.beforeCompositionInput('に');
+    events.applyNativeInput('\u{2028}a\u{2029}\u{2028}bに\u{2029}', 6, 'insertCompositionText', 'に');
+    await tick();
+
+    expect(editor.proseText()).toBe('a\n\nbに');
+    expect(editor.ime(100, 100)?.composing).toEqual({ start: 5, end: 6 });
+
+    events.composition('compositionupdate', '日本語');
+    events.beforeCompositionInput('日本語');
+    events.applyNativeInput('\u{2028}a\u{2029}\u{2028}b日本語\u{2029}', 8, 'insertCompositionText', '日本語');
+    events.composition('compositionend', '日本語');
+    await tick();
+    events.insertText('X');
+    await tick();
+
+    expect(editor.proseText()).toBe('a\n\nb日本語X');
+    expect(editor.ime(100, 100)).toMatchObject({ selection: { start: 9, end: 9 }, composing: undefined });
+    expect(input.value).toBe('\u{2028}a\u{2029}\u{2028}b日本語X\u{2029}');
+    expect(input.selectionStart).toBe(9);
+  });
+
+  it('replaces a selection with multiple paragraphs and keeps the suffix after the caret', async () => {
+    const { editor, input } = await mountEditor(doc('leftOLDright'), 5);
+    const events = imeEvents(input);
+
+    input.setSelectionRange(5, 8);
+    events.insertText('a\nb');
+    await tick();
+    expect(editor.proseText()).toBe('lefta\n\nbright');
+    expect(input.selectionStart).toBe(9);
+    expect(input.selectionEnd).toBe(9);
+
+    events.insertText('X');
+    await tick();
+    expect(editor.proseText()).toBe('lefta\n\nbXright');
+    expect(editor.ime(100, 100)?.selection).toEqual({ start: 10, end: 10 });
+  });
+
+  it('materializes paragraphs before an image and preserves the following text during native input', async () => {
+    const initialDoc = doc('tail');
+    initialDoc.root.children.unshift(entry({ type: 'image', id: 'asset', proportion: 100 }));
+    const { editor, input } = await mountEditor(initialDoc, 0);
+    const events = imeEvents(input);
+    editor.updateNow(() => {
+      editor.enqueue({ type: 'navigation', op: { type: 'move', movement: { type: 'document', direction: 'backward' }, extend: false } });
+    });
+    await tick();
+    expect(editor.appliedSnapshot.selection?.head).toMatchObject({ offset: 0, affinity: 'upstream' });
+
+    events.insertText('a\nb');
+    await tick();
+    events.insertText('X');
+    await tick();
+
+    expect(editor.proseText()).toBe('a\n\nbX\n\ntail');
+    expect(editor.appliedSnapshot.externalElements.map(({ data }) => data)).toEqual([{ type: 'image', id: 'asset', proportion: 100 }]);
+    expect(editor.ime(100, 100)?.selection).toEqual({ start: 6, end: 6 });
+    expect(input.selectionStart).toBe(6);
+  });
+
+  it('resolves input-buffer selection and composition across a commit barrier in the real WASM engine', async () => {
+    const { editor, input } = await mountEditor();
+
+    // Browser input events do not expose Compose's multi-command batch. Exercise
+    // that shared contract separately, including the shipped WASM FFI boundary.
+    editor.updateNow(() => {
+      editor.enqueue({
+        type: 'text_input',
+        ops: [
+          { type: 'replace_selection', text: 'a\n😀b' },
+          { type: 'commit_as_is' },
+          { type: 'set_composition', start: 4, end: 5 },
+          { type: 'compose', text: 'に' },
+          { type: 'set_selection', start: 4, end: 4 },
+        ],
+      });
+    });
+    await tick();
+
+    expect(editor.ime(100, 100)).toMatchObject({
+      text: '\u{2028}a\u{2029}\u{2028}😀に\u{2029}',
+      selection: { start: 5, end: 5 },
+      composing: { start: 5, end: 6 },
+    });
+    expect(input.value).toBe('\u{2028}a\u{2029}\u{2028}😀に\u{2029}');
+    expect(input.selectionStart).toBe(6);
+    expect(input.selectionEnd).toBe(6);
   });
 
   it('replaces a Korean match when macOS appends Space to the final composition update', async () => {

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -1534,26 +1534,13 @@ impl Editor {
         ime_failed: &mut bool,
         changes: &mut TickChanges,
     ) -> Result<(), EditorError> {
-        let mut messages: VecDeque<_> = messages.into();
-        while let Some(message) = messages.pop_front() {
-            let mut consumed = 1;
+        for message in messages {
             let mut outcome = CommandOutcome::Applied;
             let result: Result<(), EditorError> = match message {
-                // Coalesce composition updates until a committed message boundary.
-                // `handle_flat_ime_ops` still preserves barriers inside one message,
-                // while stopping here keeps per-message failure outcomes truthful.
+                // One message is one input-coordinate buffer. A later message
+                // starts in document coordinates, so concatenating its ops would
+                // silently change what its positions refer to.
                 Message::TextInput { ops } => {
-                    let mut batch = ops;
-                    while matches!(messages.front(), Some(Message::TextInput { .. }))
-                        && !batch.iter().any(|op| matches!(op, FlatImeOp::CommitAsIs))
-                    {
-                        if let Message::TextInput { ops } =
-                            messages.pop_front().expect("matched text input message")
-                        {
-                            batch.extend(ops);
-                            consumed += 1;
-                        }
-                    }
                     if *ime_failed {
                         log::warn!(
                             "dropping text input batch queued after an absorbed ime failure"
@@ -1561,8 +1548,7 @@ impl Editor {
                         outcome = CommandOutcome::Rejected {
                             reason: CommandRejection::InvalidArgument,
                         };
-                    } else if let Err(e) =
-                        self.process_message(Message::TextInput { ops: batch }, changes)
+                    } else if let Err(e) = self.process_message(Message::TextInput { ops }, changes)
                     {
                         if is_illegal_slot(&e) {
                             log::warn!(
@@ -1620,7 +1606,7 @@ impl Editor {
                     return Err(error);
                 }
             }
-            command_outcomes.extend(std::iter::repeat_n(outcome, consumed));
+            command_outcomes.push(outcome);
         }
         Ok(())
     }
@@ -2932,13 +2918,10 @@ mod tests {
         );
     }
 
-    // A frame's worth of IME composition traffic arrives as several consecutive
-    // `TextInput` messages; `tick` coalesces them into batched reduces. The
-    // coalesced drain must land on the same document, composition, and selection
-    // as ticking each message separately. `CommitAsIs` remains an execution
-    // barrier inside the combined flat-op vector.
+    // Draining a frame's composition messages together must preserve the
+    // document, composition and selection produced by ticking them separately.
     #[test]
-    fn tick_coalesces_consecutive_text_input_messages() {
+    fn tick_preserves_consecutive_text_input_message_boundaries() {
         let (state, ..) = state! {
             doc { root { p1: paragraph { text("ab") } } }
             selection: (p1, 2)

--- a/crates/editor-core/src/handle/key.rs
+++ b/crates/editor-core/src/handle/key.rs
@@ -6,7 +6,7 @@ use editor_transaction::HistoryMeta;
 
 use crate::editor::Editor;
 use crate::error::EditorError;
-use crate::handle::paragraph_break::apply_list_paragraph_break;
+use crate::handle::paragraph_break::apply_paragraph_break;
 use crate::message::*;
 
 pub fn handle_key_event(editor: &mut Editor, event: KeyEvent) -> Result<(), EditorError> {
@@ -26,33 +26,7 @@ pub fn handle_key_event(editor: &mut Editor, event: KeyEvent) -> Result<(), Edit
             Ok(())
         }),
         (Key::Enter, _) => editor.transact(|tr| {
-            let applied = commands::chain!(
-                tr,
-                commands::optional!(commands::materialize_synthetic_selection_blocks()),
-                |tr| commands::first!(
-                    tr,
-                    commands::materialize_gap_paragraph(),
-                    commands::insert_paragraph_after_unit_selection(),
-                    |tr| {
-                        let selection_was_range = tr
-                            .selection()
-                            .is_some_and(|selection| !selection.is_collapsed());
-                        commands::chain!(
-                            tr,
-                            commands::optional!(commands::delete_selection()),
-                            |tr| commands::first!(
-                                tr,
-                                |tr| apply_list_paragraph_break(tr, selection_was_range),
-                                commands::lift_last_paragraph(),
-                                commands::split_paragraph(),
-                            ),
-                        )
-                    },
-                ),
-            )?;
-            if applied {
-                tr.clear_pending_format()?;
-            }
+            apply_paragraph_break(tr)?;
             Ok(())
         }),
         (Key::Backspace, _) if editor.try_undo_auto_replacement() => {

--- a/crates/editor-core/src/handle/paragraph_break.rs
+++ b/crates/editor-core/src/handle/paragraph_break.rs
@@ -1,6 +1,37 @@
 use editor_commands::{self as commands, CommandResult};
 use editor_transaction::Transaction;
 
+pub(super) fn apply_paragraph_break(tr: &mut Transaction) -> CommandResult {
+    let applied = commands::chain!(
+        tr,
+        commands::optional!(commands::materialize_synthetic_selection_blocks()),
+        |tr| commands::first!(
+            tr,
+            commands::materialize_gap_paragraph(),
+            commands::insert_paragraph_after_unit_selection(),
+            |tr| {
+                let selection_was_range = tr
+                    .selection()
+                    .is_some_and(|selection| !selection.is_collapsed());
+                commands::chain!(
+                    tr,
+                    commands::optional!(commands::delete_selection()),
+                    |tr| commands::first!(
+                        tr,
+                        |tr| apply_list_paragraph_break(tr, selection_was_range),
+                        commands::lift_last_paragraph(),
+                        commands::split_paragraph(),
+                    ),
+                )
+            },
+        ),
+    )?;
+    if applied {
+        tr.clear_pending_format()?;
+    }
+    Ok(applied)
+}
+
 pub(super) fn apply_list_paragraph_break(
     tr: &mut Transaction,
     selection_was_range: bool,

--- a/crates/editor-core/src/handle/text_input.rs
+++ b/crates/editor-core/src/handle/text_input.rs
@@ -3,18 +3,120 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use editor_commands::{self as commands, CommandError, CommandResult};
-use editor_common::{HistoryTag, StrExt};
+use editor_common::HistoryTag;
 use editor_model::{DocView, Modifier, ModifierType};
 use editor_state::{
-    Composition, FLAT_CLOSE, FLAT_OPEN, FlatSegment, Position, ProjectedState, ResolvedPosition,
-    ResolvedPositionFlatExt, Selection, apply_pending, as_gap_cursor, continuation_at, flat_chars,
-    flat_segments_in_range, flat_size, is_unit_node_selection, replacement_paint,
+    Affinity, Composition, FLAT_CLOSE, FLAT_OPEN, FlatSegment, Position, ProjectedState,
+    ResolvedPosition, ResolvedPositionFlatExt, Selection, StablePosition, apply_pending,
+    as_gap_cursor, continuation_at, flat_chars, flat_segments_in_range, flat_size,
+    replacement_paint,
 };
 use editor_transaction::{HistoryMeta, Transaction};
 
 use crate::editor::Editor;
 use crate::error::EditorError;
+use crate::handle::paragraph_break::apply_paragraph_break;
 use crate::message::*;
+
+mod coordinates;
+use coordinates::{ImeTextPosition, remap_ime_tail};
+
+fn replace_ime_text(
+    tr: &mut Transaction,
+    selection: Selection,
+    text: &str,
+    paint: Option<Vec<Modifier>>,
+    inserted: &mut BTreeMap<usize, Option<StablePosition>>,
+) -> Result<(), CommandError> {
+    tr.set_selection(Some(selection))?;
+    let mut remaining = text;
+    let mut input_offset = 0;
+    loop {
+        let line_end = remaining.find(['\r', '\n']).unwrap_or(remaining.len());
+        let line = &remaining[..line_end];
+        let line_len = line.chars().count();
+        if !line.is_empty() || text.is_empty() {
+            let Some(selection) = tr.selection() else {
+                return Err(CommandError::InvalidArgument(
+                    "IME text replacement could not be applied".into(),
+                ));
+            };
+            if !commands::replace_range_with_text(tr, selection, line, paint.clone())? {
+                return Err(CommandError::InvalidArgument(
+                    "IME text replacement could not be applied".into(),
+                ));
+            }
+            let view = tr.view();
+            let Some(end) = tr.selection().and_then(|s| s.head.resolve(&view)) else {
+                return Err(CommandError::InvalidArgument(
+                    "IME text replacement could not be applied".into(),
+                ));
+            };
+            let Some(start) = end.to_flat().checked_sub(line_len) else {
+                return Err(CommandError::InvalidArgument(
+                    "IME text replacement could not be applied".into(),
+                ));
+            };
+            for (offset, binding) in inserted.range_mut(input_offset..=input_offset + line_len) {
+                let offset = start + offset - input_offset;
+                let Some(position) = ResolvedPosition::from_flat(&view, offset) else {
+                    return Err(CommandError::InvalidArgument(
+                        "IME text replacement could not be applied".into(),
+                    ));
+                };
+                let mut position: Position = (&position).into();
+                position.affinity = Affinity::Upstream;
+                *binding = Some(StablePosition::capture(&position, &view));
+            }
+        } else if let Some(binding) = inserted.get_mut(&input_offset) {
+            // A leading break must see the original range/gap/unit selection.
+            // In particular, an empty text replacement would delete a list
+            // range before Enter can decide whether to split or leave its item.
+            let view = tr.view();
+            if let Some(selection) = tr.selection().and_then(|s| s.resolve(&view))
+                && view
+                    .node(selection.from().node())
+                    .is_some_and(|n| n.spec().is_textblock())
+            {
+                let mut position: Position = selection.from().into();
+                position.affinity = Affinity::Upstream;
+                *binding = Some(StablePosition::capture(&position, &view));
+            }
+        }
+        if line_end == remaining.len() {
+            break;
+        }
+        let crlf = remaining[line_end..].starts_with("\r\n");
+        // Match Enter: an inapplicable break (e.g. in a fold title) is a
+        // no-op, not a reason to discard the rest of a committed text input.
+        apply_paragraph_break(tr)?;
+        let Some(selection) = tr.selection() else {
+            return Err(CommandError::InvalidArgument(
+                "IME text replacement could not be applied".into(),
+            ));
+        };
+        let boundary = StablePosition::capture(&selection.head, &tr.view());
+        // At a gap or unit there was no preceding text position: Enter creates
+        // one paragraph, and both sides of the input break name its start.
+        if let Some(binding) = inserted.get_mut(&input_offset)
+            && binding.is_none()
+        {
+            *binding = Some(boundary.clone());
+        }
+        input_offset += line_len + 1;
+        if let Some(binding) = inserted.get_mut(&input_offset) {
+            *binding = Some(boundary.clone());
+        }
+        if crlf {
+            input_offset += 1;
+            if let Some(binding) = inserted.get_mut(&input_offset) {
+                *binding = Some(boundary);
+            }
+        }
+        remaining = &remaining[line_end + if crlf { 2 } else { 1 }..];
+    }
+    Ok(())
+}
 
 fn selection_from_flat_range(
     doc: &DocView,
@@ -121,6 +223,7 @@ struct FlatText {
 }
 
 impl FlatText {
+    #[cfg(test)]
     fn whole(chars: Vec<char>) -> Self {
         let total = chars.len();
         Self {
@@ -225,33 +328,6 @@ struct FlatImeTextChange {
     replace_start: usize,
     replace_end: usize,
     insert: Vec<char>,
-}
-
-fn remap_op(op: &FlatImeOp, before: &FlatImeState, after: &FlatImeState) -> FlatImeOp {
-    match op {
-        FlatImeOp::SetSelection { start, end } => remap_range(before, after, *start, *end)
-            .map_or_else(
-                || op.clone(),
-                |(start, end)| FlatImeOp::SetSelection { start, end },
-            ),
-        FlatImeOp::SetComposition { start, end } => remap_range(before, after, *start, *end)
-            .map_or_else(
-                || op.clone(),
-                |(start, end)| FlatImeOp::SetComposition { start, end },
-            ),
-        _ => op.clone(),
-    }
-}
-
-fn remap_range(
-    before: &FlatImeState,
-    after: &FlatImeState,
-    start: usize,
-    end: usize,
-) -> Option<(usize, usize)> {
-    let before_cursor = (before.sel_start, before.sel_end);
-    let after_cursor = (after.sel_start, after.sel_end);
-    ((start, end) == before_cursor).then_some(after_cursor)
 }
 
 impl FlatImeTextChange {
@@ -443,30 +519,11 @@ impl FlatImeState {
         })
     }
 
-    fn from_editor_whole(editor: &Editor) -> Option<Self> {
-        let state = editor.state();
-        let doc = state.view();
-        let flat_size = flat_size(&doc);
-        let selection = state.selection?;
-        let anchor = selection.anchor.resolve(&doc)?.to_flat();
-        let head = selection.head.resolve(&doc)?.to_flat();
-        let comp = state
-            .composition
-            .filter(|c| composition_range_valid(&doc, c.start, c.end))
-            .map(|c| (c.start, c.end));
-        Some(FlatImeState {
-            text: FlatText::whole(flat_chars(&doc, 0..flat_size)),
-            sel_start: anchor.min(head),
-            sel_end: anchor.max(head),
-            comp,
-        })
-    }
-
     fn apply(&mut self, op: &FlatImeOp) -> Option<FlatImeTextChange> {
         match op {
             FlatImeOp::SetSelection { start, end } => {
-                self.sel_start = (*start).min(self.text.len());
-                self.sel_end = (*end).min(self.text.len());
+                self.sel_start = (*start.min(end)).min(self.text.len());
+                self.sel_end = (*start.max(end)).min(self.text.len());
                 None
             }
             FlatImeOp::ReplaceSelection { text } => {
@@ -742,8 +799,6 @@ struct FlatDelta {
     replace_end: usize,
     end_tokens: usize,
     ins_text: String,
-    // Result-buffer text start for remapping composition after token-only replacement.
-    composition_text_start: Option<usize>,
 }
 
 fn analyze_delta(
@@ -789,11 +844,6 @@ fn analyze_delta(
         replace_end,
         end_tokens: forward_count,
         ins_text,
-        composition_text_start: chars
-            .slice(replace_start..replace_end)
-            .iter()
-            .any(|c| is_token(*c))
-            .then_some(replace_start),
     }
 }
 
@@ -855,13 +905,25 @@ fn flat_ime_ops_have_direct_backspace_shape(ops: &[FlatImeOp]) -> bool {
 }
 
 pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(), EditorError> {
-    for segment in ops.split_inclusive(|op| matches!(op, FlatImeOp::CommitAsIs)) {
-        handle_flat_ime_segment(editor, segment)?;
+    let mut ops = ops;
+    let mut remaining = ops.as_mut_slice();
+    while !remaining.is_empty() {
+        let count = remaining
+            .iter()
+            .position(|op| matches!(op, FlatImeOp::CommitAsIs))
+            .map_or(remaining.len(), |index| index + 1);
+        let (segment, tail) = remaining.split_at_mut(count);
+        handle_flat_ime_segment(editor, segment, tail)?;
+        remaining = tail;
     }
     Ok(())
 }
 
-fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(), EditorError> {
+fn handle_flat_ime_segment(
+    editor: &mut Editor,
+    ops: &[FlatImeOp],
+    tail: &mut [FlatImeOp],
+) -> Result<(), EditorError> {
     let mut delete_paint = editor.ime_delete_paint.take();
     let plain_backspace = flat_ime_ops_form_plain_backspace(editor, ops);
     let standalone_backspace = plain_backspace && flat_ime_ops_have_direct_backspace_shape(ops);
@@ -881,8 +943,10 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
     }
 
     let mut committed_composition = false;
+    let mut tail_coordinates = None;
     let committed_insert = (|| -> Result<bool, EditorError> {
-        let initial = match FlatImeState::from_editor(editor, ops) {
+        let reach: Vec<_> = ops.iter().chain(tail.iter()).cloned().collect();
+        let initial = match FlatImeState::from_editor(editor, &reach) {
             Some(s) => s,
             None => return Ok(false),
         };
@@ -890,6 +954,22 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
         let reduced = initial.clone().reduce_flat_ime_ops(ops);
 
         if reduced.text_change.is_none() {
+            return Ok(false);
+        }
+        // Composition is confined to one text block. A committed multiline
+        // replacement is supported, but a preedit spanning paragraph breaks
+        // cannot be represented by the document composition contract.
+        if reduced.state.comp.is_some_and(|(start, end)| {
+            start >= reduced.state.text.base
+                && start <= end
+                && end <= reduced.state.text.base + reduced.state.text.chars.len()
+                && reduced
+                    .state
+                    .text
+                    .slice(start..end)
+                    .iter()
+                    .any(|c| matches!(c, '\n' | '\r'))
+        }) {
             return Ok(false);
         }
 
@@ -901,28 +981,9 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
             .and_then(|s| s.resolve(&gap_view))
             .and_then(|rs| as_gap_cursor(&rs))
             .is_some();
-        let (initial, reduced) = if initial.text != reduced.state.text && started_at_gap {
+        if initial.text != reduced.state.text && started_at_gap {
             delete_paint = None;
-            let before_materialize = initial.clone();
-            editor.transact(|tr| {
-                tr.keep_pending_modifiers();
-                tr.set_composition(None)?;
-                commands::materialize_gap_paragraph(tr)?;
-                Ok(())
-            })?;
-            let initial = match FlatImeState::from_editor_whole(editor) {
-                Some(s) => s,
-                None => return Ok(false),
-            };
-            let replay_ops: Vec<_> = ops
-                .iter()
-                .map(|op| remap_op(op, &before_materialize, &initial))
-                .collect();
-            let reduced = initial.clone().reduce_flat_ime_ops(&replay_ops);
-            (initial, reduced)
-        } else {
-            (initial, reduced)
-        };
+        }
 
         let reduced_committed_composition = reduced.committed_composition;
         let result = reduced.state;
@@ -979,13 +1040,8 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
             &text_change.insert,
             initial.sel_start,
         );
-        let should_insert_after_unit_selection =
-            !delta.ins_text.is_empty()
-                && text_change.replace_start == initial.sel_start
-                && text_change.replace_end == initial.sel_end
-                && editor.state().selection.as_ref().is_some_and(|selection| {
-                    is_unit_node_selection(selection, &editor.state().view())
-                });
+        let replaces_selection = text_change.replace_start == initial.sel_start
+            && text_change.replace_end == initial.sel_end;
         let has_text_delta = !del.is_empty() || !text_change.insert.is_empty();
         let has_structural_seams = delta.start_tokens > 0 || delta.end_tokens > 0;
 
@@ -1016,111 +1072,137 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
             None
         };
 
-        if has_text_delta || result.comp.is_some() || editor.state().composition.is_some() {
+        let selection_changed =
+            (initial.sel_start, initial.sel_end) != (result.sel_start, result.sel_end);
+        if has_text_delta
+            || selection_changed
+            || result.comp.is_some()
+            || editor.state().composition.is_some()
+        {
             editor.transact(|tr| {
-                let mut composition_text_start = delta.composition_text_start;
+                // Ordinary typing needs only the caret/composition endpoints,
+                // not one document anchor for every character of a large commit.
+                let mut inserted = BTreeMap::new();
+                let mut capture = |offset| {
+                    let position = ImeTextPosition::capture(&tr.view(), &text_change, offset);
+                    if let Some(ImeTextPosition::Inserted(index)) = &position {
+                        inserted.entry(*index).or_insert(None);
+                    }
+                    position
+                };
+                let selection_start = capture(result.sel_start);
+                let selection_end = capture(result.sel_end);
+                let composition = result
+                    .comp
+                    .map(|(start, end)| (capture(start), capture(end)));
+                let tail_positions = (!tail.is_empty()).then(|| {
+                    (result.text.base..=result.text.base + result.text.chars.len())
+                        .map(&mut capture)
+                        .collect::<Vec<_>>()
+                });
 
                 if has_text_delta {
-                    if should_insert_after_unit_selection {
-                        commands::chain!(
-                            tr,
-                            commands::insert_paragraph_after_unit_selection(),
-                            commands::insert_text(&delta.ins_text),
-                        )?;
-                        composition_text_start = Some(text_change.replace_start);
-                    } else if has_structural_seams {
-                        let full_replace = text_change.replace_start == initial.sel_start
-                            && text_change.replace_end == initial.sel_end;
-                        if full_replace {
+                    if has_structural_seams && !replaces_selection {
+                        let deletes_body = delta.replace_start != delta.replace_end;
+                        let paint = if !delta.ins_text.is_empty() {
                             let sel = selection_from_flat_range(
                                 &tr.view(),
-                                text_change.replace_start,
-                                text_change.replace_end,
-                            )?;
-                            commands::replace_range_with_text(
-                                tr,
-                                sel,
-                                &delta.ins_text,
-                                sidecar_before.clone(),
-                            )?;
-                        } else {
-                            let deletes_body = delta.replace_start != delta.replace_end;
-                            let paint = if !delta.ins_text.is_empty() {
-                                let sel = selection_from_flat_range(
-                                    &tr.view(),
-                                    delta.replace_start,
-                                    delta.replace_end,
+                                delta.replace_start,
+                                delta.replace_end,
+                            )
+                            .ok();
+                            sel.and_then(|sel| {
+                                editor_state::replacement_paint(
+                                    &tr.state().projected,
+                                    sel.anchor,
+                                    sel.head,
                                 )
-                                .ok();
-                                sel.and_then(|sel| {
-                                    editor_state::replacement_paint(
-                                        &tr.state().projected,
-                                        sel.anchor,
-                                        sel.head,
-                                    )
-                                })
+                            })
+                        } else {
+                            None
+                        };
+
+                        if deletes_body {
+                            let sel = selection_from_flat_range(
+                                &tr.view(),
+                                delta.replace_start,
+                                delta.replace_end,
+                            )?;
+                            commands::replace_range_with_text(tr, sel, "", None)?;
+                        }
+
+                        if delta.end_tokens > 0 {
+                            let previous_selection = tr.selection();
+                            if !deletes_body {
+                                set_selection_at_flat(tr, delta.replace_end)?;
+                            }
+                            for _ in 0..delta.end_tokens {
+                                if !structural_forward(tr)? {
+                                    tr.set_selection(previous_selection)?;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if delta.start_tokens > 0 {
+                            let previous_selection = tr.selection();
+                            let selection_ready = if deletes_body {
+                                true
                             } else {
-                                None
+                                set_selection_at_flat(tr, delta.replace_start)?
                             };
 
-                            if deletes_body {
-                                let sel = selection_from_flat_range(
-                                    &tr.view(),
-                                    delta.replace_start,
-                                    delta.replace_end,
-                                )?;
-                                commands::replace_range_with_text(tr, sel, "", None)?;
-                            }
-
-                            if delta.end_tokens > 0 {
-                                let previous_selection = tr.selection();
-                                if !deletes_body {
-                                    set_selection_at_flat(tr, delta.replace_end)?;
-                                }
-                                for _ in 0..delta.end_tokens {
-                                    if !structural_forward(tr)? {
+                            if selection_ready {
+                                for _ in 0..delta.start_tokens {
+                                    if !structural_backward(tr)? {
                                         tr.set_selection(previous_selection)?;
                                         break;
                                     }
                                 }
                             }
-
-                            if delta.start_tokens > 0 {
-                                let previous_selection = tr.selection();
-                                let selection_ready = if deletes_body {
-                                    true
-                                } else {
-                                    set_selection_at_flat(tr, delta.replace_start)?
-                                };
-
-                                if selection_ready {
-                                    for _ in 0..delta.start_tokens {
-                                        if !structural_backward(tr)? {
-                                            tr.set_selection(previous_selection)?;
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-
-                            if !delta.ins_text.is_empty()
-                                && let Some(head) = tr.selection().map(|s| s.head)
-                            {
-                                commands::replace_range_with_text(
-                                    tr,
-                                    Selection::collapsed(head),
-                                    &delta.ins_text,
-                                    sidecar_before.clone().or(paint),
-                                )?;
-                            }
                         }
-                        composition_text_start = Some(text_change.replace_start);
+
+                        if !delta.ins_text.is_empty()
+                            && let Some(head) = tr.selection().map(|s| s.head)
+                        {
+                            replace_ime_text(
+                                tr,
+                                Selection::collapsed(head),
+                                &delta.ins_text,
+                                sidecar_before.clone().or(paint),
+                                &mut inserted,
+                            )?;
+                        }
                     } else {
-                        let sel = selection_from_flat_range(
-                            &tr.view(),
-                            delta.replace_start,
-                            delta.replace_end,
-                        )?;
+                        // Prepare a text insertion only for the actual editor
+                        // selection, not for a range reconstructed during IME
+                        // structural replay. A leading break prepares its own
+                        // target through the shared Enter workflow instead.
+                        if replaces_selection
+                            && !delta.ins_text.is_empty()
+                            && !delta.ins_text.starts_with(['\r', '\n'])
+                        {
+                            commands::first!(
+                                tr,
+                                commands::materialize_gap_paragraph(),
+                                commands::insert_paragraph_after_unit_selection(),
+                                |_tr| Ok(true),
+                            )?;
+                        }
+                        // Flat offsets alone lose the affinity that identifies
+                        // a gap or unit selection. Preserve the actual target
+                        // when this batch replaces the current selection.
+                        let sel = if replaces_selection {
+                            tr.selection().ok_or(CommandError::InvalidArgument(
+                                "IME text replacement has no selection".into(),
+                            ))?
+                        } else {
+                            selection_from_flat_range(
+                                &tr.view(),
+                                delta.replace_start,
+                                delta.replace_end,
+                            )?
+                        };
                         let paint = sidecar_before.clone().or_else(|| {
                             delete_paint
                                 .as_ref()
@@ -1130,53 +1212,43 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
                                 })
                                 .map(|(_, paint)| paint.clone())
                         });
-                        commands::replace_range_with_text(tr, sel, &delta.ins_text, paint)?;
+                        replace_ime_text(tr, sel, &delta.ins_text, paint, &mut inserted)?;
                     }
                 }
 
-                // Without structural replay the reduced coordinates are only
-                // meaningful when the document agrees with the reduced buffer;
-                // a dropped edit (e.g. a rejected replacement) leaves them
-                // pointing at unrelated text.
-                let reduced_applied = flat_size(&tr.view()) == result.text.len();
+                if has_text_delta
+                    && tr.doc_changed()
+                    && text_change.insert.is_empty()
+                    && let Some(binding) = inserted.get_mut(&0)
+                    && binding.is_none()
+                    && let Some(selection) = tr.selection()
+                {
+                    *binding = Some(StablePosition::capture(&selection.head, &tr.view()));
+                }
 
-                // None = leave the current composition untouched.
-                let composition_update = match (result.comp, composition_text_start) {
-                    // A structural replay rebuilds flat coordinates, so a composing
-                    // region the IME placed outside the replayed insert has no
-                    // mapping; drop it rather than fail the whole edit.
-                    (Some((start, end)), Some(text_start)) => Some((|| {
-                        // Text before the replayed range keeps its flat
-                        // coordinates, so a composing region there needs no
-                        // remap.
-                        if start <= end && end < text_start {
-                            return Some(Composition { start, end });
-                        }
-                        let inserted_len = delta.ins_text.char_count();
-                        let relative_start = start.checked_sub(text_start)?;
-                        let relative_end = end.checked_sub(text_start)?;
-                        if relative_start > relative_end || relative_end > inserted_len {
-                            return None;
-                        }
+                // Even a document no-op (such as Enter in a fold title) can
+                // change the native buffer's width. Keep its bound positions
+                // for the rest of the batch before skipping state publication.
+                if let Some(positions) = tail_positions {
+                    let bindings = positions
+                        .into_iter()
+                        .map(|position| position.and_then(|position| position.bind(&inserted)))
+                        .collect();
+                    tail_coordinates = Some((result.clone(), bindings));
+                }
+                // Rejected replacements must not publish positions from the
+                // input buffer as though their text had reached the document.
+                if has_text_delta && !tr.doc_changed() {
+                    return Ok(());
+                }
 
-                        let doc = tr.view();
-                        let inserted_start = tr
-                            .selection()
-                            .and_then(|selection| selection.head.resolve(&doc))
-                            .and_then(|head| head.to_flat().checked_sub(inserted_len))?;
-
+                {
+                    let composition = composition.and_then(|(start, end)| {
                         Some(Composition {
-                            start: inserted_start + relative_start,
-                            end: inserted_start + relative_end,
+                            start: start?.resolve(tr, &inserted)?,
+                            end: end?.resolve(tr, &inserted)?,
                         })
-                    })()),
-                    (Some((start, end)), None) => {
-                        reduced_applied.then_some(Some(Composition { start, end }))
-                    }
-                    (None, _) => Some(None),
-                };
-
-                if let Some(composition) = composition_update {
+                    });
                     let composition = composition.filter(|composition| {
                         composition_range_valid(&tr.view(), composition.start, composition.end)
                     });
@@ -1197,20 +1269,22 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
                     }
                 }
 
-                // Without structural replay the reduced coordinates match the
-                // document 1:1, so the reduced selection is authoritative
-                // (e.g. a delete before the composing text keeps the caret at
-                // the composition, not at the deletion site).
-                if has_text_delta && composition_text_start.is_none() && reduced_applied {
+                if has_text_delta || selection_changed {
+                    let target = selection_start.and_then(|start| {
+                        Some((
+                            start.resolve(tr, &inserted)?,
+                            selection_end?.resolve(tr, &inserted)?,
+                        ))
+                    });
                     let doc = tr.view();
                     let current = tr.selection().and_then(|s| {
                         let anchor = s.anchor.resolve(&doc)?.to_flat();
                         let head = s.head.resolve(&doc)?.to_flat();
                         Some((anchor.min(head), anchor.max(head)))
                     });
-                    if current != Some((result.sel_start, result.sel_end))
-                        && let Ok(sel) =
-                            selection_from_flat_range(&doc, result.sel_start, result.sel_end)
+                    if let Some((start, end)) = target
+                        && current != target
+                        && let Ok(sel) = selection_from_flat_range(&doc, start, end)
                     {
                         commands::set_selection(tr, sel)?;
                     }
@@ -1235,6 +1309,10 @@ fn handle_flat_ime_segment(editor: &mut Editor, ops: &[FlatImeOp]) -> Result<(),
         })?;
     }
 
+    if let Some((input, bindings)) = tail_coordinates {
+        remap_ime_tail(editor, input, bindings, tail)?;
+    }
+
     Ok(())
 }
 
@@ -1252,6 +1330,27 @@ mod tests {
             selection: (r, 0, <)
         };
         state
+    }
+
+    #[test]
+    fn multiline_input_positions_follow_gap_paragraph_materialization() {
+        let mut editor = Editor::new_test(leading_gap_state());
+        let ime = editor.ime(100, 100).unwrap().unwrap();
+        let end = ime.selection.start + 3;
+        editor.apply(Message::TextInput {
+            ops: vec![
+                FlatImeOp::ReplaceSelection {
+                    text: "a\nb".into(),
+                },
+                FlatImeOp::SetSelection { start: end, end },
+                FlatImeOp::ReplaceSelection { text: "X".into() },
+            ],
+        });
+        let (expected, ..) = state! {
+            doc { root { paragraph { text("a") } p: paragraph { text("bX") } image paragraph { text("b") } } }
+            selection: (p, 2)
+        };
+        assert_state_eq!(editor.state(), &expected);
     }
 
     fn between_monolithic_gap_state() -> editor_state::State {
@@ -1290,6 +1389,23 @@ mod tests {
             state,
             Message::TextInput {
                 ops: vec![FlatImeOp::ClearComposition],
+            },
+        );
+    }
+
+    #[test]
+    fn composition_outside_the_input_buffer_is_discarded() {
+        let (state, ..) = state! {
+            doc { root { p: paragraph { text("abc") } } }
+            selection: (p, 1)
+        };
+        assert_apply_preserves_state(
+            state,
+            Message::TextInput {
+                ops: vec![FlatImeOp::SetComposition {
+                    start: 1,
+                    end: usize::MAX,
+                }],
             },
         );
     }
@@ -1698,8 +1814,8 @@ mod tests {
 
     #[test]
     fn rejected_newline_compose_leaves_state_untouched() {
-        // replace_range_with_text rejects newline-bearing replacements; the
-        // dropped edit must not move the caret to reduced coordinates, mark
+        // A preedit cannot span paragraphs. The dropped edit must not move
+        // the caret to reduced coordinates, mark
         // untouched document text as composing, or consume pending modifiers.
         let (state, ..) = state! {
             doc { root { p1: paragraph { text("hello") } } }
@@ -5123,7 +5239,7 @@ mod tests {
     }
 
     #[test]
-    fn flat_ime_set_composition_beyond_insert_in_token_edit_is_dropped() {
+    fn flat_ime_set_composition_after_token_edit_follows_existing_text() {
         let (state, ..) = state! {
             doc { root {
                 paragraph { text("가나") }
@@ -5143,14 +5259,17 @@ mod tests {
         }]);
         editor
             .tick()
-            .expect("unmappable composing region must not fail");
+            .expect("composing region after the edit must follow its text");
 
         let (expected, ..) = state! {
             doc { root { p1: paragraph { text("가나다라") } } }
             selection: (p1, 2, <)
         };
         assert_state_eq!(editor.state(), &expected);
-        assert_eq!(editor.state().composition, None);
+        assert_eq!(
+            editor.state().composition,
+            Some(Composition { start: 4, end: 5 })
+        );
     }
 
     fn ios_backspace_ops(start: usize, end: usize) -> Vec<FlatImeOp> {

--- a/crates/editor-core/src/handle/text_input/coordinates.rs
+++ b/crates/editor-core/src/handle/text_input/coordinates.rs
@@ -1,0 +1,195 @@
+use std::collections::BTreeMap;
+
+use editor_commands::CommandError;
+use editor_model::DocView;
+use editor_state::{ResolvedPosition, ResolvedPositionFlatExt, StablePosition, StableResolveCtx};
+use editor_transaction::Transaction;
+
+use super::{FlatImeState, FlatImeTextChange};
+use crate::editor::Editor;
+use crate::error::EditorError;
+use crate::message::FlatImeOp;
+
+// Positions outside an insertion belong to existing document content. Positions
+// inside it belong to the text supplied by the IME, whose newlines may create
+// more than one structural flat unit. Bind those positions as the handler edits
+// the document, instead of predicting the number of structural tokens.
+pub(super) enum ImeTextPosition {
+    Existing(StablePosition),
+    Inserted(usize),
+}
+
+impl ImeTextPosition {
+    pub(super) fn capture(
+        view: &DocView,
+        change: &FlatImeTextChange,
+        offset: usize,
+    ) -> Option<Self> {
+        let inserted_end = change.replace_start + change.insert.len();
+        if (change.replace_start != change.replace_end || !change.insert.is_empty())
+            && (change.replace_start..=inserted_end).contains(&offset)
+        {
+            return Some(Self::Inserted(offset - change.replace_start));
+        }
+        let original = if offset < change.replace_start {
+            offset
+        } else {
+            change.replace_end.checked_add(offset - inserted_end)?
+        };
+        let position = ResolvedPosition::from_flat(view, original)?;
+        Some(Self::Existing(StablePosition::capture(
+            &(&position).into(),
+            view,
+        )))
+    }
+
+    pub(super) fn resolve(
+        &self,
+        tr: &Transaction,
+        inserted: &BTreeMap<usize, Option<StablePosition>>,
+    ) -> Option<usize> {
+        let position = match self {
+            Self::Existing(position) => position,
+            Self::Inserted(offset) => inserted.get(offset)?.as_ref()?,
+        };
+        let view = tr.view();
+        let ctx = StableResolveCtx::from_live(&view, tr.state().projected.seq_checkout());
+        position
+            .resolve(&ctx)?
+            .resolve(&view)
+            .map(|pos| pos.to_flat())
+    }
+
+    pub(super) fn bind(
+        self,
+        inserted: &BTreeMap<usize, Option<StablePosition>>,
+    ) -> Option<StablePosition> {
+        match self {
+            Self::Existing(position) => Some(position),
+            Self::Inserted(offset) => inserted.get(&offset).cloned().flatten(),
+        }
+    }
+}
+
+// Rebase the rest of a native batch after a commit has executed structural
+// edits or automatic text replacement. Both buffers advance with each command:
+// later positions refer to the text after earlier commands, not to a snapshot
+// frozen at the preceding commit boundary.
+pub(super) fn remap_ime_tail(
+    editor: &Editor,
+    mut input: FlatImeState,
+    bindings: Vec<Option<StablePosition>>,
+    ops: &mut [FlatImeOp],
+) -> Result<(), EditorError> {
+    let view = editor.state().view();
+    let ctx = StableResolveCtx::from_live(&view, editor.state().projected.seq_checkout());
+    let mut offsets: Vec<_> = bindings
+        .iter()
+        .map(|binding| {
+            binding
+                .as_ref()?
+                .resolve(&ctx)?
+                .resolve(&view)
+                .map(|pos| pos.to_flat())
+        })
+        .collect();
+    if offsets
+        .iter()
+        .enumerate()
+        .all(|(index, offset)| *offset == Some(input.text.base + index))
+    {
+        return Ok(());
+    }
+    let mut reach = ops.to_vec();
+    reach.push(FlatImeOp::SetSelection {
+        start: offsets.iter().flatten().copied().min().unwrap_or(0),
+        end: offsets.iter().flatten().copied().max().unwrap_or(0),
+    });
+    let Some(mut output) = FlatImeState::from_editor(editor, &reach) else {
+        return Ok(());
+    };
+
+    for op in ops {
+        let input_base = input.text.base;
+        let map = |offset: usize| {
+            offset
+                .checked_sub(input_base)
+                .and_then(|index| offsets.get(index))
+                .copied()
+                .flatten()
+                .ok_or_else(|| {
+                    EditorError::from(CommandError::InvalidArgument(
+                        "IME position no longer maps to the edited document".into(),
+                    ))
+                })
+        };
+        let mapped = match op {
+            FlatImeOp::SetSelection { start, end } => FlatImeOp::SetSelection {
+                start: map(*start)?,
+                end: map(*end)?,
+            },
+            FlatImeOp::SetComposition { start, end } => FlatImeOp::SetComposition {
+                start: map(*start)?,
+                end: map(*end)?,
+            },
+            FlatImeOp::MoveCursor { .. } => {
+                let mut moved = input.clone();
+                moved.apply(op);
+                let position = map(moved.sel_start)?;
+                FlatImeOp::SetSelection {
+                    start: position,
+                    end: position,
+                }
+            }
+            FlatImeOp::DeleteSurrounding { .. } | FlatImeOp::DeleteSurroundingUtf16 { .. } => {
+                let mut deleted = input.clone();
+                let change = deleted.apply(op);
+                let (before, after) = input.surrounding_delete_bases();
+                let (output_before, output_after) = output.surrounding_delete_bases();
+                let (start, end) = change.map_or((before, after), |change| {
+                    (change.replace_start, change.replace_end)
+                });
+                FlatImeOp::DeleteSurrounding {
+                    before: if start < before {
+                        output_before.saturating_sub(map(start)?)
+                    } else {
+                        0
+                    },
+                    after: if end > after {
+                        map(end)?.saturating_sub(output_after)
+                    } else {
+                        0
+                    },
+                }
+            }
+            _ => op.clone(),
+        };
+        let input_change = input.apply(op);
+        let output_change = output.apply(&mapped);
+        if let Some(input_change) = input_change {
+            // Several input boundaries can name one document boundary (CRLF,
+            // or text collapsed by automatic replacement). Deleting between
+            // them still shortens the input buffer even if the document edit
+            // is empty, so its entries must be removed from this map.
+            let output_change = match output_change {
+                Some(change) => change,
+                None => FlatImeTextChange::collapsed_at(map(input_change.replace_start)?),
+            };
+            let output_end = output_change.replace_start + output_change.insert.len();
+            for offset in offsets.iter_mut().flatten() {
+                *offset = if *offset >= output_change.replace_end {
+                    output_end + (*offset - output_change.replace_end)
+                } else {
+                    (*offset).min(output_change.replace_start)
+                };
+            }
+            offsets.splice(
+                input_change.replace_start - input.text.base
+                    ..=input_change.replace_end - input.text.base,
+                (output_change.replace_start..=output_end).map(Some),
+            );
+        }
+        *op = mapped;
+    }
+    Ok(())
+}

--- a/crates/editor-core/src/message.rs
+++ b/crates/editor-core/src/message.rs
@@ -385,6 +385,12 @@ pub enum SystemEvent {
 #[ffi]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+/// Edits to the IME's linear input buffer, initially addressed in document-flat
+/// Unicode scalar offsets. Each operation addresses the buffer after preceding
+/// operations in the same message, including across `CommitAsIs` barriers.
+/// Inserted CR/LF characters retain their input-buffer width; the engine binds
+/// their positions to the actual paragraph edits. Hosts must not pre-expand
+/// them into structural document offsets or separate Enter messages.
 pub enum FlatImeOp {
     SetSelection { start: usize, end: usize },
     ReplaceSelection { text: String },

--- a/crates/editor-core/src/tests/fixtures/ime-multiline-selection.json
+++ b/crates/editor-core/src/tests/fixtures/ime-multiline-selection.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "text_input",
+    "ops": [
+      { "type": "replace_selection", "text": "a\nb" },
+      { "type": "set_selection", "start": 4, "end": 4 },
+      { "type": "replace_selection", "text": "X" }
+    ]
+  }
+]

--- a/crates/editor-core/src/text_replacement_tests.rs
+++ b/crates/editor-core/src/text_replacement_tests.rs
@@ -74,6 +74,344 @@ const MULTILINE_PAT_PATTERN: &str = r"P1\nP2";
 const MULTILINE_PAT_SUBSTITUTE: &str = "Q";
 
 #[test]
+fn ime_leading_newline_preserves_list_range_enter_behavior() {
+    for text in ["\n", "\r\n"] {
+        let (initial, ..) = state! {
+            doc { root { bullet_list { list_item { p: paragraph { text("abc") } } } paragraph {} } }
+            selection: (p, 0) -> (p, 3)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::ReplaceSelection { text: text.into() }],
+        });
+        let (expected, ..) = state! {
+            doc { root {
+                bullet_list {
+                    list_item { paragraph {} }
+                    list_item { p: paragraph {} }
+                }
+                paragraph {}
+            } }
+            selection: (p, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+}
+
+#[test]
+fn ime_leading_newline_inserts_only_one_paragraph_after_a_unit_selection() {
+    for text in ["\n", "\r\n"] {
+        let (initial, ..) = state! {
+            doc { r: root { paragraph { text("a") } horizontal_rule paragraph { text("b") } } }
+            selection: (r, 1, >) -> (r, 2, <)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::ReplaceSelection { text: text.into() }],
+        });
+        let (expected, ..) = state! {
+            doc { root { paragraph { text("a") } horizontal_rule p: paragraph {} paragraph { text("b") } } }
+            selection: (p, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+}
+
+#[test]
+fn ime_leading_newline_materializes_a_gap_without_splitting_it_again() {
+    for text in ["\n", "\r\n"] {
+        let (initial, ..) = state! {
+            doc { r: root { image paragraph { text("b") } } }
+            selection: (r, 0, <)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::ReplaceSelection { text: text.into() }],
+        });
+        let (expected, ..) = state! {
+            doc { root { p: paragraph {} image paragraph { text("b") } } }
+            selection: (p, 0)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+}
+
+#[test]
+fn ime_multiline_commit_in_fold_title_keeps_text_when_enter_is_inapplicable() {
+    for ops in [
+        vec![FlatImeOp::ReplaceSelection {
+            text: "X\nY".into(),
+        }],
+        vec![FlatImeOp::ReplaceSelection {
+            text: "X\r\nY".into(),
+        }],
+        vec![
+            FlatImeOp::ReplaceSelection { text: "\n".into() },
+            FlatImeOp::CommitAsIs,
+            FlatImeOp::SetSelection { start: 4, end: 4 },
+            FlatImeOp::ReplaceSelection { text: "XY".into() },
+        ],
+    ] {
+        let (initial, ..) = state! {
+            doc { root {
+                fold { title: fold_title { text("ab") } fold_content { paragraph {} } }
+                paragraph {}
+            } }
+            selection: (title, 1)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::TextInput { ops });
+        let (expected, ..) = state! {
+            doc { root {
+                fold { title: fold_title { text("aXYb") } fold_content { paragraph {} } }
+                paragraph {}
+            } }
+            selection: (title, 3)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+}
+
+#[test]
+fn ime_leading_gap_break_binds_all_input_boundaries_to_the_new_paragraph() {
+    for offset in 0..=2 {
+        let (initial, ..) = state! {
+            doc { r: root { image paragraph { text("b") } } }
+            selection: (r, 0, <)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::TextInput {
+            ops: vec![
+                FlatImeOp::ReplaceSelection {
+                    text: "\r\n".into(),
+                },
+                FlatImeOp::CommitAsIs,
+                FlatImeOp::SetSelection {
+                    start: offset,
+                    end: offset,
+                },
+                FlatImeOp::ReplaceSelection { text: "X".into() },
+            ],
+        });
+        let (expected, ..) = state! {
+            doc { root { p: paragraph { text("X") } image paragraph { text("b") } } }
+            selection: (p, 1)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+}
+
+#[test]
+fn ime_crlf_partial_delete_updates_coordinates_even_without_a_document_edit() {
+    for delete in [
+        FlatImeOp::DeleteSurrounding {
+            before: 1,
+            after: 0,
+        },
+        FlatImeOp::DeleteSurroundingUtf16 {
+            before: 1,
+            after: 0,
+        },
+    ] {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph {} } }
+            selection: (p, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::TextInput {
+            ops: vec![
+                FlatImeOp::ReplaceSelection {
+                    text: "a\r\nb".into(),
+                },
+                FlatImeOp::CommitAsIs,
+                FlatImeOp::SetSelection { start: 4, end: 4 },
+                delete,
+                // The input is now OPEN a CR b CLOSE: offset 4 is after b.
+                FlatImeOp::SetSelection { start: 4, end: 4 },
+                FlatImeOp::ReplaceSelection { text: "X".into() },
+            ],
+        });
+        let (expected, ..) = state! {
+            doc { root { paragraph { text("a") } p: paragraph { text("bX") } } }
+            selection: (p, 2)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+}
+
+#[test]
+fn ime_multiline_selection_matches_the_native_input_buffer() {
+    let (initial, ..) = state! {
+        doc { root { p: paragraph {} } }
+        selection: (p, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    // Also checked against the real Kotlin normalizer. Native text starts as
+    // OPEN CLOSE, then becomes OPEN a newline b CLOSE; offset 4 is after b.
+    let messages: Vec<Message> =
+        serde_json::from_str(include_str!("tests/fixtures/ime-multiline-selection.json")).unwrap();
+    let request = editor.enqueue_request(messages).unwrap();
+    editor.tick_through(request).unwrap();
+
+    let (expected, ..) = state! {
+        doc { root { paragraph { text("a") } p: paragraph { text("bX") } } }
+        selection: (p, 2)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn ime_multiline_positions_survive_commit_barriers_and_later_edits() {
+    for (text, end) in [("a\nb", 4), ("a\r\nb", 5), ("a\rb", 4)] {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph {} } }
+            selection: (p, 0)
+        };
+        let mut editor = Editor::new_test(initial);
+        let request = editor
+            .enqueue_request(vec![Message::TextInput {
+                ops: vec![
+                    FlatImeOp::Compose { text: text.into() },
+                    FlatImeOp::CommitAsIs,
+                    FlatImeOp::ReplaceSelection {
+                        text: "😀".into()
+                    },
+                    FlatImeOp::SetSelection {
+                        start: end + 1,
+                        end: end + 1,
+                    },
+                    FlatImeOp::ReplaceSelection { text: "X".into() },
+                ],
+            }])
+            .unwrap();
+        editor.tick_through(request).unwrap();
+        let (expected, ..) = state! {
+            doc { root { paragraph { text("a") } p: paragraph { text("b😀X") } } }
+            selection: (p, 3)
+        };
+        assert_state_eq!(editor.state(), &expected);
+    }
+}
+
+#[test]
+fn ime_multiline_composition_maps_to_the_inserted_paragraph() {
+    let (initial, ..) = state! {
+        doc { root { p: paragraph {} } }
+        selection: (p, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    let request = editor
+        .enqueue_request(vec![Message::TextInput {
+            ops: vec![
+                FlatImeOp::ReplaceSelection {
+                    text: "a\nb".into(),
+                },
+                FlatImeOp::CommitAsIs,
+                FlatImeOp::SetComposition { start: 3, end: 4 },
+                FlatImeOp::Compose { text: "乙".into() },
+                FlatImeOp::SetSelection { start: 3, end: 3 },
+            ],
+        }])
+        .unwrap();
+    editor.tick_through(request).unwrap();
+    let (expected, ..) = state! {
+        doc { root { paragraph { text("a") } p: paragraph { text("乙") } } }
+        selection: (p, 0)
+    };
+    assert_state_eq!(editor.state(), &expected);
+    assert_eq!(
+        editor.state().composition,
+        Some(Composition { start: 4, end: 5 })
+    );
+}
+
+#[test]
+fn ime_delete_after_multiline_commit_counts_input_newlines_not_structural_tokens() {
+    let (initial, ..) = state! {
+        doc { root { p: paragraph {} } }
+        selection: (p, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    let request = editor
+        .enqueue_request(vec![Message::TextInput {
+            ops: vec![
+                FlatImeOp::ReplaceSelection {
+                    text: "a\nb".into(),
+                },
+                FlatImeOp::CommitAsIs,
+                FlatImeOp::SetSelection { start: 3, end: 3 },
+                FlatImeOp::DeleteSurroundingUtf16 {
+                    before: 1,
+                    after: 0,
+                },
+                FlatImeOp::ReplaceSelection { text: "X".into() },
+            ],
+        }])
+        .unwrap();
+    editor.tick_through(request).unwrap();
+    let (expected, ..) = state! {
+        doc { root { p: paragraph { text("aXb") } } }
+        selection: (p, 2)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn ime_messages_start_in_document_coordinates_even_in_one_request() {
+    let (initial, ..) = state! {
+        doc { root { p: paragraph {} } }
+        selection: (p, 0)
+    };
+    let mut editor = Editor::new_test(initial);
+    let request = editor
+        .enqueue_request(vec![
+            Message::TextInput {
+                ops: vec![FlatImeOp::ReplaceSelection {
+                    text: "a\nb".into(),
+                }],
+            },
+            Message::TextInput {
+                ops: vec![
+                    FlatImeOp::SetSelection { start: 5, end: 5 },
+                    FlatImeOp::ReplaceSelection { text: "X".into() },
+                ],
+            },
+        ])
+        .unwrap();
+    editor.tick_through(request).unwrap();
+    let (expected, ..) = state! {
+        doc { root { paragraph { text("a") } p: paragraph { text("bX") } } }
+        selection: (p, 2)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
+fn ime_position_after_commit_follows_automatic_replacement() {
+    let (initial, ..) = state! {
+        doc { root { p: paragraph {} } }
+        selection: (p, 0)
+    };
+    let mut editor = editor_with_rules(initial, vec![rule("abc", "X", false)]);
+    let request = editor
+        .enqueue_request(vec![Message::TextInput {
+            ops: vec![
+                FlatImeOp::Compose { text: "abc".into() },
+                FlatImeOp::CommitAsIs,
+                FlatImeOp::SetSelection { start: 4, end: 4 },
+                FlatImeOp::ReplaceSelection { text: "!".into() },
+            ],
+        }])
+        .unwrap();
+    editor.tick_through(request).unwrap();
+    let (expected, ..) = state! {
+        doc { root { p: paragraph { text("X!") } } }
+        selection: (p, 2)
+    };
+    assert_state_eq!(editor.state(), &expected);
+}
+
+#[test]
 fn plain_rule_applies_on_insertion() {
     let (s, ..) = state! {
         doc { root { p1: paragraph { text("") } } }

--- a/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/browser/editor_ffi.d.ts
@@ -43,6 +43,16 @@ export interface Changeset<P> {
 }
 
 /**
+ * Edits to the IME's linear input buffer, initially addressed in document-flat
+ * Unicode scalar offsets. Each operation addresses the buffer after preceding
+ * operations in the same message, including across `CommitAsIs` barriers.
+ * Inserted CR/LF characters retain their input-buffer width; the engine binds
+ * their positions to the actual paragraph edits. Hosts must not pre-expand
+ * them into structural document offsets or separate Enter messages.
+ */
+export type FlatImeOp = { type: "set_selection"; start: number; end: number } | { type: "replace_selection"; text: string } | { type: "compose"; text: string } | { type: "delete_surrounding"; before: number; after: number } | { type: "delete_surrounding_utf16"; before: number; after: number } | { type: "set_composition"; start: number; end: number } | { type: "clear_composition" } | { type: "commit_as_is" } | { type: "move_cursor"; delta: number };
+
+/**
  * One node in the op-DAG. `id` is the op's unique identifier (also reused as
  * the semantic identifier — RGA element id, OR-Set add token — by the
  * payload). `parents` are the op-DAG parents of this op (the heads of the
@@ -644,8 +654,6 @@ export type ExternalDndPayloadKind = "text" | "html" | "image_files" | "files" |
 export type ExternalElementData = { type: "image"; id: string | undefined; proportion: number } | { type: "file"; id: string | undefined } | { type: "embed"; id: string | undefined } | { type: "archived"; id: string | undefined };
 
 export type FileNodeAttr = { type: "id"; value: string | undefined };
-
-export type FlatImeOp = { type: "set_selection"; start: number; end: number } | { type: "replace_selection"; text: string } | { type: "compose"; text: string } | { type: "delete_surrounding"; before: number; after: number } | { type: "delete_surrounding_utf16"; before: number; after: number } | { type: "set_composition"; start: number; end: number } | { type: "clear_composition" } | { type: "commit_as_is" } | { type: "move_cursor"; delta: number };
 
 export type FoldContentNodeAttr = void;
 

--- a/crates/editor-ffi/pkg/server/editor_ffi.d.ts
+++ b/crates/editor-ffi/pkg/server/editor_ffi.d.ts
@@ -43,6 +43,16 @@ export interface Changeset<P> {
 }
 
 /**
+ * Edits to the IME's linear input buffer, initially addressed in document-flat
+ * Unicode scalar offsets. Each operation addresses the buffer after preceding
+ * operations in the same message, including across `CommitAsIs` barriers.
+ * Inserted CR/LF characters retain their input-buffer width; the engine binds
+ * their positions to the actual paragraph edits. Hosts must not pre-expand
+ * them into structural document offsets or separate Enter messages.
+ */
+export type FlatImeOp = { type: "set_selection"; start: number; end: number } | { type: "replace_selection"; text: string } | { type: "compose"; text: string } | { type: "delete_surrounding"; before: number; after: number } | { type: "delete_surrounding_utf16"; before: number; after: number } | { type: "set_composition"; start: number; end: number } | { type: "clear_composition" } | { type: "commit_as_is" } | { type: "move_cursor"; delta: number };
+
+/**
  * One node in the op-DAG. `id` is the op's unique identifier (also reused as
  * the semantic identifier — RGA element id, OR-Set add token — by the
  * payload). `parents` are the op-DAG parents of this op (the heads of the
@@ -794,8 +804,6 @@ export type ExternalDndPayloadKind = "text" | "html" | "image_files" | "files" |
 export type ExternalElementData = { type: "image"; id: string | undefined; proportion: number } | { type: "file"; id: string | undefined } | { type: "embed"; id: string | undefined } | { type: "archived"; id: string | undefined };
 
 export type FileNodeAttr = { type: "id"; value: string | undefined };
-
-export type FlatImeOp = { type: "set_selection"; start: number; end: number } | { type: "replace_selection"; text: string } | { type: "compose"; text: string } | { type: "delete_surrounding"; before: number; after: number } | { type: "delete_surrounding_utf16"; before: number; after: number } | { type: "set_composition"; start: number; end: number } | { type: "clear_composition" } | { type: "commit_as_is" } | { type: "move_cursor"; delta: number };
 
 export type FoldContentNodeAttr = void;
 


### PR DESCRIPTION
여러 줄 입력이나 연속된 IME 편집에서 커서·선택·조합 범위가 어긋날 수 있는 문제를 수정합니다.

여러 줄을 입력하면 엔진이 줄바꿈을 문단으로 변환하면서 위치 계산이 달라집니다. 이 차이를 반영하지 않아, 뒤이어 요청된 입력이나 선택이 다른 위치에 적용될 수 있었습니다. 예를 들어 a\nb를 넣은 뒤 b 뒤에 X를 입력하라는 요청이 올바르게 a\nbX로 이어지도록 수정합니다.

- IME 입력 버퍼의 좌표를 실제 문서 위치에 매핑하여 문단 분리와 조합 확정 이후에도 후속 편집 위치를 유지합니다.
- 앱과 웹의 줄바꿈 전처리를 제거하고, Rust 엔진에서 공통 Enter 처리 로직을 사용하도록 통합합니다.
- Android 입력 배치도 공통 변환 경로를 사용하며, 앞선 편집 결과와 IME가 요청한 커서 위치를 반영합니다.
- 서로 다른 입력 메시지를 합치지 않아 메시지별 좌표 기준을 보존합니다.
- CRLF 처리, 목록·이미지 경계의 줄바꿈, 연속 편집에 대한 회귀 테스트를 보강합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>