### PR TITLE
테마 설정에 출처 및 라이선스 링크 추가

### DIFF
--- a/apps/website/src/routes/website/(dashboard)/@preference/ThemeTab.svelte
+++ b/apps/website/src/routes/website/(dashboard)/@preference/ThemeTab.svelte
@@ -7,6 +7,7 @@
   import { Dialog } from '@typie/ui/notification';
   import mixpanel from 'mixpanel-browser';
   import CheckIcon from '~icons/lucide/check';
+  import ExternalLinkIcon from '~icons/lucide/external-link';
   import MonitorIcon from '~icons/lucide/monitor';
   import MoonIcon from '~icons/lucide/moon';
   import SunIcon from '~icons/lucide/sun';
@@ -281,4 +282,23 @@
       {/each}
     </div>
   </div>
+
+  <a
+    class={flex({
+      alignSelf: 'start',
+      alignItems: 'center',
+      gap: '4px',
+      fontSize: '12px',
+      color: 'text.hint',
+      textUnderlineOffset: '3px',
+      _hover: { color: 'text.muted', textDecoration: 'underline' },
+      _focusVisible: { color: 'text.muted', textDecoration: 'underline' },
+    })}
+    href="https://raw.githubusercontent.com/penxle/typie/main/assets/themes/NOTICES.md"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    테마 출처 및 라이선스
+    <Icon aria-label="외부 링크" icon={ExternalLinkIcon} size={12} />
+  </a>
 </div>


### PR DESCRIPTION
테마 설정 하단에 기존 테마 출처·라이선스 문서로 연결되는 링크를 추가합니다.

외부 링크 아이콘을 표시하며, 웹에서는 새 탭으로, 데스크톱 앱에서는 기본 브라우저로 엽니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>