### PR TITLE
Android 에디터의 IME 후보창 위치 수정

### DIFF
--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorCursorAnchorInfoController.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorCursorAnchorInfoController.kt
@@ -1,0 +1,183 @@
+package co.typie.editor.input
+
+import android.content.Context
+import android.graphics.Matrix
+import android.graphics.RectF
+import android.os.Build
+import android.view.View
+import android.view.ViewTreeObserver
+import android.view.inputmethod.CursorAnchorInfo
+import android.view.inputmethod.EditorBoundsInfo
+import android.view.inputmethod.InputConnection
+import android.view.inputmethod.InputMethodManager
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.text.TextRange
+import co.typie.editor.ffi.Ime
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+internal class EditorCursorAnchorInfoController(
+  private val view: View,
+  private val scope: CoroutineScope,
+  private val ime: () -> Ime?,
+  private val focusedRectInRoot: () -> Rect?,
+  private val firstRectForRangeInRoot: (TextRange) -> Rect?,
+  private val textFieldRectInRoot: () -> Rect?,
+  private val textClippingRectInRoot: () -> Rect?,
+  private val isSessionCurrent: () -> Boolean,
+) {
+  private var updates: Job? = null
+  private var closed = false
+  private var pendingImmediate = false
+  private var monitor = false
+  private var filters = 0
+
+  fun requestUpdates(mode: Int): Boolean {
+    if (closed || !scope.isActive || !isSessionCurrent() || mode and SUPPORTED_FLAGS.inv() != 0)
+      return false
+    pendingImmediate = mode and InputConnection.CURSOR_UPDATE_IMMEDIATE != 0
+    monitor = mode and InputConnection.CURSOR_UPDATE_MONITOR != 0
+    filters = mode and FILTER_FLAGS
+    if (!pendingImmediate && !monitor) {
+      updates?.cancel()
+      updates = null
+      return true
+    }
+    if (updates == null) {
+      updates =
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+          // Report after layout so scrolling, zooming and moving the Android window all use
+          // the same coordinates as the frame about to be drawn.
+          val listener = ViewTreeObserver.OnPreDrawListener {
+            if (pendingImmediate || monitor) update()
+            true
+          }
+          val observer = view.viewTreeObserver
+          observer.addOnPreDrawListener(listener)
+          try {
+            awaitCancellation()
+          } finally {
+            if (observer.isAlive) observer.removeOnPreDrawListener(listener)
+            else view.viewTreeObserver.removeOnPreDrawListener(listener)
+          }
+        }
+    }
+    view.invalidate()
+    return true
+  }
+
+  fun close() {
+    closed = true
+    updates?.cancel()
+    updates = null
+  }
+
+  private fun update() {
+    if (closed || !isSessionCurrent()) return
+    val ctx = ime() ?: return
+    val caret = focusedRectInRoot() ?: return
+    val clipping = textClippingRectInRoot() ?: return
+    val imm =
+      view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager ?: return
+    if (!imm.isActive(view)) return
+
+    val matrix = Matrix()
+    view.transformMatrixToGlobal(matrix)
+    val builder = CursorAnchorInfo.Builder().setMatrix(matrix)
+    builder.setSelectionRange(
+      ctx.windowUtf16Offset(ctx.selection.start),
+      ctx.windowUtf16Offset(ctx.selection.end),
+    )
+    if (includes(InputConnection.CURSOR_UPDATE_FILTER_INSERTION_MARKER)) {
+      builder.setInsertionMarkerLocation(
+        caret.left,
+        caret.top,
+        caret.bottom,
+        caret.bottom,
+        caret.visibilityFlags(clipping),
+      )
+    }
+    val composition = ctx.composing
+    if (composition != null) {
+      val start = ctx.windowUtf16Offset(composition.start)
+      val end = ctx.windowUtf16Offset(composition.end)
+      builder.setComposingText(start, ctx.text.subSequence(start, end))
+      if (includes(InputConnection.CURSOR_UPDATE_FILTER_CHARACTER_BOUNDS)) {
+        var index = start
+        while (index < end) {
+          val next = index + Character.charCount(Character.codePointAt(ctx.text, index))
+          val rect = firstRectForRangeInRoot(TextRange(index, next))
+          if (rect != null) {
+            for (utf16Index in index until next) {
+              builder.addCharacterBounds(
+                utf16Index,
+                rect.left,
+                rect.top,
+                rect.right,
+                rect.bottom,
+                rect.visibilityFlags(clipping),
+              )
+            }
+          }
+          index = next
+        }
+      }
+    }
+    if (
+      Build.VERSION.SDK_INT >= 33 && includes(InputConnection.CURSOR_UPDATE_FILTER_EDITOR_BOUNDS)
+    ) {
+      textFieldRectInRoot()?.let { bounds ->
+        builder.setEditorBoundsInfo(
+          EditorBoundsInfo.Builder()
+            .setEditorBounds(RectF(bounds.left, bounds.top, bounds.right, bounds.bottom))
+            .setHandwritingBounds(RectF(bounds.left, bounds.top, bounds.right, bounds.bottom))
+            .build()
+        )
+      }
+    }
+    imm.updateCursorAnchorInfo(view, builder.build())
+    pendingImmediate = false
+    if (!monitor) {
+      updates?.cancel()
+      updates = null
+    }
+  }
+
+  private fun includes(filter: Int): Boolean = filters == 0 || filters and filter != 0
+
+  private fun Rect.visibilityFlags(clipping: Rect): Int {
+    var flags = 0
+    if (
+      right >= clipping.left &&
+        left <= clipping.right &&
+        bottom >= clipping.top &&
+        top <= clipping.bottom
+    ) {
+      flags = flags or CursorAnchorInfo.FLAG_HAS_VISIBLE_REGION
+    }
+    if (
+      left < clipping.left ||
+        right > clipping.right ||
+        top < clipping.top ||
+        bottom > clipping.bottom
+    ) {
+      flags = flags or CursorAnchorInfo.FLAG_HAS_INVISIBLE_REGION
+    }
+    return flags
+  }
+
+  private companion object {
+    const val FILTER_FLAGS =
+      InputConnection.CURSOR_UPDATE_FILTER_INSERTION_MARKER or
+        InputConnection.CURSOR_UPDATE_FILTER_CHARACTER_BOUNDS or
+        InputConnection.CURSOR_UPDATE_FILTER_EDITOR_BOUNDS
+    const val SUPPORTED_FLAGS =
+      InputConnection.CURSOR_UPDATE_IMMEDIATE or
+        InputConnection.CURSOR_UPDATE_MONITOR or
+        FILTER_FLAGS
+  }
+}

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInput.android.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInput.android.kt
@@ -40,7 +40,9 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
   val androidView = view
   val extractMonitor = ImeExtractMonitor()
   editorImeExtractMonitors[editor] = extractMonitor
