### PR TITLE
앱 hover 피드백의 색상과 표시 영역 개선

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/share/EntityShareSheetParts.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entity/share/EntityShareSheetParts.kt
@@ -131,11 +131,8 @@ private fun ShareThumbnailUploadButton(
         modifier =
           Modifier.size(width = SHARE_THUMBNAIL_WIDTH_DP.dp, height = SHARE_THUMBNAIL_HEIGHT_DP.dp)
             .clip(shape)
-            .background(
-              if (thumbnailUrl == null && enabled && hovered) AppTheme.colors.surfaceHover
-              else AppTheme.colors.surfaceInset,
-              shape,
-            )
+            .background(AppTheme.colors.surfaceInset, shape)
+            .hoverFeedback(enabled = thumbnailUrl == null && enabled, shape = shape)
             .border(
               width = 1.dp,
               color =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entitytransfer/EntityPasteBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/entitytransfer/EntityPasteBar.kt
@@ -62,7 +62,7 @@ fun EntityPasteBar(
               .hoverFeedback(
                 enabled = enabled,
                 shape = AppShapes.circle,
-                hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.12f),
+                hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.06f),
                 activeColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.20f),
               )
               .clickable(enabled = enabled, onClick = onPaste)
@@ -104,7 +104,7 @@ fun EntityPasteBar(
               .hoverFeedback(
                 enabled = enabled,
                 shape = AppShapes.circle,
-                hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.12f),
+                hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.06f),
                 activeColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.20f),
               )
               .clickable(enabled = enabled, onClick = onClear)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/note/NoteCard.kt
