### PR TITLE
루비가 있는 줄의 paragraph break 크기 수정

### DIFF
--- a/crates/editor-view/src/query/paragraph_break.rs
+++ b/crates/editor-view/src/query/paragraph_break.rs
@@ -12,6 +12,7 @@ use editor_state::{
     paragraph_break_at_end, paragraph_break_ending_at,
 };
 
+use crate::measure::text::ruby::ruby_extra_top;
 use crate::page::{LayoutPage, PageRect};
 use crate::paginate::types::{LayoutContent, LayoutLine, SpacingKind};
 
@@ -180,15 +181,17 @@ fn geometry_for_line_entry(
     let pos = paragraph_break_range.anchor;
     let page_idx = page_for_y(pages, entry.rect.y)?;
     let x = entry.rect.x + super::grapheme::x_at_offset(line, &pos);
-    let width = entry.rect.height * 0.15;
+    let band = ruby_extra_top(line.baseline, line.ascent, &line.ruby_annotations);
+    let height = (entry.rect.height - band).max(0.0);
+    let width = height * 0.15;
     Some(ParagraphBreakGeometry {
         rect: PageRect::new(
             page_idx,
             Rect::from_xywh(
                 x,
-                entry.rect.y - pages[page_idx].y_start,
+                entry.rect.y + band - pages[page_idx].y_start,
                 width,
-                entry.rect.height,
+                height,
             ),
         ),
         line_right: entry.rect.right(),

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -1367,6 +1367,95 @@ mod tests {
     }
 
     #[test]
+    fn paragraph_break_with_ruby_matches_base_line_geometry() {
+        use editor_model::{Anchor, Bias, Modifier, SpanOp};
+
+        let (mut doc, _root, first_para, second_para) = two_para_doc("abc", "def");
+        let (plain_pd, plain_index) = build_index(&doc, 400.0);
+        let plain_view = DocView::new(&plain_pd);
+        let plain_break = super::super::paragraph_break::paragraph_break_occurrence_for_node(
+            &plain_index,
+            &plain_view,
+            first_para,
+        )
+        .unwrap()
+        .geometry
+        .rect
+        .rect;
+
+        doc.spans = doc
+            .spans
+            .apply(
+                Dot::ROOT,
+                SpanOp::AddSpan {
+                    start: Anchor {
+                        id: Dot::new(11, 2),
+                        bias: Bias::Before,
+                    },
+                    end: Anchor {
+                        id: Dot::new(11, 4),
+                        bias: Bias::After,
+                    },
+                    modifier: Modifier::Ruby {
+                        text: "annotation".to_string(),
+                    },
+                },
+            )
+            .unwrap();
+        let (pd, index) = build_index(&doc, 400.0);
+        let view = DocView::new(&pd);
+        let (entry, line) = first_line_for_para(&index, &first_para).unwrap();
+        assert!(!line.ruby_annotations.is_empty());
+        assert!(entry.rect.height > plain_break.height);
+
+        let text = Selection::new(Position::new(first_para, 0), Position::new(first_para, 3));
+        let text_rect = selection_rects(&index, &text.resolve(&view).unwrap())[0].rect;
+        let paragraph_break = super::super::paragraph_break::paragraph_break_occurrence_for_node(
+            &index, &view, first_para,
+        )
+        .unwrap();
+        let break_rect = paragraph_break.geometry.rect.rect;
+        assert_close(
+            break_rect.y,
+            text_rect.y,
+            "paragraph break top matches base text",
+        );
+        assert_close(
+            break_rect.height,
+            text_rect.height,
+            "paragraph break height matches base text",
+        );
+        assert_close(
+            break_rect.height,
+            plain_break.height,
+            "ruby preserves paragraph break height",
+        );
+        assert_close(
+            break_rect.width,
+            plain_break.width,
+            "ruby preserves paragraph break width",
+        );
+
+        let selection = Selection::new(Position::new(first_para, 0), Position::new(second_para, 1));
+        for direct_touch in [false, true] {
+            let rects =
+                selection_rect_sets(&index, &selection.resolve(&view).unwrap(), direct_touch);
+            assert_eq!(
+                rects.line_box_rects.len(),
+                2,
+                "ruby text and paragraph break share a rect"
+            );
+            assert_eq!(rects.mark_rects.len(), 2);
+            assert_close(rects.mark_rects[0].rect.y, text_rect.y, "merged mark top");
+            assert_close(
+                rects.mark_rects[0].rect.height,
+                text_rect.height,
+                "merged mark height",
+            );
+        }
+    }
+
+    #[test]
     fn direct_touch_extends_only_active_paragraph_break_presentation_to_line_end() {
         let (doc, _root, first_para, _second_para) = two_para_doc("abc", "def");
         let (pd, index) = build_index(&doc, 400.0);


### PR DESCRIPTION
- 루비가 있는 줄에서 문단 끝 선택 영역이 루비 높이까지 커지는 문제를 수정합니다.
- 문단 끝 선택 영역의 위치와 크기를 본문에 맞춰, 함께 선택한 텍스트와 하나의 사각형으로 이어지도록 합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>