### PR TITLE
웹 IME 후보창과 입력 소스 표시 위치 수정

### DIFF
--- a/apps/website/src/lib/editor-ffi/components/Input.svelte
+++ b/apps/website/src/lib/editor-ffi/components/Input.svelte
@@ -8,6 +8,7 @@
   import { handleKeyDown } from '../handlers/keyboard';
   import { IME_CONTEXT_AFTER_LIMIT, IME_CONTEXT_BEFORE_LIMIT, normalizeImeContext } from '../input/ime-context';
   import { ImeInputAdapter } from '../input/ime-input-adapter';
+  import { syncImeInputScroll } from '../input/ime-input-geometry';
   import { wireImeResyncListener } from '../input/ime-resync';
   import { getViewportOverlayContext } from './ViewportOverlay.svelte';
   import type { Message } from '@typie/editor-ffi/browser';
@@ -52,6 +53,11 @@
     inputAdapter.syncFromEditor(editor.inputEl);
   };
 
+  const syncInputScroll = () => {
+    if (!editor?.focused || !editor.inputEl || editor.terminal) return;
+    syncImeInputScroll(editor.inputEl);
+  };
+
   const inputRect = $derived.by(() => {
     void viewportOverlay.change;
     if (!editor || editor.terminal) return null;
@@ -74,7 +80,9 @@
     if (!editor?.focused || !editor.inputEl || editor.terminal) return;
 
     void editor.appliedImeRevision;
+    void inputRect;
     syncInput();
+    syncInputScroll();
   });
 
   $effect(() => {
@@ -104,12 +112,16 @@
     style:top={`${inputRect?.top ?? -9999}px`}
     style:width={`${inputRect?.width ?? 1}px`}
     style:height={`${inputRect?.height ?? 1}px`}
+    style:font-size={`${inputRect?.height ?? 1}px`}
+    style:line-height={`${inputRect?.height ?? 1}px`}
     class={css({
       position: 'fixed',
       opacity: '0',
       pointerEvents: 'none',
       resize: 'none',
       overflow: 'hidden',
+      whiteSpace: 'pre',
+      overflowWrap: 'normal',
     })}
     autocapitalize="off"
     autocomplete="off"
@@ -181,6 +193,8 @@
       }
       handlePaste(ctx, e, handlePasteFailure);
     }}
+    onscroll={syncInputScroll}
+    onselect={syncInputScroll}
     readonly={editor.readOnly}
     spellcheck={false}></textarea>
 {/if}

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.test.ts
@@ -586,6 +586,28 @@ describe('ImeInputAdapter', () => {
     ]);
   });
 
