### PR TITLE
iOS FFI 빌드 최소 지원 버전을 15.6으로 명시

### DIFF
--- a/crates/editor-ffi/justfile
+++ b/crates/editor-ffi/justfile
@@ -94,6 +94,12 @@ ensure cmd *install:
 
 [private]
 build features target:
+    #!/usr/bin/env bash
+    set -e
+    # Match the app/Compose minimum; cc otherwise defaults to the installed SDK.
+    if [[ "{{target}}" == *-apple-ios* ]]; then
+        export IPHONEOS_DEPLOYMENT_TARGET=15.6
+    fi
     rustup target add {{target}}
     cargo build --manifest-path {{justfile_directory()}}/Cargo.toml \
         --profile {{profile}}-{{features}} --features {{features}} --target {{target}}


### PR DESCRIPTION
앱은 iOS 15.6부터 지원하지만, FFI의 일부 네이티브 의존성은 빌드 머신의 SDK 버전(26.5)을 최소 지원 버전으로 기록하고 있었습니다.

iPhone·시뮬레이터용 FFI 빌드에 `IPHONEOS_DEPLOYMENT_TARGET=15.6`을 명시해 앱의 지원 버전과 맞춥니다. 다른 플랫폼 빌드에는 적용하지 않습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>