### PR TITLE
앱 툴바 hover 시 인디케이터 표시

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/toolbar/ToolbarPages.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.gestures.ScrollableDefaults
 import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -154,6 +156,8 @@ internal fun EditorToolbarPages(
   val density = LocalDensity.current
   val hapticFeedback = LocalHapticFeedback.current
   val hazeState = LocalHazeState.current
+  val hoverInteractionSource = remember { MutableInteractionSource() }
+  val hovered by hoverInteractionSource.collectIsHoveredAsState()
   val secondaryToolbarTransition = remember { MutableTransitionState(false) }
   secondaryToolbarTransition.targetState = secondaryToolbarVisible
   val secondaryToolbarInLayout = secondaryToolbarVisible || !secondaryToolbarTransition.isIdle
@@ -418,7 +422,7 @@ internal fun EditorToolbarPages(
     }
 
     val indicatorHeldVisible =
-      pagerState.indicatorInteracting || pagerState.indicatorPageTransitioning
+      hovered || pagerState.indicatorInteracting || pagerState.indicatorPageTransitioning
     LaunchedEffect(pagerState.indicatorPulse, indicatorHeldVisible) {
       if (pagerState.indicatorPulse == 0 && !indicatorHeldVisible) {
         pagerState.indicatorVisible = false
@@ -638,7 +642,8 @@ internal fun EditorToolbarPages(
                 .alpha(indicatorAlpha)
                 .then(
                   if (indicatorAlpha > 0.01f) {
-                    Modifier.toolbarIndicatorGestures(
+                    Modifier.hoverable(hoverInteractionSource)
+                      .toolbarIndicatorGestures(
                         pageCount = pageCount,
                         currentPageIndex = currentPageIndex,
                         onIndicatorProgress = { progress ->
@@ -701,6 +706,7 @@ internal fun EditorToolbarPages(
             modifier =
               Modifier.fillMaxWidth()
                 .height(ToolbarSecondaryHeight)
+                .hoverable(hoverInteractionSource)
                 .toolbarVerticalSwipeGestures(onSwipeDown = onSecondaryToolbarClear)
           ) {
             Box(
@@ -788,6 +794,7 @@ internal fun EditorToolbarPages(
                 .shadow(AppTheme.shadows.sm, ToolbarCapsuleShape)
                 .pressScale(ToolbarCapsulePressedScale)
                 .clip(ToolbarCapsuleShape)
+                .hoverable(hoverInteractionSource)
                 .hazeBlur(
                   input = HazeInput.Sources(hazeState),
                   style =


### PR DESCRIPTION
마우스·트랙패드로 툴바 페이지를 쉽게 전환할 수 있도록 hover 시 인디케이터를 표시합니다.

- 기본 툴바와 세부 옵션 툴바에 hover하면 인디케이터가 나타납니다.
- 인디케이터로 포인터를 옮겨도 표시를 유지합니다.
- 포인터가 벗어나면 기존처럼 2초 후 페이드아웃합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>