### PR TITLE
모바일 Font Specimen 에러 fallback으로 이름 표시

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Img.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Img.kt
@@ -152,5 +152,6 @@ private fun PlaceholderAsyncImage(
     contentScale = contentScale,
     colorFilter = colorFilter,
     loading = { placeholder() },
+    error = { placeholder() },
   )
 }


### PR DESCRIPTION
폰트 선택 목록에서 Noto Sans NKo처럼 이름에 포함된 문자를 지원하지 않는 폰트가 빈칸으로 표시되는 문제를 수정합니다.

미리보기 이미지 요청이 실패하면 폰트 이름을 일반 텍스트로 표시합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>