### PR TITLE
JVM Desktop의 작업실 이미지 로딩 오류 수정

### DIFF
--- a/apps/mobile/compose/build.gradle.kts
+++ b/apps/mobile/compose/build.gradle.kts
@@ -188,7 +188,7 @@ kotlin {
         implementation(compose.desktop.currentOs)
         implementation(libs.jna)
         implementation(libs.kotlinx.coroutines.swing)
-        implementation(libs.ktor.client.cio)
+        implementation(libs.ktor.client.okhttp)
         implementation(libs.sqldelight.driver.jvm)
       }
     }

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -80,7 +80,6 @@ kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.re
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor", version.ref = "kotlinx-serialization" }
 ksafe = { module = "eu.anifantakis:ksafe", version.ref = "ksafe" }
-ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }


### PR DESCRIPTION
JVM Desktop에서 작업실 프로필·커버 이미지를 불러오지 못하는 문제를 수정합니다.

- 이미지 서버와의 TLS 연결에 실패하던 CIO 대신 OkHttp를 Desktop HTTP 엔진으로 사용합니다.
- 사용하지 않는 CIO 의존성 항목을 제거합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>