### PR TITLE
IME 삭제 및 빈 조합 처리 오류 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/input/EditorImeCommandNormalizer.kt
@@ -85,13 +85,14 @@ internal object EditorImeCommandNormalizer {
           )
       }
       hasActiveComposition =
-        when (op) {
-          is FlatImeOp.Compose,
-          is FlatImeOp.SetComposition -> true
-          is FlatImeOp.ClearComposition,
-          is FlatImeOp.CommitAsIs -> false
-          else -> hasActiveComposition
-        }
+        valueAfter?.let { it.composition != null }
+          ?: when (op) {
+            is FlatImeOp.Compose -> op.text.isNotEmpty()
+            is FlatImeOp.SetComposition -> op.start != op.end
+            is FlatImeOp.ClearComposition,
+            is FlatImeOp.CommitAsIs -> false
+            else -> hasActiveComposition
+          }
     }
 
     return if (ops.isEmpty()) emptyList() else listOf(Message.TextInput(ops))
@@ -133,10 +134,9 @@ internal object EditorImeCommandNormalizer {
           FlatImeOp.ClearComposition
         } else {
           ime?.let {
-            FlatImeOp.SetComposition(
-              it.windowStart + windowText.codePointOffsetAtUtf16Index(minOf(start, end)),
-              it.windowStart + windowText.codePointOffsetAtUtf16Index(maxOf(start, end)),
-            )
+            val from = it.windowStart + windowText.codePointOffsetAtUtf16Index(minOf(start, end))
+            val to = it.windowStart + windowText.codePointOffsetAtUtf16Index(maxOf(start, end))
+            if (from == to) FlatImeOp.ClearComposition else FlatImeOp.SetComposition(from, to)
           }
         }
       is DeleteSurroundingTextCommand ->

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/input/EditorImeCommandNormalizerTest.kt
@@ -1,6 +1,7 @@
 package co.typie.editor.input
 
 import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
 import androidx.compose.ui.text.input.DeleteSurroundingTextInCodePointsCommand
 import androidx.compose.ui.text.input.FinishComposingTextCommand
 import androidx.compose.ui.text.input.SetComposingRegionCommand