+  var activeCursorAnchorInfo: EditorCursorAnchorInfoController? = null
   return PlatformTextInputMethodRequest { outAttrs ->
+    activeCursorAnchorInfo?.close()
     outAttrs.inputType =
       InputType.TYPE_CLASS_TEXT or
         InputType.TYPE_TEXT_FLAG_MULTI_LINE or
@@ -50,6 +52,22 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
     val ctx = editor.appliedState.ime
     outAttrs.initialSelStart = ctx?.let { it.windowUtf16Offset(it.selection.start) } ?: -1
     outAttrs.initialSelEnd = ctx?.let { it.windowUtf16Offset(it.selection.end) } ?: -1
+    val cursorAnchorInfo =
+      EditorCursorAnchorInfoController(
+        view = androidView,
+        scope = this,
+        ime = {
+          editor.publishedState.ime?.takeIf {
+            !editor.imeNotificationsPaused && it == editor.appliedState.ime
+          }
+        },
+        focusedRectInRoot = focusedRectInRoot,
+        firstRectForRangeInRoot = firstRectForRangeInRoot,
+        textFieldRectInRoot = textFieldRectInRoot,
+        textClippingRectInRoot = textClippingRectInRoot,
+        isSessionCurrent = isSessionCurrent,
+      )
+    activeCursorAnchorInfo = cursorAnchorInfo
     val connection =
       EditorInputConnection(
         editor = editor,
@@ -57,6 +75,7 @@ internal actual suspend fun PlatformTextInputSessionScope.createEditorInputReque
         inputSessionScope = this,
         bringIntoViewRequests = bringIntoViewRequests,
         extractMonitor = extractMonitor,
+        cursorAnchorInfo = cursorAnchorInfo,
         isSessionCurrent = isSessionCurrent,
         onIncomingContent = onIncomingContent,
       )

--- a/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
+++ b/apps/mobile/compose/src/androidMain/kotlin/co/typie/editor/input/EditorInputConnection.kt
@@ -83,6 +83,7 @@ internal class EditorInputConnection(
   private val inputSessionScope: CoroutineScope,
   private val bringIntoViewRequests: EditorBringIntoViewRequests,
   private val extractMonitor: ImeExtractMonitor,
+  private val cursorAnchorInfo: EditorCursorAnchorInfoController,
   private val isSessionCurrent: () -> Boolean,
   private val onIncomingContent: (IncomingContentCandidates) -> Boolean,
 ) : InputConnection {
@@ -299,12 +300,19 @@ internal class EditorInputConnection(
 
   override fun performPrivateCommand(action: String?, data: Bundle?): Boolean = false
 
-  override fun requestCursorUpdates(cursorUpdateMode: Int): Boolean = false
+  override fun requestCursorUpdates(cursorUpdateMode: Int): Boolean {
+    recordCall("requestCursorUpdates", "mode=$cursorUpdateMode")
+    return cursorAnchorInfo.requestUpdates(cursorUpdateMode)
+  }
+
+  override fun requestCursorUpdates(cursorUpdateMode: Int, cursorUpdateFilter: Int): Boolean =
+    requestCursorUpdates(cursorUpdateMode or cursorUpdateFilter)
 
   override fun getHandler() = null
 
   override fun closeConnection() {
     recordCall("closeConnection", "")
+    cursorAnchorInfo.close()
     extractMonitor.token = null
     batch.closeConnection()
   }


### PR DESCRIPTION
- Chromebook에서 일본어 입력 시 IME 후보창이 화면 왼쪽 위에 표시되는 문제를 수정합니다.
- Android IME에 커서와 조합 중인 글자의 위치를 전달해 후보창이 입력 위치 근처에 표시되도록 합니다.
- 스크롤·확대·축소·창 이동 시에도 위치 정보를 갱신하고, 입력 연결이 종료되면 갱신을 중단합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>