### PR TITLE
페이지 연결 실패 안내와 재시도 추가

### DIFF
--- a/apps/website/src/lib/bootstrap.test.ts
+++ b/apps/website/src/lib/bootstrap.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { checkBootstrapAssertion } from './bootstrap';
+
+describe('checkBootstrapAssertion', () => {
+  it('turns a failed fetch into a recoverable page error', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(checkBootstrapAssertion(fetch)).rejects.toMatchObject({ status: 503, body: { code: 'network_error' } });
+  });
+
+  it.each([502, 503, 504])('rejects HTTP %s without a maintenance response as unavailable', async (status) => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(null, { status }));
+
+    await expect(checkBootstrapAssertion(fetch)).rejects.toMatchObject({ status, body: { code: 'service_unavailable' } });
+  });
+
+  it('preserves an explicit maintenance response when retrying', async () => {
+    const body = {
+      code: 'maintenance',
+      message: '점검 중이에요.',
+      maintenance: { title: '서버 점검 중', message: '점검 중이에요.', until: null },
+    };
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(Response.json(body, { status: 503 }));
+
+    await expect(checkBootstrapAssertion(fetch)).rejects.toMatchObject({ status: 503, body });
+  });
+
+  it('allows loading to continue for a normal bootstrap response', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(Response.json(null));
+
+    await expect(checkBootstrapAssertion(fetch)).resolves.toBeUndefined();
+  });
+});

--- a/apps/website/src/lib/bootstrap.ts
+++ b/apps/website/src/lib/bootstrap.ts
@@ -16,10 +16,18 @@ export type Bootstrap = {
 };
 
 export async function checkBootstrapAssertion(fetch: typeof globalThis.fetch): Promise<void> {
-  const resp = await fetch('/api/bootstrap');
+  const resp = await fetch('/api/bootstrap').catch((err: unknown) => {
+    if (err instanceof TypeError) {
+      error(503, { code: 'network_error', message: '서버에 연결할 수 없어요.' });
+    }
+    throw err;
+  });
   const body = await resp.json().catch(() => null);
   if (body?.code === 'maintenance') {
     error(resp.status, body);
+  }
+  if (resp.status === 502 || resp.status === 503 || resp.status === 504) {
+    error(resp.status, { code: 'service_unavailable', message: '서버를 일시적으로 사용할 수 없어요.' });
   }
 }
 