@@ -18,6 +19,74 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class EditorImeCommandNormalizerTest {
+  @Test
+  fun `composing region clamped to an empty range clears native composition`() {
+    val ime =
+      Ime(
+        text = "abcd",
+        windowStart = 10,
+        selection = ImeRange(12, 12),
+        composing = ImeRange(11, 12),
+      )
+    val messages =
+      EditorImeCommandNormalizer.normalize(
+        listOf(SetComposingRegionCommand(20, 30), CommitTextCommand("X", 1)),
+        ime,
+      )
+    assertEquals(
+      listOf(
+        Message.TextInput(listOf(FlatImeOp.ClearComposition, FlatImeOp.ReplaceSelection("X")))
+      ),
+      messages,
+    )
+  }
+
+  @Test
+  fun `deleting the whole composition commits at the later selection`() {
+    val ime =
+      Ime(text = "abcd", windowStart = 0, selection = ImeRange(2, 2), composing = ImeRange(1, 2))
+    for (delete in
+      listOf(DeleteSurroundingTextCommand(1, 0), DeleteSurroundingTextInCodePointsCommand(1, 0))) {
+      val messages =
+        EditorImeCommandNormalizer.normalize(
+          listOf(delete, SetSelectionCommand(2, 2), CommitTextCommand("X", 1)),
+          ime,
+        )
+      val deleteOp =
+        if (delete is DeleteSurroundingTextCommand) FlatImeOp.DeleteSurroundingUtf16(1, 0)
+        else FlatImeOp.DeleteSurrounding(1, 0)
+      assertEquals(
+        listOf(
+          Message.TextInput(
+            listOf(deleteOp, FlatImeOp.SetSelection(2, 2), FlatImeOp.ReplaceSelection("X"))
+          )
+        ),
+        messages,
+      )
+    }
+  }
+
+  @Test
+  fun `empty preedit clears composition even without an IME snapshot`() {
+    val messages =
+      EditorImeCommandNormalizer.normalize(
+        listOf(
+          SetComposingTextCommand("", 1),
+          FinishComposingTextCommand(),
+          CommitTextCommand("X", 1),
+        ),
+        ime = null,
+      )
+    assertEquals(
+      listOf(
+        Message.TextInput(
+          listOf(FlatImeOp.Compose(""), FlatImeOp.ClearComposition, FlatImeOp.ReplaceSelection("X"))
+        )
+      ),
+      messages,
+    )
+  }
+
   @Test
   fun `commit cursor position is retained before a later edit`() {
     val ime =

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorImeCoordinateContractTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/editor/input/EditorImeCoordinateContractTest.kt
@@ -1,6 +1,9 @@
 package co.typie.editor.input
 
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
+import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.SetSelectionCommand
 import co.typie.editor.ffi.Ime
 import co.typie.editor.ffi.ImeRange
@@ -11,6 +14,60 @@ import kotlin.test.assertEquals
 import kotlinx.serialization.json.Json
 
 class EditorImeCoordinateContractTest {
+  @Test
+  fun `deletion and empty composition match the native buffer and Rust fixtures`() {
+    val fixture =
+      File("../../../crates/editor-core/src/tests/fixtures/ime-delete-composition.json").readText()
+    val messages = Json.decodeFromString<Map<String, List<Message>>>(fixture)
+    for (name in messages.keys) {
+      val ime =
+        Ime(
+          text = "\u2028abcd\u2029",
+          windowStart = 0,
+          selection = if (name == "delete-before-selection") ImeRange(2, 4) else ImeRange(3, 3),
+          composing =
+            when (name) {
+              "delete-inside-composition" -> ImeRange(2, 4)
+              "empty-composition" -> ImeRange(2, 3)
+              else -> null
+            },
+        )
+      val commands =
+        when (name) {
+          "delete-before-selection" ->
+            listOf(DeleteSurroundingTextCommand(1, 0), CommitTextCommand("X", 1))
+          "delete-inside-composition" ->
+            listOf(
+              DeleteSurroundingTextCommand(1, 0),
+              SetSelectionCommand(3, 3),
+              CommitTextCommand("X", 1),
+            )
+          "empty-composition" ->
+            listOf(
+              SetComposingTextCommand("", 1),
+              SetSelectionCommand(3, 3),
+              CommitTextCommand("X", 1),
+            )
+          else -> error("Unknown fixture: $name")
+        }
+      val expected =
+        when (name) {
+          "delete-before-selection" -> "Xd" to 2
+          "delete-inside-composition" -> "aXd" to 3
+          else -> "acXd" to 4
+        }
+      val native = ime.toEditProcessor().apply(commands)
+      assertEquals("\u2028${expected.first}\u2029", native.text, name)
+      assertEquals(TextRange(expected.second), native.selection, name)
+      assertEquals(null, native.composition, name)
+      assertEquals(
+        messages.getValue(name),
+        EditorImeCommandNormalizer.normalize(commands, ime),
+        name,
+      )
+    }
+  }
+
   @Test
   fun `multiline selection messages match the Rust integration fixture`() {
     val ime =

--- a/crates/editor-core/src/editor.rs
+++ b/crates/editor-core/src/editor.rs
@@ -4646,6 +4646,9 @@ mod tests {
         // below the limit — but the active composition defers the re-anchor.
         editor.apply(Message::TextInput {
             ops: vec![
+                // Surrounding deletes count from the selection, so move to
+                // the composition start before deleting the preceding text.
+                FlatImeOp::SetSelection { start: 7, end: 7 },
                 FlatImeOp::DeleteSurrounding {
                     before: 1,
                     after: 0,
@@ -4654,6 +4657,7 @@ mod tests {
                     before: 1,
                     after: 0,
                 },
+                FlatImeOp::SetSelection { start: 6, end: 6 },
             ],
         });
         let ctx = editor.ime(3, 3).unwrap().unwrap();

--- a/crates/editor-core/src/handle/text_input.rs
+++ b/crates/editor-core/src/handle/text_input.rs
@@ -11,7 +11,7 @@ use editor_state::{
     as_gap_cursor, continuation_at, flat_chars, flat_segments_in_range, flat_size,
     replacement_paint,
 };
-use editor_transaction::{HistoryMeta, Transaction};
+use editor_transaction::{HistoryMeta, MergeKind, Transaction};
 
 use crate::editor::Editor;
 use crate::error::EditorError;
@@ -550,7 +550,7 @@ impl FlatImeState {
                 self.text.splice(start..end, chars.iter().copied());
                 self.sel_start = new_end;
                 self.sel_end = new_end;
-                self.comp = Some((start, new_end));
+                self.comp = (start < new_end).then_some((start, new_end));
                 Some(FlatImeTextChange {
                     replace_start: start,
                     replace_end: end,
@@ -594,19 +594,11 @@ impl FlatImeState {
         }
     }
 
-    // deleteSurrounding must not touch the composing text: lengths count from
-    // its edges (AOSP BaseInputConnection contract).
+    // InputConnection/Compose exclude the selection, not the composition.
+    // A deletion may shorten or remove the composing range.
     fn surrounding_delete_bases(&self) -> (usize, usize) {
         let len = self.text.len();
-        let cursor = self.sel_start.min(len);
-        match self.comp {
-            Some((comp_start, comp_end)) => {
-                let base_before = cursor.min(comp_start);
-                let base_after = self.sel_end.max(comp_end).min(len).max(base_before);
-                (base_before, base_after)
-            }
-            None => (cursor, cursor),
-        }
+        (self.sel_start.min(len), self.sel_end.min(len))
     }
 
     fn apply_surrounding_deletes(
@@ -618,14 +610,12 @@ impl FlatImeState {
     ) -> Option<FlatImeTextChange> {
         let deletes_before = del_start < base_before;
         let deletes_after = base_after < del_end;
-        // Deleting on both sides of a non-empty composing region is two
-        // disjoint edits — unrepresentable as one flat replacement (same
-        // policy as disjoint batches), so the op is ignored.
+        // The handler splits two-sided deletes before reduction, so each
+        // change can preserve the selected text and its per-character paint.
         if base_before < base_after && deletes_before && deletes_after {
             return None;
         }
 
-        let remap_selection = self.comp.is_some();
         let (start, end) = if base_before < base_after {
             if deletes_before {
                 (del_start, base_before)
@@ -638,11 +628,7 @@ impl FlatImeState {
 
         if start < end {
             self.text.splice(start..end, std::iter::empty());
-            self.remap_after_delete(start, end, remap_selection);
-        }
-        if !remap_selection {
-            self.sel_start = del_start;
-            self.sel_end = del_start;
+            self.remap_after_delete(start, end);
         }
         (start < end).then_some(FlatImeTextChange {
             replace_start: start,
@@ -651,7 +637,7 @@ impl FlatImeState {
         })
     }
 
-    fn remap_after_delete(&mut self, del_start: usize, del_end: usize, remap_selection: bool) {
+    fn remap_after_delete(&mut self, del_start: usize, del_end: usize) {
         let removed = del_end - del_start;
         let map = |pos: usize| {
             if pos >= del_end {
@@ -661,12 +647,35 @@ impl FlatImeState {
             }
         };
         if let Some((start, end)) = self.comp {
-            self.comp = Some((map(start), map(end)));
+            let (start, end) = (map(start), map(end));
+            self.comp = (start < end).then_some((start, end));
         }
-        if remap_selection {
-            self.sel_start = map(self.sel_start);
-            self.sel_end = map(self.sel_end);
+        self.sel_start = map(self.sel_start);
+        self.sel_end = map(self.sel_end);
+    }
+
+    fn contiguous_prefix_len(mut self, ops: &[FlatImeOp]) -> usize {
+        let mut change: Option<FlatImeAnchoredChangeTracker> = None;
+        let mut last_edit_end = 0;
+        for (index, op) in ops.iter().enumerate() {
+            if let Some(next) = self.apply(op) {
+                match &mut change {
+                    Some(change) => {
+                        if !change.absorb(next, &self.text) {
+                            // Keep the next edit's selection/composition setup
+                            // with that edit, including an empty Web target.
+                            return last_edit_end;
+                        }
+                    }
+                    None => change = Some(FlatImeAnchoredChangeTracker::new(next, &self.text)),
+                }
+                last_edit_end = index + 1;
+            }
+            if matches!(op, FlatImeOp::CommitAsIs) {
+                return index + 1;
+            }
         }
+        ops.len()
     }
 
     #[cfg(test)]
@@ -724,8 +733,8 @@ impl FlatImeState {
                 let change = FlatImeTextChange::collapsed_at(initial_sel_start);
                 (Some(change.clone()), Some(change))
             }
-            // A batch with disjoint text edits cannot be represented as one safe
-            // flat replacement. Ignore it instead of widening the edited range.
+            // Only a contiguous segment is representable as one replacement.
+            // The handler splits disjoint edits before calling this reducer.
             None => (None, None),
         };
 
@@ -905,15 +914,42 @@ fn flat_ime_ops_have_direct_backspace_shape(ops: &[FlatImeOp]) -> bool {
 }
 
 pub fn handle_flat_ime_ops(editor: &mut Editor, ops: Vec<FlatImeOp>) -> Result<(), EditorError> {
-    let mut ops = ops;
+    let mut normalized = Vec::with_capacity(ops.len());
+    for op in ops {
+        // Delete after first so the before count retains its original base.
+        // Two disjoint sides must never become a replacement of the selection.
+        match op {
+            FlatImeOp::DeleteSurrounding { before, after } if before > 0 && after > 0 => {
+                normalized.push(FlatImeOp::DeleteSurrounding { before: 0, after });
+                normalized.push(FlatImeOp::DeleteSurrounding { before, after: 0 });
+            }
+            FlatImeOp::DeleteSurroundingUtf16 { before, after } if before > 0 && after > 0 => {
+                normalized.push(FlatImeOp::DeleteSurroundingUtf16 { before: 0, after });
+                normalized.push(FlatImeOp::DeleteSurroundingUtf16 { before, after: 0 });
+            }
+            _ => normalized.push(op),
+        }
+    }
+    let mut ops = normalized;
     let mut remaining = ops.as_mut_slice();
+    let mut undo_start = editor.undo_history.undos_len();
     while !remaining.is_empty() {
-        let count = remaining
-            .iter()
-            .position(|op| matches!(op, FlatImeOp::CommitAsIs))
-            .map_or(remaining.len(), |index| index + 1);
+        let count = if remaining.len() == 1 {
+            1
+        } else {
+            let Some(initial) = FlatImeState::from_editor(editor, remaining) else {
+                return Ok(());
+            };
+            initial.contiguous_prefix_len(remaining)
+        };
         let (segment, tail) = remaining.split_at_mut(count);
-        handle_flat_ime_segment(editor, segment, tail)?;
+        let committed = matches!(segment.last(), Some(FlatImeOp::CommitAsIs));
+        let isolate_history = !committed && !tail.is_empty();
+        handle_flat_ime_segment(editor, segment, tail, isolate_history)?;
+        if committed || tail.is_empty() || editor.last_history_tag().is_some() {
+            editor.undo_history.merge_since(undo_start);
+            undo_start = editor.undo_history.undos_len();
+        }
         remaining = tail;
     }
     Ok(())
@@ -923,6 +959,7 @@ fn handle_flat_ime_segment(
     editor: &mut Editor,
     ops: &[FlatImeOp],
     tail: &mut [FlatImeOp],
+    isolate_history: bool,
 ) -> Result<(), EditorError> {
     let mut delete_paint = editor.ime_delete_paint.take();
     let plain_backspace = flat_ime_ops_form_plain_backspace(editor, ops);
@@ -1290,6 +1327,9 @@ fn handle_flat_ime_segment(
                     }
                 }
 
+                if isolate_history {
+                    tr.update_meta(|meta| meta.merge = MergeKind::Isolated);
+                }
                 Ok(())
             })?;
         }
@@ -2783,6 +2823,29 @@ mod tests {
     }
 
     #[test]
+    fn empty_composition_does_not_anchor_later_preedit() {
+        for empty in [
+            FlatImeOp::Compose { text: "".into() },
+            FlatImeOp::DeleteSurrounding {
+                before: 1,
+                after: 0,
+            },
+        ] {
+            let mut s = flat_ime_state("abcd", 2);
+            s.comp = Some((1, 2));
+            s.apply(&empty);
+            assert_eq!(flat_ime_text(&s), "acd");
+            assert_eq!(s.comp, None);
+            let s = s.reduce(&[
+                FlatImeOp::SetSelection { start: 2, end: 2 },
+                FlatImeOp::Compose { text: "X".into() },
+            ]);
+            assert_eq!(flat_ime_text(&s), "acXd");
+            assert_eq!(s.comp, Some((2, 3)));
+        }
+    }
+
+    #[test]
     fn korean_ime_recomposition_batch() {
         let o = FLAT_OPEN;
         let c = FLAT_CLOSE;
@@ -2928,9 +2991,9 @@ mod tests {
     }
 
     #[test]
-    fn flat_ime_disjoint_text_edits_are_ignored() {
+    fn flat_ime_disjoint_text_edits_preserve_intervening_paint() {
         let (s, ..) = state! {
-            doc { root { p1: paragraph { text("abcdef") } } }
+            doc { root { p1: paragraph { text("ab") text("cd") [bold] text("ef") } } }
             selection: (p1, 0)
         };
         let editor = apply_flat_ime_ops(
@@ -2943,14 +3006,37 @@ mod tests {
             ],
         );
         let (expected, ..) = state! {
-            doc { root { p1: paragraph { text("abcdef") } } }
-            selection: (p1, 0)
+            doc { root { p1: paragraph { text("aB") text("cd") [bold] text("Ef") } } }
+            selection: (p1, 5)
         };
         assert_state_eq!(editor.state(), &expected);
     }
 
     #[test]
-    fn flat_ime_disjoint_text_edits_at_gap_cursor_do_not_materialize() {
+    fn flat_ime_disjoint_edit_keeps_its_empty_web_composition_target() {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph { text("abcdef") } } }
+            selection: (p, 1) -> (p, 2)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::TextInput {
+            ops: vec![
+                FlatImeOp::ReplaceSelection { text: "B".into() },
+                FlatImeOp::SetComposition { start: 5, end: 5 },
+                FlatImeOp::Compose { text: "X".into() },
+                FlatImeOp::CommitAsIs,
+            ],
+        });
+        let (expected, ..) = state! {
+            doc { root { p: paragraph { text("aBcdXef") } } }
+            selection: (p, 5)
+        };
+        assert_state_eq!(editor.state(), &expected);
+        assert_eq!(editor.state().composition, None);
+    }
+
+    #[test]
+    fn flat_ime_disjoint_text_edits_away_from_gap_cursor_do_not_materialize_it() {
         let (s, ..) = state! {
             doc { r: root { image paragraph { text("abcdef") } } }
             selection: (r, 0, <)
@@ -2980,8 +3066,8 @@ mod tests {
         });
 
         let (expected, ..) = state! {
-            doc { r: root { image paragraph { text("abcdef") } } }
-            selection: (r, 0, <)
+            doc { root { image p: paragraph { text("aBcdEf") } } }
+            selection: (p, 5)
         };
         assert_state_eq!(editor.state(), &expected);
     }
@@ -3451,6 +3537,40 @@ mod tests {
             selection: (p1, 1)
         };
         assert_state_eq!(editor.state(), &expected);
+    }
+
+    #[test]
+    fn flat_ime_delete_both_sides_preserves_selection_and_paint() {
+        for op in [
+            FlatImeOp::DeleteSurrounding {
+                before: 1,
+                after: 1,
+            },
+            FlatImeOp::DeleteSurroundingUtf16 {
+                before: 2,
+                after: 2,
+            },
+        ] {
+            let (initial, ..) = state! {
+                doc { root { p: paragraph { text("😀") text("bc") [bold] text("😺") } } }
+                selection: (p, 1) -> (p, 3)
+            };
+            let mut editor = Editor::new_test(initial.clone());
+            editor.apply(Message::TextInput { ops: vec![op] });
+            let (expected, ..) = state! {
+                doc { root { p: paragraph { text("bc") [bold] } } }
+                selection: (p, 0) -> (p, 2)
+            };
+            assert_state_eq!(editor.state(), &expected);
+            editor.apply(Message::History {
+                op: HistoryOp::Undo,
+            });
+            assert_state_eq!(editor.state(), &initial);
+            editor.apply(Message::History {
+                op: HistoryOp::Redo,
+            });
+            assert_state_eq!(editor.state(), &expected);
+        }
     }
 
     #[test]
@@ -5092,7 +5212,7 @@ mod tests {
     }
 
     #[test]
-    fn flat_ime_delete_surrounding_excludes_composing_text() {
+    fn flat_ime_delete_surrounding_deletes_composing_text_before_caret() {
         let (state, ..) = state! {
             doc { root { p1: paragraph { text("가") } } }
             selection: (p1, 1)
@@ -5113,14 +5233,11 @@ mod tests {
         });
 
         let (expected, ..) = state! {
-            doc { root { p1: paragraph { text("나") } } }
+            doc { root { p1: paragraph { text("가") } } }
             selection: (p1, 1)
         };
         assert_state_eq!(editor.state(), &expected);
-        assert_eq!(
-            editor.state().composition,
-            Some(Composition { start: 1, end: 2 })
-        );
+        assert_eq!(editor.state().composition, None);
     }
 
     #[test]
@@ -5156,7 +5273,7 @@ mod tests {
     }
 
     #[test]
-    fn flat_ime_delete_surrounding_both_sides_of_composing_text_is_ignored() {
+    fn flat_ime_delete_surrounding_both_sides_of_caret_in_composing_text() {
         let (state, ..) = state! {
             doc { root { p1: paragraph { text("가다") } } }
             selection: (p1, 1)
@@ -5173,14 +5290,11 @@ mod tests {
         });
 
         let (expected, ..) = state! {
-            doc { root { p1: paragraph { text("가나다") } } }
-            selection: (p1, 2)
+            doc { root { p1: paragraph { text("가") } } }
+            selection: (p1, 1)
         };
         assert_state_eq!(editor.state(), &expected);
-        assert_eq!(
-            editor.state().composition,
-            Some(Composition { start: 2, end: 3 })
-        );
+        assert_eq!(editor.state().composition, None);
     }
 
     #[test]

--- a/crates/editor-core/src/tests/fixtures/ime-delete-composition.json
+++ b/crates/editor-core/src/tests/fixtures/ime-delete-composition.json
@@ -1,0 +1,32 @@
+{
+  "delete-before-selection": [
+    {
+      "type": "text_input",
+      "ops": [
+        { "type": "delete_surrounding_utf16", "before": 1, "after": 0 },
+        { "type": "replace_selection", "text": "X" }
+      ]
+    }
+  ],
+  "delete-inside-composition": [
+    {
+      "type": "text_input",
+      "ops": [
+        { "type": "delete_surrounding_utf16", "before": 1, "after": 0 },
+        { "type": "set_selection", "start": 3, "end": 3 },
+        { "type": "compose", "text": "X" },
+        { "type": "commit_as_is" }
+      ]
+    }
+  ],
+  "empty-composition": [
+    {
+      "type": "text_input",
+      "ops": [
+        { "type": "compose", "text": "" },
+        { "type": "set_selection", "start": 3, "end": 3 },
+        { "type": "replace_selection", "text": "X" }
+      ]
+    }
+  ]
+}

--- a/crates/editor-core/src/text_replacement_tests.rs
+++ b/crates/editor-core/src/text_replacement_tests.rs
@@ -240,6 +240,65 @@ fn ime_crlf_partial_delete_updates_coordinates_even_without_a_document_edit() {
 }
 
 #[test]
+fn ime_disjoint_edits_keep_automatic_replacement_undo_boundary() {
+    let (initial, ..) = state! {
+        doc { root { p: paragraph { text("abcdef") } } }
+        selection: (p, 1) -> (p, 2)
+    };
+    let mut editor = editor_with_rules(initial, vec![rule("B", "β", false)]);
+    editor.apply(Message::TextInput {
+        ops: vec![
+            FlatImeOp::ReplaceSelection { text: "B".into() },
+            FlatImeOp::SetSelection { start: 5, end: 6 },
+            FlatImeOp::ReplaceSelection { text: "E".into() },
+        ],
+    });
+    assert_eq!(flat_text(&editor), "\u{2028}aβcdEf\u{2029}");
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+    assert_eq!(flat_text(&editor), "\u{2028}aβcdef\u{2029}");
+    editor.apply(Message::History {
+        op: HistoryOp::Undo,
+    });
+    assert_eq!(flat_text(&editor), "\u{2028}aBcdef\u{2029}");
+}
+
+#[test]
+fn ime_deletion_and_empty_composition_match_the_native_input_buffer() {
+    let fixtures: std::collections::BTreeMap<String, Vec<Message>> =
+        serde_json::from_str(include_str!("tests/fixtures/ime-delete-composition.json")).unwrap();
+    for (name, start, end, composition, text, caret) in [
+        ("delete-before-selection", 2, 4, None, "Xd", 1),
+        ("delete-inside-composition", 3, 3, Some((2, 4)), "aXd", 2),
+        ("empty-composition", 3, 3, Some((2, 3)), "acXd", 3),
+    ] {
+        let (initial, ..) = state! {
+            doc { root { p: paragraph { text("abcd") } } }
+            selection: (p, 2)
+        };
+        let mut editor = Editor::new_test(initial);
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::SetSelection { start, end }],
+        });
+        if let Some((start, end)) = composition {
+            editor.apply(Message::TextInput {
+                ops: vec![FlatImeOp::SetComposition { start, end }],
+            });
+        }
+        let request = editor.enqueue_request(fixtures[name].clone()).unwrap();
+        editor.tick_through(request).unwrap();
+        assert_eq!(
+            flat_text(&editor),
+            format!("\u{2028}{text}\u{2029}"),
+            "{name}"
+        );
+        assert_eq!(caret_flat(&editor), caret + 1, "{name}");
+        assert_eq!(editor.state().composition, None, "{name}");
+    }
+}
+
+#[test]
 fn ime_multiline_selection_matches_the_native_input_buffer() {
     let (initial, ..) = state! {
         doc { root { p: paragraph {} } }

--- a/crates/editor-state/src/undo.rs
+++ b/crates/editor-state/src/undo.rs
@@ -218,6 +218,26 @@ impl UndoHistory {
         }
     }
 
+    /// Combine transactions of one action, retaining its first pre-edit
+    /// selection. Tagged entries (e.g. automatic replacements) keep their own
+    /// undo boundary. The caller isolates the action's first transaction so
+    /// it cannot have merged into an entry before `start`.
+    pub fn merge_since(&mut self, start: usize) {
+        if self.undos.len().saturating_sub(start) < 2
+            || self.undos[start..].iter().any(|entry| entry.tag.is_some())
+        {
+            return;
+        }
+        let tail = self.undos.split_off(start + 1);
+        let first = self.undos.last_mut().expect("start names an undo entry");
+        for entry in tail {
+            first.ops.extend(entry.ops);
+        }
+        first.merge = RecordMerge::Isolated;
+        self.last_push = None;
+        self.sync_last_tag_from_top();
+    }
+
     /// Undo the most recent entry: apply each op's inverse to `state`, returning
     /// the applied inverse ops (so the editor can broadcast them), the selection
     /// to restore, and the ids of the entry's own ops — the edits this call took


### PR DESCRIPTION
조합 중인 글자를 모두 지워도 이전 조합 위치가 남아, 커서를 옮긴 뒤 입력해도 지운 자리에 글자가 들어갈 수 있었습니다. 삭제 후 조합·선택 상태를 올바르게 갱신합니다.
또한 한 입력 요청에서 서로 떨어진 두 곳을 수정하면 요청 전체가 무시되던 문제를 고칩니다. 중간 텍스트와 서식은 보존하고, 되돌리기는 한 번에 처리합니다.

- 주변 텍스트 삭제 시 선택 범위를 유지하고 조합 범위를 삭제 결과에 맞게 조정합니다.
- 조합이 비워진 뒤 다음 입력이 이전 조합 위치에 삽입되는 문제를 수정합니다.
- 한 입력 묶음에서 떨어진 위치의 편집을 중간 텍스트와 서식을 보존하며 순서대로 적용합니다.
- 나누어 실행한 편집을 함께 되돌리되, 자동 치환의 별도 Undo 경계는 유지합니다.
- Compose 편집 버퍼와 Rust 엔진의 결과를 비교하는 회귀 테스트를 추가합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>