### PR TITLE
앱 눌림 효과의 스크롤 오작동과 연속 재생 수정

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/ui/input/TrackpadGesture.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/ui/input/TrackpadGesture.android.kt
@@ -1,0 +1,11 @@
+package co.typie.ui.input
+
+import android.view.MotionEvent
+import androidx.compose.ui.input.pointer.PointerEvent
+
+internal actual val PointerEvent.isTrackpadGesture: Boolean
+  get() =
+    // ChromeOS also sends these gestures as finger DOWN/MOVE/UP events on Android 13,
+    // where Compose does not yet translate them to Pan/Scale pointer events.
+    motionEvent?.classification == MotionEvent.CLASSIFICATION_TWO_FINGER_SWIPE ||
+      motionEvent?.classification == MotionEvent.CLASSIFICATION_PINCH

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/Modifier.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ext/Modifier.kt
@@ -1,18 +1,17 @@
 package co.typie.ext
 
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseOut
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable as foundationClickable
 import androidx.compose.foundation.combinedClickable as foundationCombinedClickable
 import androidx.compose.foundation.horizontalScroll as foundationHorizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.verticalScroll as foundationVerticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -137,20 +136,15 @@ fun Modifier.pointerIgnore(): Modifier =
 @Composable
 fun Modifier.pressScale(targetScale: Float = 0.98f): Modifier {
   val interactionSource = LocalInteractionSource.current ?: return this
-  val scale = remember { Animatable(1f) }
-
-  LaunchedEffect(interactionSource) {
-    interactionSource.interactions.collect { interaction ->
-      when (interaction) {
-        is PressInteraction.Press -> scale.animateTo(targetScale, tween(100, easing = EaseOut))
-        is PressInteraction.Release,
-        is PressInteraction.Cancel -> scale.animateTo(1f, tween(100, easing = EaseOut))
-      }
-    }
-  }
+  val pressed by interactionSource.collectIsPressedAsState()
+  val scale by
+    animateFloatAsState(
+      targetValue = if (pressed) targetScale else 1f,
+      animationSpec = tween(100, easing = EaseOut),
+    )
 
   return this.graphicsLayer {
-    scaleX = scale.value
-    scaleY = scale.value
+    scaleX = scale
+    scaleY = scale
   }
 }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarControls.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarControls.kt
@@ -52,6 +52,7 @@ import co.typie.ui.component.tooltip.tooltip
 import co.typie.ui.icon.Icon
 import co.typie.ui.icon.IconData
 import co.typie.ui.input.hoverFeedback