--- a/apps/website/src/lib/graphql/server.test.ts
+++ b/apps/website/src/lib/graphql/server.test.ts
@@ -1,0 +1,109 @@
+import { createServer } from 'node:net';
+import { AggregatedError } from '@mearie/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '../../routes/graphql/+server';
+import { loadQuery } from './server';
+import type { Artifact } from '@mearie/svelte';
+
+const privateEnv = vi.hoisted(() => ({ PRIVATE_API_URL: 'http://api.test' }));
+vi.mock('$app/environment', () => ({ browser: false, dev: true }));
+vi.mock('$env/dynamic/private', () => ({ env: privateEnv }));
+vi.mock('$env/dynamic/public', () => ({ env: {} }));
+vi.mock('./client', () => ({ mearieClient: null, scalars: {} }));
+
+const query = {
+  kind: 'query',
+  name: 'PageQuery',
+  body: 'query PageQuery { __typename }',
+  selections: [{ kind: 'Field', name: '__typename', type: 'String' }],
+} satisfies Artifact<'query'>;
+
+const url = new URL('https://typie.test/document');
+
+const cookies = {
+  get: (name: string) => (name === 'typie-did' ? 'test-device' : undefined),
+  delete: vi.fn(),
+};
+
+const proxyFetch: typeof fetch = async (input, init) => {
+  expect(input).toBe('/graphql');
+  return POST({
+    request: new Request(new URL('/graphql', url), init),
+    cookies,
+    getClientAddress: () => '127.0.0.1',
+  } as unknown as Parameters<typeof POST>[0]);
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cookies.delete.mockClear();
+  privateEnv.PRIVATE_API_URL = 'http://api.test';
+});
+
+describe('loadQuery errors', () => {
+  it('turns a failed fetch into a recoverable page error', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(loadQuery({ fetch, url }, query)).rejects.toMatchObject({ status: 503, body: { code: 'network_error' } });
+  });
+
+  it.each([502, 503, 504])('treats HTTP %s as unavailable without inventing a maintenance response', async (status) => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(null, { status }));
+
+    await expect(loadQuery({ fetch, url }, query)).rejects.toMatchObject({ status, body: { code: 'service_unavailable' } });
+  });
+
+  it('preserves the authentication redirect', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(null, { status: 401 }));
+
+    await expect(loadQuery({ fetch, url }, query)).rejects.toMatchObject({ status: 302, location: url.href });
+  });
+
+  it('does not classify invalid JSON as a connection failure', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response('invalid JSON'));
+
+    await expect(loadQuery({ fetch, url }, query)).rejects.toBeInstanceOf(AggregatedError);
+  });
+});
+
+describe('GraphQL proxy errors', () => {
+  it('returns 502 when the API refuses connections and exposes a recoverable page error', async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (!address || typeof address === 'string') throw new Error('Missing server address');
+    privateEnv.PRIVATE_API_URL = `http://127.0.0.1:${address.port}`;
+
+    const response = await proxyFetch('/graphql', { method: 'POST', body: '{}' });
+    expect(response.status).toBe(502);
+    await expect(loadQuery({ fetch: proxyFetch, url }, query)).rejects.toMatchObject({
+      status: 502,
+      body: { code: 'service_unavailable' },
+    });
+  });
+
+  it('returns 502 when the connection fails while reading the API response body', async () => {
+    const body = new ReadableStream({ start: (controller) => controller.error(new TypeError('terminated')) });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(body)));
+
+    await expect(proxyFetch('/graphql', { method: 'POST', body: '{}' })).resolves.toMatchObject({ status: 502 });
+  });
+
+  it.each([401, 500])('preserves an API HTTP %s response and authentication handling', async (status) => {
+    const body = { errors: [{ message: 'API error' }] };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json(body, { status })));
+
+    const response = await proxyFetch('/graphql', { method: 'POST', body: '{}' });
+    expect(response.status).toBe(status);
+    await expect(response.json()).resolves.toEqual(body);
+    expect(cookies.delete.mock.calls).toEqual(status === 401 ? [['typie-at', { path: '/' }]] : []);
+  });
+
+  it('does not hide unexpected proxy errors as API connection failures', async () => {
+    const failure = new Error('Unexpected proxy failure');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(failure));
+
+    await expect(proxyFetch('/graphql', { method: 'POST', body: '{}' })).rejects.toBe(failure);
+  });
+});

--- a/apps/website/src/lib/graphql/server.ts
+++ b/apps/website/src/lib/graphql/server.ts
@@ -57,8 +57,19 @@ export async function loadQuery<T extends Artifact<'query'>>(
           error(inner.status, { message: inner.message, code: inner.code });
         }
 