@@ -427,10 +427,11 @@ private fun NoteCollapsedContent(
       Row(
         modifier =
           Modifier.weight(1f)
-            .padding(end = 12.dp, top = 12.dp, bottom = 12.dp)
+            .padding(end = 6.dp, top = 6.dp, bottom = 6.dp)
             .hoverFeedback(shape = AppShapes.rounded(AppShapes.sm))
             .clickable { onExpand() }
-            .pressScale(0.985f),
+            .pressScale(0.985f)
+            .padding(6.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.Top,
       ) {
@@ -460,16 +461,7 @@ private fun NoteCollapsedContent(
           NoteCollapsedMetaRow(note = note)
         }
 
-        Box(
-          modifier =
-            Modifier.size(NoteActionButtonSize)
-              .then(
-                LocalInteractionSource.current?.let {
-                  Modifier.hoverFeedback(it, shape = AppShapes.rounded(AppShapes.sm))
-                } ?: Modifier
-              ),
-          contentAlignment = Alignment.Center,
-        ) {
+        Box(modifier = Modifier.size(NoteActionButtonSize), contentAlignment = Alignment.Center) {
           Icon(
             icon = Lucide.Maximize2,
             modifier = Modifier.size(15.dp),
@@ -489,7 +481,10 @@ private fun NoteCardLeadingContent(
   onToggleStatus: () -> Unit,
 ) {
   Column(
-    modifier = Modifier.padding(10.dp).width(NoteGripHitTargetSize),
+    // The remaining 6.dp of the trailing gap belongs to the body hover area.
+    modifier =
+      Modifier.padding(start = 10.dp, top = 10.dp, end = 4.dp, bottom = 10.dp)
+        .width(NoteGripHitTargetSize),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     NoteStatusToggleButton(resolved = resolved, colorOption = colorOption, onClick = onToggleStatus)

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/TrialRemainingChip.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/domain/subscription/TrialRemainingChip.kt
@@ -102,7 +102,7 @@ fun TrialRemainingChip() {
           Modifier.background(AppTheme.colors.surfaceInverse, AppShapes.circle)
             .hoverFeedback(
               shape = AppShapes.circle,
-              hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.12f),
+              hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.06f),
               activeColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.20f),
             )
             .clickable(onClick = openSubscribe)
@@ -165,7 +165,7 @@ private fun TrialReminderBalloon(daysLeft: Int, legacy: Boolean, onTap: () -> Un
             .background(AppTheme.colors.surfaceInverse, shape)
             .hoverFeedback(
               shape = shape,
-              hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.12f),
+              hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.06f),
               activeColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.20f),
             )
             .clickable(onClick = { onTap() })

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/auth/login/LoginScreen.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/auth/login/LoginScreen.kt
@@ -305,7 +305,7 @@ private fun SingleSignOnButton(
               lerp(
                 backgroundColor,
                 if (backgroundColor == Color.Black) foregroundColor else Color.Black,
-                0.12f,
+                0.06f,
               ),
             activeColor =
               lerp(

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorSubscriptionBanner.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/EditorSubscriptionBanner.kt
@@ -80,7 +80,7 @@ fun BoxScope.EditorSubscriptionBanner(
         .hoverFeedback(
           source,
           shape = AppShapes.rounded(AppShapes.lg),
-          hoverColor = lerp(surface, Color.Black, 0.12f).copy(alpha = 0.5f),
+          hoverColor = lerp(surface, Color.Black, 0.06f).copy(alpha = 0.5f),
           activeColor = lerp(surface, Color.Black, 0.20f).copy(alpha = 0.5f),
         )
         .clickable(interactionSource = source) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceToolbar.kt
@@ -7,6 +7,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -20,6 +23,8 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,6 +57,7 @@ import co.typie.screen.editor.editor.toolbar.ToolbarVisibilityEnterMillis
 import co.typie.screen.editor.editor.toolbar.ToolbarVisibilityExitMillis
 import co.typie.ui.component.ResponsiveContainerDefaults
 import co.typie.ui.component.Text
+import co.typie.ui.input.hoverFeedback
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.shadow
@@ -151,11 +157,14 @@ private fun ReplaceTextField(session: EditorFindReplaceSession, modifier: Modifi
       onDismiss = {},
     )
   val shape = AppShapes.rounded(AppShapes.full)
+  val interactionSource = remember { MutableInteractionSource() }
+  val focused by interactionSource.collectIsFocusedAsState()
 
   BasicTextField(
     value = inputState.value,
     onValueChange = inputState::onValueChange,
     singleLine = true,
+    interactionSource = interactionSource,
     textStyle = ToolbarLabelTextStyle.copy(color = AppTheme.colors.textDefault),
     cursorBrush = SolidColor(AppTheme.colors.textDefault),
     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
@@ -165,6 +174,8 @@ private fun ReplaceTextField(session: EditorFindReplaceSession, modifier: Modifi
         .height(ToolbarButtonSize)
         .clip(shape)
         .background(AppTheme.colors.surfaceInset, shape)
+        .hoverable(interactionSource)
+        .hoverFeedback(interactionSource, enabled = !focused, shape = shape)
         .padding(horizontal = 10.dp)
         .textInputFocusable(inputState)
         .onPreviewKeyEvent { event -> handleReplaceInputShortcut(event, session) },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/findreplace/FindReplaceTopBar.kt
@@ -2,6 +2,9 @@ package co.typie.screen.editor.editor.findreplace
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +19,8 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,6 +39,7 @@ import co.typie.ui.component.popover.PopoverMenu
 import co.typie.ui.component.topbar.TopBarButton
 import co.typie.ui.component.topbar.TopBarDefaults
 import co.typie.ui.icon.Icon
+import co.typie.ui.input.hoverFeedback
 import co.typie.ui.theme.AppShapes
 import co.typie.ui.theme.AppTheme
 import co.typie.ui.theme.shadow
@@ -62,6 +68,8 @@ internal fun FindReplaceTopBarCenter(
   }
 
   val shape = AppShapes.rounded(AppShapes.full)
+  val interactionSource = remember { MutableInteractionSource() }
+  val focused by interactionSource.collectIsFocusedAsState()
   Row(
     modifier =
       Modifier.fillMaxWidth()
@@ -70,6 +78,8 @@ internal fun FindReplaceTopBarCenter(
         .clip(shape)
         .background(TopBarDefaults.controlBackgroundColor(), shape)
         .border(1.dp, TopBarDefaults.controlBorderColor(), shape)
+        .hoverable(interactionSource)
+        .hoverFeedback(interactionSource, enabled = !focused, shape = shape)
         .padding(horizontal = 14.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
@@ -84,6 +94,7 @@ internal fun FindReplaceTopBarCenter(
       value = inputState.value,
       onValueChange = inputState::onValueChange,
       singleLine = true,
+      interactionSource = interactionSource,
       textStyle = AppTheme.typography.body.copy(color = AppTheme.colors.textDefault),
       cursorBrush = SolidColor(AppTheme.colors.textDefault),
       keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/SpellcheckOverlay.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/spellcheck/SpellcheckOverlay.kt
@@ -607,7 +607,7 @@ private fun SpellcheckActionChip(text: String, danger: Boolean = false, onClick:
           enabled = true,
           shape = AppShapes.circle,
           hoverColor =
-            if (danger) lerp(background, Color.Black, 0.12f) else AppTheme.colors.surfaceHover,
+            if (danger) lerp(background, Color.Black, 0.06f) else AppTheme.colors.surfaceHover,
           activeColor =
             if (danger) lerp(background, Color.Black, 0.20f) else AppTheme.colors.surfaceActive,
         )

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentTextInputs.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/subpane/comments/CommentTextInputs.kt
@@ -100,7 +100,7 @@ internal fun CommentComposer(
             interactionSource,
             enabled = hasText && !submitting,
             shape = CircleShape,
-            hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.12f),
+            hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.06f),
             activeColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.20f),
           )
           .clickable(interactionSource = interactionSource, enabled = hasText && !submitting) {

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Button.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/Button.kt
@@ -98,7 +98,7 @@ fun Button(
               shape = AppShapes.rounded(AppShapes.lg),
               hoverColor =
                 if (variant == ButtonVariant.Secondary) AppTheme.colors.surfaceHover
-                else lerp(colors.background, Color.Black, 0.12f),
+                else lerp(colors.background, Color.Black, 0.06f),
               activeColor =
                 if (variant == ButtonVariant.Secondary) AppTheme.colors.surfaceActive
                 else lerp(colors.background, Color.Black, 0.20f),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/bottombar/BottomBarActionButton.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/bottombar/BottomBarActionButton.kt
@@ -234,7 +234,7 @@ fun BottomBarActionButton(
                     actionInteractionSource,
                     enabled = !isMenuOpen,
                     shape = AppShapes.circle,
-                    hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.12f),
+                    hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.06f),
                     activeColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.20f),
                   )
                   .pointerInput(icon, menus) {
@@ -277,7 +277,7 @@ fun BottomBarActionButton(
                 Modifier.hoverFeedback(
                     actionInteractionSource,
                     shape = AppShapes.circle,
-                    hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.12f),
+                    hoverColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.06f),
                     activeColor = lerp(AppTheme.colors.surfaceInverse, Color.Black, 0.20f),
                   )
                   .clickable { onClick() }

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarButton.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/component/topbar/TopBarButton.kt
@@ -88,7 +88,7 @@ private fun TopBarButtonContent(
           shape = TopBarDefaults.ButtonShape,
           hoverColor =
             if (isDefaultBackground) AppTheme.colors.surfaceHover
-            else lerp(backgroundColor, Color.Black, 0.12f),
+            else lerp(backgroundColor, Color.Black, 0.06f),
           activeColor =
             if (isDefaultBackground) AppTheme.colors.surfaceActive
             else lerp(backgroundColor, Color.Black, 0.20f),

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/theme/Theme.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/ui/theme/Theme.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.unit.dp
 import co.typie.domain.bootstrap.BootstrapService
 import co.typie.domain.bootstrap.BootstrapState
@@ -91,7 +90,7 @@ val LightColors =
     surfaceInset = AppColor.light.gray.s100,
     surfaceInverse = AppColor.light.gray.s900,
     surfaceActive = AppColor.light.gray.s200,
-    surfaceHover = lerp(AppColor.light.gray.s100, AppColor.light.gray.s200, 0.5f),
+    surfaceHover = AppColor.light.gray.s900.copy(alpha = 0.04f),
     borderEmphasis = AppColor.light.gray.s300,
     borderDefault = AppColor.light.gray.s200,
     borderHairline = AppColor.light.gray.s100,
@@ -122,7 +121,7 @@ val DarkColors =
     surfaceInset = AppColor.dark.gray.s800,
     surfaceInverse = AppColor.dark.gray.s50,
     surfaceActive = AppColor.dark.gray.s700,
-    surfaceHover = lerp(AppColor.dark.gray.s800, AppColor.dark.gray.s700, 0.5f),
+    surfaceHover = AppColor.dark.gray.s50.copy(alpha = 0.03f),
     borderEmphasis = AppColor.dark.gray.s600,
     borderDefault = AppColor.dark.gray.s700,
     borderHairline = AppColor.dark.gray.s800,


### PR DESCRIPTION
Hover가 클릭처럼 강하게 보이는 문제를 줄이고, 에디터 주변 UI의 피드백을 다듬습니다.

- 공통 hover 배경색을 옅게 조정하고 강조·반전 버튼의 색 변화도 줄입니다.
- 노트 카드의 평소 배치를 유지하면서 hover 배경에 여유를 줍니다.
- 찾기·바꾸기 입력 필드에 포커스가 없을 때 표시되는 hover를 추가합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>