+import co.typie.ui.input.isTrackpadGesture
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import kotlin.math.abs
@@ -297,17 +298,18 @@ internal fun Modifier.emitPressInteractions(interactionSource: MutableInteractio
   pointerInput(interactionSource) {
     awaitEachGesture {
       val down = awaitFirstDown(requireUnconsumed = false)
+      if (currentEvent.isTrackpadGesture) return@awaitEachGesture
       val press = PressInteraction.Press(down.position)
       interactionSource.tryEmit(press)
 
-      val up = waitForUpOrCancellation()
-      val release =
-        if (up == null) {
-          PressInteraction.Cancel(press)
-        } else {
-          PressInteraction.Release(press)
-        }
-      interactionSource.tryEmit(release)
+      var released = false
+      try {
+        released = waitForUpOrCancellation() != null
+      } finally {
+        interactionSource.tryEmit(
+          if (released) PressInteraction.Release(press) else PressInteraction.Cancel(press)
+        )
+      }
     }
   }
 

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/input/TrackpadGesture.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/input/TrackpadGesture.kt
@@ -1,0 +1,5 @@
+package co.typie.ui.input
+
+import androidx.compose.ui.input.pointer.PointerEvent
+
+internal expect val PointerEvent.isTrackpadGesture: Boolean

--- a/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/PressScaleDesktopTest.kt
+++ b/apps/mobile/compose/src/desktopTest/kotlin/co/typie/ext/PressScaleDesktopTest.kt
@@ -1,0 +1,106 @@
+package co.typie.ext
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import co.typie.screen.editor.editor.toolbar.emitPressInteractions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class PressScaleDesktopTest {
+  @Test
+  fun `removing the toolbar input surface cancels its held press`() = runComposeUiTest {
+    val source = MutableInteractionSource()
+    var showInput by mutableStateOf(true)
+    mainClock.autoAdvance = false
+    setContent {
+      CompositionLocalProvider(LocalInteractionSource provides source) {
+        Box(Modifier.size(200.dp).pressScale(0.9f).testTag("surface")) {
+          if (showInput) Box(Modifier.fillMaxSize().emitPressInteractions(source))
+        }
+      }
+    }
+    val restingWidth = onNodeWithTag("surface").fetchSemanticsNode().boundsInRoot.width
+    onNodeWithTag("surface").performTouchInput { down(center) }
+    mainClock.advanceTimeBy(160)
+    assertTrue(onNodeWithTag("surface").fetchSemanticsNode().boundsInRoot.width < restingWidth)
+    runOnIdle { showInput = false }
+    mainClock.advanceTimeBy(160)
+    assertEquals(
+      restingWidth,
+      onNodeWithTag("surface").fetchSemanticsNode().boundsInRoot.width,
+      0.01f,
+    )
+  }
+
+  @Test
+  fun `rapid taps settle after the last release without replaying earlier presses`() =
+    runComposeUiTest {
+      val source = MutableInteractionSource()
+      mainClock.autoAdvance = false
+      setContent {
+        CompositionLocalProvider(LocalInteractionSource provides source) {
+          Box(Modifier.size(200.dp).pressScale(0.9f).testTag("surface"))
+        }
+      }
+      val restingWidth = onNodeWithTag("surface").fetchSemanticsNode().boundsInRoot.width
+      repeat(5) {
+        val press = PressInteraction.Press(Offset.Zero)
+        runOnIdle { source.tryEmit(press) }
+        mainClock.advanceTimeBy(32)
+        runOnIdle { source.tryEmit(PressInteraction.Release(press)) }
+        mainClock.advanceTimeBy(32)
+      }
+      mainClock.advanceTimeBy(160)
+      assertEquals(
+        restingWidth,
+        onNodeWithTag("surface").fetchSemanticsNode().boundsInRoot.width,
+        0.01f,
+      )
+    }
+
+  @Test
+  fun `releasing one of two presses keeps the surface pressed until the other is cancelled`() =
+    runComposeUiTest {
+      val source = MutableInteractionSource()
+      mainClock.autoAdvance = false
+      setContent {
+        CompositionLocalProvider(LocalInteractionSource provides source) {
+          Box(Modifier.size(200.dp).pressScale(0.9f).testTag("surface"))
+        }
+      }
+      val restingWidth = onNodeWithTag("surface").fetchSemanticsNode().boundsInRoot.width
+      val first = PressInteraction.Press(Offset.Zero)
+      val second = PressInteraction.Press(Offset.Zero)
+      runOnIdle { source.tryEmit(first) }
+      mainClock.advanceTimeBy(160)
+      runOnIdle { source.tryEmit(second) }
+      mainClock.advanceTimeBy(160)
+      runOnIdle { source.tryEmit(PressInteraction.Release(first)) }
+      mainClock.advanceTimeBy(160)
+      assertTrue(onNodeWithTag("surface").fetchSemanticsNode().boundsInRoot.width < restingWidth)
+      runOnIdle { source.tryEmit(PressInteraction.Cancel(second)) }
+      mainClock.advanceTimeBy(160)
+      assertEquals(
+        restingWidth,
+        onNodeWithTag("surface").fetchSemanticsNode().boundsInRoot.width,
+        0.01f,
+      )
+    }
+}

--- a/apps/mobile/compose/src/skikoMain/kotlin/co/typie/ui/input/TrackpadGesture.skiko.kt
+++ b/apps/mobile/compose/src/skikoMain/kotlin/co/typie/ui/input/TrackpadGesture.skiko.kt
@@ -1,0 +1,11 @@
+package co.typie.ui.input
+
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
+
+internal actual val PointerEvent.isTrackpadGesture: Boolean
+  get() =
+    type == PointerEventType.PanStart ||
+      type == PointerEventType.PanMove ||
+      type == PointerEventType.ScaleStart ||
+      type == PointerEventType.ScaleChange


### PR DESCRIPTION
- 트랙패드 스크롤·핀치를 누르기 입력과 구분해, 툴바 전체에 눌림 효과가 나타나는 문제를 수정합니다.
- 눌림 애니메이션이 현재 누름 상태를 따라가도록 변경해, 빠르게 연속 터치한 뒤에도 효과가 밀려서 재생되는 문제를 수정합니다.
- 누르는 도중 툴바 입력 영역이 사라져도 눌림 상태가 해제되도록 처리합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>