-        if (isExchangeError(inner, 'http') && inner.extensions?.statusCode === 401) {
-          redirect(302, event.url.href);
+        if (isExchangeError(inner, 'http')) {
+          const status = inner.extensions?.statusCode;
+          if (status === 401) {
+            redirect(302, event.url.href);
+          }
+
+          if (inner.cause instanceof TypeError) {
+            error(503, { code: 'network_error', message: '서버에 연결할 수 없어요.' });
+          }
+
+          if (status === 502 || status === 503 || status === 504) {
+            error(status, { code: 'service_unavailable', message: '서버를 일시적으로 사용할 수 없어요.' });
+          }
         }
 
         if (isGraphQLError(inner)) {

--- a/apps/website/src/routes/+error.svelte
+++ b/apps/website/src/routes/+error.svelte
@@ -5,11 +5,23 @@
   import { Grain } from '@typie/ui/effects';
   import dayjs from 'dayjs';
   import HeadphonesIcon from '~icons/lucide/headphones';
+  import { invalidateAll } from '$app/navigation';
   import { page } from '$app/state';
   import Logo from '$assets/logos/logo.svg?component';
 
   let error = $derived(page.error);
+  const connectionError = $derived(error?.code === 'network_error' || error?.code === 'service_unavailable');
+  let retrying = $state(false);
   const seed = Math.floor(Math.random() * 1000);
+
+  const retry = async () => {
+    retrying = true;
+    try {
+      await invalidateAll();
+    } finally {
+      retrying = false;
+    }
+  };
 </script>
 
 <div class={center({ width: '[100dvw]', height: '[100dvh]' })}>
@@ -74,6 +86,8 @@
       <h1 class={css({ fontSize: '24px', fontWeight: 'extrabold' })}>
         {#if page.status === 404}
           존재하지 않는 페이지예요
+        {:else if connectionError}
+          타이피 서버에 연결할 수 없어요
         {:else}
           앗! 문제가 발생했어요
         {/if}
@@ -81,6 +95,8 @@
       <div class={css({ fontSize: '14px', color: 'text.muted' })}>
         {#if page.status === 404}
           입력한 주소를 다시 한 번 확인해주세요.
+        {:else if connectionError}
+          연결 상태를 확인하거나 잠시 후 다시 시도해 주세요.
         {:else if error?.code === 'unexpected_error'}
           잠시 후 다시 시도해주세요.
         {:else if error?.message}
@@ -88,7 +104,9 @@
         {/if}
       </div>
 
-      {#if typeof window !== 'undefined' && !window.__webview__}
+      {#if connectionError}
+        <Button style={css.raw({ width: 'full' })} disabled={retrying} loading={retrying} onclick={retry} size="lg">다시 시도</Button>
+      {:else if typeof window !== 'undefined' && !window.__webview__}
         <Button style={css.raw({ width: 'full' })} href="/" size="lg" type="link">홈으로 돌아가기</Button>
       {/if}
 

--- a/apps/website/src/routes/graphql/+server.ts
+++ b/apps/website/src/routes/graphql/+server.ts
@@ -50,25 +50,36 @@ export const POST: RequestHandler = async ({ request, cookies, getClientAddress 
   const desktopMatch = /Typie\/(\S+)/.exec(userAgent);
   const deviceName = desktopMatch ? `Typie Desktop on ${os}` : `${browser} on ${os}`;
 
-  const response = await fetch(`${env.PRIVATE_API_URL}/graphql`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Client-IP': getClientAddress(),
-      'X-Device-Id': deviceId,
-      'X-Device-Name': deviceName,
-      'X-Device-Platform': platform,
-      ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-      ...(bootstrapBypass && { 'X-Bootstrap-Bypass': bootstrapBypass }),
-    },
-    body: await request.arrayBuffer(),
-  });
+  const requestBody = await request.arrayBuffer();
+  let response: Response;
+  let responseBody: ArrayBuffer;
+  try {
+    response = await fetch(`${env.PRIVATE_API_URL}/graphql`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Client-IP': getClientAddress(),
+        'X-Device-Id': deviceId,
+        'X-Device-Name': deviceName,
+        'X-Device-Platform': platform,
+        ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+        ...(bootstrapBypass && { 'X-Bootstrap-Bypass': bootstrapBypass }),
+      },
+      body: requestBody,
+    });
 
-  if (response.status === 401) {
-    cookies.delete('typie-at', { path: '/' });
+    if (response.status === 401) {
+      cookies.delete('typie-at', { path: '/' });
+    }
+
+    responseBody = await response.arrayBuffer();
+  } catch (err) {
+    if (err instanceof TypeError) {
+      return new Response(null, { status: 502, statusText: 'Bad Gateway' });
+    }
+    throw err;
   }
 
-  const responseBody = await response.arrayBuffer();
   const responseHeaders = new Headers(response.headers);
 
   return new Response(responseBody, {


### PR DESCRIPTION
페이지를 불러오는 중 서버 연결이 실패하면 공통 오류 화면에서 안내하고 다시 시도할 수 있도록 합니다.

- 실패한 문서 URL을 유지하고, 재시도 시 페이지를 다시 조회합니다.
- 서버가 복구되면 문서를 열고, 점검 응답을 받으면 점검 화면을 표시합니다.
- GraphQL 프록시의 API 통신 실패를 HTTP 502로 반환해 연결 오류로 처리합니다.

오류 화면 전환은 페이지 로딩 중 조회 실패에 적용되며, 같은 문서를 편집하는 중의 일시적인 연결 단절에는 기존 처리를 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>