### PR TITLE
앱 팝오버의 터치·마우스 드래그 선택 복구

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/popover/Popover.kt
@@ -238,9 +238,8 @@ fun Popover(
 
   Box(
     modifier =
-      anchorModifier.hoverable(anchorInteractionSource, enabled = !isOverlayVisible).pointerInput(
-        Unit
-      ) {
+      // Removing hoverable on open cancels the pointer handler while it is selecting pane items.
+      anchorModifier.hoverable(anchorInteractionSource).pointerInput(Unit) {
         awaitEachGesture {
           val initialDown =
             awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/popover/PopoverPointerDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ui/component/popover/PopoverPointerDesktopTest.kt
@@ -1,8 +1,13 @@
 package co.typie.ui.component.popover
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -14,11 +19,17 @@ import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import co.typie.ext.LocalScrollGestureLockState
+import co.typie.ext.ScrollGestureLockState
 import co.typie.ext.clickable
+import co.typie.ext.verticalScroll
 import co.typie.icons.Lucide
 import co.typie.ui.component.sheet.SheetBarButton
+import co.typie.ui.component.tooltip.LocalTooltipState
+import co.typie.ui.component.tooltip.TooltipState
 import co.typie.ui.theme.LocalThemeMode
 import co.typie.ui.theme.ResolvedThemeMode
 import kotlin.test.Test
@@ -28,6 +39,147 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class PopoverPointerDesktopTest {
+  @Test
+  fun touchCanSelectAnItemWithoutReleasingTheAnchorPress() =
+    selectItemFromAnchorPress(mouse = false)
+
+  @Test
+  fun mouseCanSelectAnItemWithoutReleasingTheAnchorPress() = selectItemFromAnchorPress(mouse = true)
+
+  @Test
+  fun touchCanLeaveThePaneAndReleaseWithoutSelecting() =
+    selectItemFromAnchorPress(mouse = false, releaseOutside = true)
+
+  @Test
+  fun mouseCanLeaveThePaneAndReleaseWithoutSelecting() =
+    selectItemFromAnchorPress(mouse = true, releaseOutside = true)
+
+  private fun selectItemFromAnchorPress(mouse: Boolean, releaseOutside: Boolean = false) =
+    runComposeUiTest {
+      mainClock.autoAdvance = false
+      val state = PopoverOverlayState()
+      val scrollLock = ScrollGestureLockState()
+      var selectedItem: Int? = null
+      setContent {
+        val scope = rememberCoroutineScope()
+        val tooltipState = remember(scope) { TooltipState(scope) }
+        CompositionLocalProvider(
+          LocalPopoverOverlayState provides state,
+          LocalScrollGestureLockState provides scrollLock,
+          LocalTooltipState provides tooltipState,
+          LocalThemeMode provides ResolvedThemeMode.Light,
+        ) {
+          Box(Modifier.size(320.dp).testTag("root").popoverOutsideTapHost(state)) {
+            Box(Modifier.align(Alignment.TopEnd)) {
+              PopoverMenu(
+                anchor = {
+                  SheetBarButton(Lucide.ListFilter, "필터", modifier = Modifier.testTag("anchor"))
+                }
+              ) {
+                repeat(3) { index ->
+                  item(
+                    content = {
+                      val tag =
+                        if (
+                          LocalPopoverPaneRenderPhase.current == PopoverPaneRenderPhase.Interactive
+                        )
+                          Modifier.testTag("item-$index")
+                        else Modifier
+                      Box(tag.size(180.dp, 42.dp))
+                    }
+                  ) {
+                    selectedItem = index
+                  }
+                }
+              }
+            }
+            PopoverOverlay(state)
+          }
+        }
+      }
+      val root = onNodeWithTag("root")
+      val anchorPosition = onNodeWithTag("anchor").fetchSemanticsNode().boundsInRoot.center
+      if (mouse)
+        root.performMouseInput {
+          moveTo(anchorPosition)
+          press()
+        }
+      else root.performTouchInput { down(anchorPosition) }
+      mainClock.advanceTimeBy(700)
+      waitForIdle()
+      assertTrue(state.acceptsInput, "Holding the anchor must open the popover")
+      assertTrue(scrollLock.isLocked, "The original press must keep ownership while selecting")
+
+      for (index in 1..2) {
+        val itemPosition =
+          onNodeWithTag("item-$index", useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .center
+        if (mouse) root.performMouseInput { moveTo(itemPosition) }
+        else root.performTouchInput { moveTo(itemPosition) }
+        mainClock.advanceTimeByFrame()
+        waitForIdle()
+        assertEquals(null, selectedItem, "Moving over an item must not activate it before release")
+      }
+      if (releaseOutside) {
+        if (mouse) root.performMouseInput { moveTo(Offset(20f, 280f)) }
+        else root.performTouchInput { moveTo(Offset(20f, 280f)) }
+        mainClock.advanceTimeByFrame()
+      }
+      if (mouse) root.performMouseInput { release() } else root.performTouchInput { up() }
+      mainClock.advanceTimeBy(600)
+      waitForIdle()
+      assertFalse(scrollLock.isLocked, "Release must return scrolling to the parent")
+      if (releaseOutside) {
+        assertEquals(null, selectedItem, "Releasing outside must cancel selection")
+        assertTrue(state.acceptsInput, "The opening gesture must not count as an outside tap")
+        val item = onNodeWithTag("item-2", useUnmergedTree = true)
+        if (mouse) item.performMouseInput { click() } else item.performTouchInput { click() }
+        mainClock.advanceTimeBy(600)
+        waitForIdle()
+      }
+      assertEquals(2, selectedItem, "Only the final item must be selected")
+      assertFalse(state.acceptsInput)
+    }
+
+  @Test
+  fun draggingTheAnchorBeforeTheHoldDelayScrollsWithoutOpening() = runComposeUiTest {
+    val state = PopoverOverlayState()
+    val scrollLock = ScrollGestureLockState()
+    val scrollState = ScrollState(0)
+    setContent {
+      CompositionLocalProvider(
+        LocalPopoverOverlayState provides state,
+        LocalScrollGestureLockState provides scrollLock,
+        LocalThemeMode provides ResolvedThemeMode.Light,
+      ) {
+        Box(Modifier.size(320.dp).testTag("root").popoverOutsideTapHost(state)) {
+          Column(Modifier.verticalScroll(scrollState)) {
+            Box(Modifier.height(150.dp))
+            PopoverMenu(
+              anchor = {
+                SheetBarButton(Lucide.ListFilter, "필터", modifier = Modifier.testTag("anchor"))
+              }
+            ) {
+              item(Lucide.Check, "항목") {}
+            }
+            Box(Modifier.size(320.dp, 600.dp))
+          }
+          PopoverOverlay(state)
+        }
+      }
+    }
+    val anchorPosition = onNodeWithTag("anchor").fetchSemanticsNode().boundsInRoot.center
+    onNodeWithTag("root").performTouchInput {
+      swipe(anchorPosition, anchorPosition - Offset(0f, 120f), durationMillis = 100)
+    }
+    waitForIdle()
+    assertTrue(scrollState.value > 0, "A drag before the hold must remain a scroll gesture")
+    assertFalse(state.acceptsInput)
+    assertFalse(scrollLock.isLocked)
+  }
+
   @Test
   fun outsideMouseAndTouchDismissWithoutActivatingUnderlyingControl() = runComposeUiTest {
     val state = PopoverOverlayState()


### PR DESCRIPTION
팝오버 버튼을 누른 채 메뉴를 열고, 항목으로 이동해 놓으면 선택되는 동작을 터치와 마우스 모두에서 복구합니다.

팝오버가 열릴 때 hover 입력 노드를 제거하면서 진행 중인 입력까지 취소되던 문제였습니다. 해당 노드를 유지해 선택이 끝날 때까지 입력을 추적하도록 수정합니다.

메뉴 밖에서 놓았을 때의 선택 취소와 일반 탭·클릭, 스크롤 동작도 함께 검증했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>