+  it('preserves the native selection when moving between Japanese conversion clauses', () => {
+    const harness = createImeHarness(context(''));
+    harness.compositionStart();
+    harness.beforeCompositionInput('にほんのくに');
+    harness.applyNativeInput('にほんのくに', 6);
+
+    // Converting text and moving between clauses can both deliver composition input.
+    // The latter has the same text but a different native selection.
+    for (const [text, start, end] of [
+      ['日本の国', 0, 3],
+      ['日本の国', 3, 4],
+      ['日本の国', 2, 2],
+    ] as const) {
+      harness.compositionUpdate(text);
+      harness.beforeCompositionInput(text);
+      harness.applyNativeInput(text, start, end);
+      harness.syncFromEditor();
+      harness.expectInput(text, start, end);
+    }
+    expect(harness.compositionEnd()).toBe(true);
+  });
+
   it('uses insertCompositionText data instead of duplicated native DOM preedit text', () => {
     const input = createInput();
     const messages: Message[] = [];

--- a/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-adapter.ts
@@ -342,9 +342,10 @@ export class ImeInputAdapter {
     const nextText = replaceContextRange(context, edit.target, edit.text);
     if (input.value !== nextText) {
       input.value = nextText;
+      const selection = flatOffsetToUtf16Index(nextText, context.windowStart, composing.end);
+      input.setSelectionRange(selection, selection);
     }
-    const selection = flatOffsetToUtf16Index(nextText, context.windowStart, composing.end);
-    input.setSelectionRange(selection, selection);
+    // Keep the IME's selected clause or caret when the native text already matches.
     this.#context = updateContextFromInputElement(context, input, composing);
   }
 

--- a/apps/website/src/lib/editor-ffi/input/ime-input-geometry.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-input-geometry.ts
@@ -1,0 +1,48 @@
+const textStyleProperties = [
+  'fontFamily',
+  'fontSize',
+  'fontWeight',
+  'fontStyle',
+  'fontStretch',
+  'fontVariant',
+  'fontFeatureSettings',
+  'fontVariationSettings',
+  'fontKerning',
+  'fontOpticalSizing',
+  'letterSpacing',
+  'wordSpacing',
+  'textRendering',
+  'tabSize',
+  'direction',
+] as const;
+
+export function syncImeInputScroll(input: HTMLTextAreaElement): void {
+  const style = getComputedStyle(input);
+  const mirror = document.createElement('div');
+  Object.assign(mirror.style, {
+    position: 'fixed',
+    visibility: 'hidden',
+    whiteSpace: 'pre',
+    overflowWrap: 'normal',
+    width: `${input.clientWidth}px`,
+  });
+  for (const property of textStyleProperties) {
+    mirror.style[property] = style[property];
+  }
+
+  // A textarea does not expose its caret rectangle. Measure the same unwrapped
+  // text with DOM layout, including tabs, fallback fonts, and bidirectional runs.
+  const text = document.createTextNode(`${input.value}\u{200B}`);
+  mirror.append(text);
+  input.after(mirror);
+  const range = document.createRange();
+  const offset = input.selectionDirection === 'backward' ? input.selectionStart : input.selectionEnd;
+  range.setStart(text, offset);
+  range.collapse(true);
+  const left = range.getBoundingClientRect().left - mirror.getBoundingClientRect().left;
+  mirror.remove();
+
+  // Programmatic selection changes do not reliably scroll the native caret into
+  // view. Its x coordinate must coincide with the textarea's editor-caret anchor.
+  input.scrollLeft = left;
+}

--- a/apps/website/src/lib/editor-ffi/input/ime-text-replacement.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/input/ime-text-replacement.browser.test.ts
@@ -161,6 +161,54 @@ describe('web IME text replacement', () => {
     expect(input.selectionStart).toBe(9);
   });
 
+  it('keeps Japanese clauses on the same native input line at the editor caret height', async () => {
+    const { input } = await mountEditor();
+    const events = imeEvents(input);
+    events.composition('compositionstart', '');
+    events.composition('compositionupdate', 'に');
+    events.beforeCompositionInput('に');
+    events.applyNativeInput('\u{2028}に\u{2029}', 2, 'insertCompositionText', 'に');
+    await tick();
+    const initialScrollHeight = input.scrollHeight;
+
+    events.composition('compositionupdate', '日本の国');
+    events.beforeCompositionInput('日本の国');
+    events.applyNativeInput('\u{2028}日本の国\u{2029}', 5, 'insertCompositionText', '日本の国');
+    await tick();
+
+    // Extra clauses must extend horizontally, without moving their candidate anchors
+    // onto different textarea lines. The surrounding paragraph separators remain.
+    expect(input.scrollHeight).toBe(initialScrollHeight);
+    const rect = input.getBoundingClientRect();
+    const style = getComputedStyle(input);
+    expect(Number.parseFloat(style.lineHeight)).toBeCloseTo(rect.height, 1);
+    expect(Number.parseFloat(style.fontSize)).toBeCloseTo(rect.height, 1);
+  });
+
+  it('aligns the native input scroll with programmatic caret movement in a long line', async () => {
+    const { editor, input } = await mountEditor(doc('Long text before the caret '.repeat(5)), 100);
+    const nativePrefixWidth = () => {
+      const probe = input.cloneNode() as HTMLTextAreaElement;
+      probe.value = input.value.slice(0, input.selectionEnd);
+      input.after(probe);
+      const width = probe.scrollWidth;
+      probe.remove();
+      return width;
+    };
+    await expect.poll(() => input.getBoundingClientRect().left).toBeGreaterThan(-1000);
+    await expect.poll(() => input.scrollLeft).toBeGreaterThan(100);
+    expect(Math.abs(input.scrollLeft - nativePrefixWidth())).toBeLessThanOrEqual(1);
+
+    editor.updateNow(() => {
+      editor.enqueue({ type: 'selection', op: { type: 'set_flat', start: 1, end: 1 } });
+    });
+    await tick();
+
+    expect(input.selectionStart).toBe(1);
+    expect(input.scrollLeft).toBeLessThan(10);
+    expect(Math.abs(input.scrollLeft - nativePrefixWidth())).toBeLessThanOrEqual(1);
+  });
+
   it('replaces a selection with multiple paragraphs and keeps the suffix after the caret', async () => {
     const { editor, input } = await mountEditor(doc('leftOLDright'), 5);
     const events = imeEvents(input);


### PR DESCRIPTION
일본어 조합 중 후보창이 본문을 가리거나, 언어 전환 시 macOS 입력 소스 표시가 커서에서 멀리 나타나는 문제를 수정합니다.

IME 입력을 받는 숨겨진 textarea의 배치를 보정합니다.
- 자동 줄바꿈을 막고 글자 높이를 에디터 커서 높이에 맞춥니다.
- textarea 내부의 커서 위치를 측정해 가로 스크롤을 조정하여, 브라우저가 인식하는 입력 위치를 화면의 커서와 맞춥니다.
- 조합 텍스트 갱신 시 IME가 선택한 문절과 커서 위치를 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>