### PR TITLE
선택 영역 좌표 조회의 불필요한 레이아웃 순회 줄이기

### DIFF
--- a/crates/editor-view/src/query/layout_index.rs
+++ b/crates/editor-view/src/query/layout_index.rs
@@ -516,6 +516,10 @@ impl LayoutIndex {
 }
 
 impl LayoutEntry {
+    pub(crate) fn path(&self) -> &[usize] {
+        &self.path
+    }
+
     pub(crate) fn node<'a>(&self, layout_index: &'a LayoutIndex) -> Option<&'a LayoutNode> {
         node_at_path(&layout_index.tree.root, &self.path)
     }

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -141,6 +141,7 @@ struct SelectionWalk<'a, 'doc> {
     to: &'a Position,
     from_owner: Option<&'a LayoutEntry>,
     to_owner: Option<&'a LayoutEntry>,
+    from_path: Option<&'a [usize]>,
     pages: &'a [LayoutPage],
     selection: &'a ResolvedSelection<'doc>,
     direct_touch_interaction: bool,
@@ -219,6 +220,9 @@ fn selection_rect_sets(
         to: &to,
         from_owner,
         to_owner,
+        from_path: from_owner
+            .map(LayoutEntry::path)
+            .or_else(|| layout_index.box_path(&from.node)),
         pages,
         selection,
         direct_touch_interaction,
@@ -833,7 +837,6 @@ fn visit_box(
     let mark_rects_before = rects.mark_rects.len();
     let text_rects_before = rects.text_rects.len();
     let mut has_content_child = false;
-    let mut content_idx = 0usize;
 
     if from_at_box_level && *phase == Phase::Before && from.offset == 0 {
         *phase = Phase::Inside;
@@ -842,7 +845,31 @@ fn visit_box(
         *phase = Phase::After;
     }
 
-    for child in &bx.children {
+    // Before the selection, follow its indexed path without visiting earlier
+    // siblings. Keep the ancestors in the walk for paragraph breaks and blocks
+    // whose selection geometry replaces their descendants.
+    let first_child = if *phase == Phase::Before {
+        walk.from_path
+            .and_then(|path| path.strip_prefix(layout_index.box_path(&bx.node)?))
+            .and_then(|path| path.first().copied())
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    // Parent-level offsets count content children, not layout spacing nodes.
+    let mut content_idx = if from_at_box_level || to_at_box_level {
+        bx.children[..first_child]
+            .iter()
+            .filter(|child| !matches!(child.content, LayoutContent::Spacing(_)))
+            .count()
+    } else {
+        0
+    };
+
+    for child in &bx.children[first_child..] {
+        if *phase == Phase::After {
+            break;
+        }
         let is_spacing = matches!(child.content, LayoutContent::Spacing(_));
 
         visit_node(child, walk, phase, rects);
@@ -1260,6 +1287,53 @@ mod tests {
             "wrapped paragraph must yield ≥2 text rects (phase machine), got {:?}",
             rects
         );
+    }
+
+    #[test]
+    fn selection_in_later_paragraph_ends_at_parent_boundary() {
+        let root = Dot::ROOT;
+        let first = Dot::new(41, 1);
+        let second = Dot::new(41, 100);
+        let third = Dot::new(41, 200);
+        let mut items = Vec::new();
+        for (para, text) in [
+            (first, "abcdefghij"),
+            (second, "klmnopqrst"),
+            (third, "uvwxyz"),
+        ] {
+            items.push((
+                para,
+                SeqItem::Block {
+                    node_type: NodeType::Paragraph,
+                    parents: vec![root],
+                    attrs: vec![],
+                },
+            ));
+            for (offset, ch) in text.chars().enumerate() {
+                items.push((
+                    Dot::new(41, para.clock + offset as u64 + 1),
+                    SeqItem::Char(ch),
+                ));
+            }
+        }
+        let doc = logs(&items);
+        let (pd, index) = build_index(&doc, 40.0);
+        let view = DocView::new(&pd);
+        let from = Position::new(second, 8);
+        let to = Position::new(root, 2);
+        let selection = Selection::new(from, to).resolve(&view).unwrap();
+        let expected = Selection::new(from, Position::new(second, 10))
+            .resolve(&view)
+            .unwrap();
+
+        let first_line = index.entry_for_position(&Position::new(first, 0)).unwrap();
+        let selected_line = index.entry_for_position(&from).unwrap();
+        assert!(selected_line.rect.y > first_line.rect.bottom());
+        for direct_touch in [false, true] {
+            let actual = selection_rect_sets(&index, &selection, direct_touch);
+            assert_eq!(actual.line_box_rects.len(), 1);
+            assert_eq!(actual, selection_rect_sets(&index, &expected, direct_touch));
+        }
     }
 
     #[test]


### PR DESCRIPTION
짧은 선택 영역의 좌표를 조회할 때도 문서 전체 레이아웃을 순회하던 비용을 줄입니다.

- 레이아웃 인덱스로 선택 시작점 앞의 노드를 건너뛰고, 끝점에 도달하면 순회를 멈춥니다.
- 문단 끝 표시와 표 전체 선택을 포함한 기존 좌표 계산 결과를 유지합니다.

Mac 합성 벤치마크에서 60만 자 문서의 네 글자 범위 조회 CPU 중앙값이 약 105–107µs에서 1.5–5.7µs로 줄었습니다. 실기기 스크롤에서는 뚜렷한 체감 변화가 없었습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>