### PR TITLE
루비 공간이 부족할 때만 줄 간격을 늘리도록 수정

### DIFF
--- a/crates/editor-renderer/src/renderer.rs
+++ b/crates/editor-renderer/src/renderer.rs
@@ -349,16 +349,9 @@ fn underline_rect(m: LineMetrics, run_x: f32, run_width: f32) -> Rect {
     )
 }
 
-fn text_background_rect(
-    line_rect: Rect,
-    m: LineMetrics,
-    ruby_extra_top: f32,
-    run_x: f32,
-    run_width: f32,
-) -> Rect {
-    let text_height = (m.ascent + m.descent - ruby_extra_top).max(0.0);
-    let text_area = (line_rect.height - ruby_extra_top).max(0.0);
-    let text_top = ruby_extra_top + (text_area - text_height).max(0.0) * 0.5;
+fn text_background_rect(line_rect: Rect, m: LineMetrics, run_x: f32, run_width: f32) -> Rect {
+    let text_height = (m.ascent + m.descent).max(0.0);
+    let text_top = (line_rect.height - text_height).max(0.0) * 0.5;
     Rect::from_xywh(run_x, text_top, run_width, text_height)
 }
 
@@ -1313,13 +1306,10 @@ impl<'a> PageVisitor for RenderVisitor<'a> {
         let t = self.root_transform.translate(local_rect.x, local_rect.y);
 
         if self.on(RenderLayer::Background) {
-            let ruby_extra_top =
-                editor_view::ruby_extra_top(metrics.baseline, metrics.ascent, ruby_annotations);
             for run in glyph_runs {
                 if let Some(ref bg_token) = run.background_color {
                     let bg_color = self.theme.color(bg_token);
-                    let run_rect =
-                        text_background_rect(local_rect, metrics, ruby_extra_top, run.x, run.width);
+                    let run_rect = text_background_rect(local_rect, metrics, run.x, run.width);
                     self.sink.fill_rect(run_rect, bg_color, t);
                 }
             }
@@ -2088,8 +2078,8 @@ mod tests {
             descent: 15.0,
         };
 
-        // No ruby (ruby_extra_top = 0): identical to the legacy centred formula.
-        let r = text_background_rect(line_rect, m, 0.0, 12.0, 34.0);
+        // The base text remains centered in its line box.
+        let r = text_background_rect(line_rect, m, 12.0, 34.0);
         let v1_text_height = m.ascent + m.descent;
         let selection_height = line_rect.height;
         let line_top = (selection_height - v1_text_height) * 0.5;
@@ -2100,29 +2090,6 @@ mod tests {
         assert!((r.height - v1_text_height).abs() < 0.01);
         assert!((selection_height - 100.0).abs() < 0.01);
         assert!(r.height < selection_height);
-    }
-
-    #[test]
-    fn text_background_rect_excludes_ruby_band() {
-        // Ruby inflates `ascent` and the line box top by `ruby_extra_top`. The
-        // fill must hug the base text only: height drops by the ruby band and
-        // the rect starts below it, never reaching into the ruby. (TR-222)
-        let line_rect = Rect::from_xywh(0.0, 0.0, 120.0, 100.0);
-        let m = LineMetrics {
-            baseline: 80.0,
-            ascent: 60.0, // base ascent 40 + ruby band 20
-            descent: 15.0,
-        };
-        let ruby_extra_top = 20.0;
-
-        let with_ruby = text_background_rect(line_rect, m, ruby_extra_top, 12.0, 34.0);
-        let without = text_background_rect(line_rect, m, 0.0, 12.0, 34.0);
-
-        // Height excludes the ruby band: (60-20)+15 = 55, vs 75 without.
-        assert!((with_ruby.height - 55.0).abs() < 0.01);
-        assert!(with_ruby.height < without.height);
-        // The rect starts below the ruby band reserved at the top.
-        assert!(with_ruby.y >= ruby_extra_top - 0.01);
     }
 
     /// Render the Background layer for a one-line doc and return the single

--- a/crates/editor-view/src/lib.rs
+++ b/crates/editor-view/src/lib.rs
@@ -19,7 +19,6 @@ mod viewport;
 pub use dnd::*;
 pub use external::ExternalElement;
 pub use measure::text::measure::TabGap;
-pub use measure::text::ruby::ruby_extra_top;
 pub use page::*;
 pub use page_fragment::{
     PageFragmentAtom, PageFragmentBox, PageFragmentContent, PageFragmentDecoration,

--- a/crates/editor-view/src/measure/text/measure.rs
+++ b/crates/editor-view/src/measure/text/measure.rs
@@ -24,7 +24,6 @@ use super::inline::{
 use super::layout::build_layout;
 use super::resolve::{ResolvedTextStyle, apply_pending_to_style, style_from_effective_modifiers};
 use super::ruby::build_ruby_annotations;
-use super::ruby::ruby_extra_top;
 use super::seg_cache::{self, SegmentCache};
 use super::strut::compute_strut;
 use super::style_run::resolve_style_runs;
@@ -97,11 +96,14 @@ impl MeasuredLine {
                     glyph.y += delta;
                 }
             }
+        }
+        let ruby_delta = delta - (ascent - self.ascent);
+        if ruby_delta != 0.0 {
             for annotation in &mut line.ruby_annotations {
-                annotation.baseline_y += delta;
+                annotation.baseline_y += ruby_delta;
                 for run in &mut annotation.glyph_runs {
                     for glyph in &mut run.glyphs {
-                        glyph.y += delta;
+                        glyph.y += ruby_delta;
                     }
                 }
             }
@@ -304,11 +306,6 @@ fn measure_segment<'a>(
         .into_iter()
         .enumerate()
         .map(|(i, (line, ruby_annotations))| {
-            let extra_top = ruby_extra_top(line.baseline, line.ascent, &ruby_annotations);
-            let new_ascent = line.ascent + extra_top;
-            let new_baseline = line.baseline + extra_top;
-            let new_height = line.height + extra_top;
-
             let line_offset_range = if n == 1 {
                 Some(seg_off.clone())
             } else if i == 0 {
@@ -318,32 +315,6 @@ fn measure_segment<'a>(
             } else {
                 None
             };
-
-            let glyph_runs = line
-                .glyph_runs
-                .into_iter()
-                .map(|mut r| {
-                    if extra_top != 0.0 {
-                        for g in &mut r.glyphs {
-                            g.y += extra_top;
-                        }
-                    }
-                    r
-                })
-                .collect::<Vec<_>>();
-
-            let ruby_annotations = ruby_annotations
-                .into_iter()
-                .map(|mut a| {
-                    a.baseline_y += extra_top;
-                    for run in &mut a.glyph_runs {
-                        for g in &mut run.glyphs {
-                            g.y += extra_top;
-                        }
-                    }
-                    a
-                })
-                .collect::<Vec<_>>();
 
             let tab_gaps: Vec<TabGap> = line
                 .tab_gaps_raw
@@ -358,13 +329,13 @@ fn measure_segment<'a>(
 
             MeasuredLine {
                 node: para,
-                height: new_height,
-                baseline: new_baseline,
-                ascent: new_ascent,
+                height: line.height,
+                baseline: line.baseline,
+                ascent: line.ascent,
                 descent: line.descent,
                 cursor_ascent: strut.ascent,
                 cursor_descent: strut.descent,
-                glyph_runs,
+                glyph_runs: line.glyph_runs,
                 ruby_annotations,
                 empty_caret_x: empty_caret_x_for(align, indent, width),
                 offset_range: line_offset_range,
@@ -820,7 +791,7 @@ mod tests {
     }
 
     #[test]
-    fn ruby_inflates_line_and_carries_annotations() {
+    fn ruby_preserves_base_line_metrics_and_carries_annotations() {
         let plain = measure(&build_logs(vec![ch('\u{6F22}'), ch('\u{5B57}')]), 1.0e6).0;
         let mut l = build_logs(vec![ch('\u{6F22}'), ch('\u{5B57}')]);
         l.spans = SpanLog::new()
@@ -840,17 +811,27 @@ mod tests {
             !ruby[0].ruby_annotations.is_empty(),
             "ruby annotations present"
         );
-        let d_ascent = ruby[0].ascent - plain[0].ascent;
-        let d_baseline = ruby[0].baseline - plain[0].baseline;
-        let d_height = ruby[0].height - plain[0].height;
-        assert!(
-            d_ascent > 0.0,
-            "ruby strictly inflates the line (extra_top > 0)"
+        assert_eq!(ruby[0].ascent, plain[0].ascent);
+        assert_eq!(ruby[0].descent, plain[0].descent);
+        assert_eq!(ruby[0].baseline, plain[0].baseline);
+        assert_eq!(ruby[0].height, plain[0].height);
+        assert_eq!(ruby[0].glyph_runs, plain[0].glyph_runs);
+
+        let expanded = expand_line_for_caret(
+            &ruby[0],
+            &LineStrutExpansion {
+                ascent: ruby[0].ascent + 10.0,
+                descent: ruby[0].descent + 2.0,
+                min_line_height: ruby[0].height + 20.0,
+            },
         );
-        assert!(
-            (d_ascent - d_baseline).abs() < 1e-3 && (d_ascent - d_height).abs() < 1e-3,
-            "extra_top added uniformly to ascent/baseline/height",
-        );
+        let ruby_bottom = expanded
+            .ruby_annotations
+            .iter()
+            .map(|annotation| annotation.baseline_y + annotation.descent)
+            .reduce(f32::max)
+            .unwrap();
+        assert!((expanded.baseline - expanded.ascent - ruby_bottom - 2.0).abs() < 0.001);
     }
 
     #[test]

--- a/crates/editor-view/src/measure/text/ruby.rs
+++ b/crates/editor-view/src/measure/text/ruby.rs
@@ -2,23 +2,6 @@ pub(crate) const RUBY_FONT_SIZE_RATIO: f32 = 0.5;
 pub(crate) const RUBY_FONT_SIZE_MIN_PX: f32 = 12.0;
 pub(crate) const RUBY_GAP: f32 = 2.0;
 
-pub fn ruby_extra_top(baseline: f32, ascent: f32, ruby_annotations: &[RubyAnnotation]) -> f32 {
-    if ruby_annotations.is_empty() {
-        return 0.0;
-    }
-    let max_ruby_ascent = ruby_annotations
-        .iter()
-        .map(|r| r.ascent)
-        .fold(0.0, f32::max);
-    let max_ruby_descent = ruby_annotations
-        .iter()
-        .map(|r| r.descent)
-        .fold(0.0, f32::max);
-    let required_top = max_ruby_ascent + max_ruby_descent + RUBY_GAP;
-    let available_top = (baseline - ascent).max(0.0);
-    (required_top - available_top).max(0.0)
-}
-
 use std::borrow::Cow;
 
 use editor_resource::{Resource, TextBrush};

--- a/crates/editor-view/src/page_fragment.rs
+++ b/crates/editor-view/src/page_fragment.rs
@@ -11,7 +11,7 @@ use crate::paginate::types::{
     ChildAttachment, LayoutAtom, LayoutContent, LayoutLine, LayoutNode, LayoutTree,
 };
 use crate::query::Edges;
-use crate::style::{BoxStyle, DecorationData};
+use crate::style::{BoxStyle, DecorationData, Direction};
 
 #[derive(Debug, Clone)]
 pub struct PageFragmentTree {
@@ -89,13 +89,37 @@ pub(crate) fn build_page_fragment_tree(
     }
 }
 
+fn paint_top(node: &LayoutNode) -> Option<f32> {
+    match &node.content {
+        LayoutContent::Line(line) if !line.is_phantom => Some(
+            line.ruby_annotations
+                .iter()
+                .map(|ruby| node.rect.y + ruby.baseline_y - ruby.ascent)
+                .fold(node.rect.y, f32::min),
+        ),
+        LayoutContent::Box(b) => {
+            // Later vertical content cannot rise above the first painted child:
+            // pagination keeps ruby clear of all preceding content.
+            let top = match b.style.direction {
+                Direction::Vertical => b.children.iter().find_map(paint_top),
+                Direction::Horizontal => b.children.iter().filter_map(paint_top).reduce(f32::min),
+            };
+            top.map(|top| top.min(node.rect.y))
+        }
+        LayoutContent::Atom(_) => Some(node.rect.y),
+        _ => None,
+    }
+}
+
 fn fragment_node(node: &LayoutNode, page: &LayoutPage) -> Option<PageFragmentNode> {
     let node_top = node.rect.y;
     let node_bottom = node.rect.bottom();
     let visible_top = page.content_y_start;
     let visible_bottom = page.content_y_end;
 
-    if node_bottom <= visible_top || node_top >= visible_bottom {
+    if node_bottom <= visible_top
+        || (node_top >= visible_bottom && paint_top(node).is_none_or(|top| top >= visible_bottom))
+    {
         return None;
     }
 
@@ -107,7 +131,7 @@ fn fragment_node(node: &LayoutNode, page: &LayoutPage) -> Option<PageFragmentNod
                 node.rect.x,
                 fragment_top - page.y_start,
                 node.rect.width,
-                fragment_bottom - fragment_top,
+                (fragment_bottom - fragment_top).max(0.0),
             );
             let content = PageFragmentContent::Box(PageFragmentBox {
                 node: b.node,
@@ -134,10 +158,8 @@ fn fragment_node(node: &LayoutNode, page: &LayoutPage) -> Option<PageFragmentNod
             return Some(PageFragmentNode { rect, content });
         }
         LayoutContent::Line(l) => {
-            debug_assert!(
-                node_top >= visible_top && node_bottom <= visible_bottom,
-                "line layout node should be contained by its page content window"
-            );
+            // Continuous rendering pages can split the leading shared by two
+            // lines. Include the next line's ruby on both sides of that split.
             PageFragmentContent::Line(fragment_line(l))
         }
         LayoutContent::Atom(a) => {

--- a/crates/editor-view/src/paginate/mod.rs
+++ b/crates/editor-view/src/paginate/mod.rs
@@ -1,2 +1,6 @@
 pub(crate) mod paginator;
+mod placement;
 pub(crate) mod types;
+
+#[cfg(test)]
+mod ruby_tests;

--- a/crates/editor-view/src/paginate/paginator.rs
+++ b/crates/editor-view/src/paginate/paginator.rs
@@ -8,6 +8,11 @@ use crate::measure::types::{MeasuredBox, MeasuredContent, MeasuredNode, Measured
 use crate::page::LayoutPage;
 use crate::style::*;
 
+pub(crate) use super::placement::{box_content_top, content_bottom};
+use super::placement::{
+    child_border_bottom, child_border_top, leading_chrome_height, line_y, place_node_at,
+    positioned_style, trailing_chrome_height,
+};
 use super::types::*;
 
 pub(crate) struct Paginator {
@@ -17,6 +22,7 @@ pub(crate) struct Paginator {
     content_height: f32,
     margins: EdgeInsets,
     accumulated_y: f32,
+    previous_content_bottom: f32,
     current_x: f32,
     current_width: f32,
     page_content_top: f32,
@@ -35,6 +41,7 @@ impl Paginator {
             content_height,
             margins,
             accumulated_y: margins.top,
+            previous_content_bottom: 0.0,
             current_x: margins.left,
             current_width: content_width,
             page_content_top: margins.top,
@@ -52,6 +59,7 @@ impl Paginator {
             content_height: max_content_height,
             margins,
             accumulated_y: margins.top,
+            previous_content_bottom: 0.0,
             current_x: margins.left,
             current_width: content_width,
             page_content_top: margins.top,
@@ -75,12 +83,14 @@ impl Paginator {
         parent: Dot,
         child_index: usize,
         accumulated_y: f32,
+        previous_content_bottom: f32,
         current_x: f32,
         current_width: f32,
         page_content_top: f32,
         page_content_bottom: f32,
     ) -> LayoutNode {
         self.accumulated_y = accumulated_y;
+        self.previous_content_bottom = previous_content_bottom;
         self.current_x = current_x;
         self.current_width = current_width;
         self.page_content_top = page_content_top;
@@ -123,9 +133,13 @@ impl Paginator {
                 placed
             }
             MeasuredContent::Line(l) => {
-                let y = self.accumulated_y;
+                let y = line_y(l, self.accumulated_y, self.previous_content_bottom);
                 let x = self.current_x;
-                self.accumulated_y += node.height;
+                self.accumulated_y = y + node.height;
+                if !l.is_phantom {
+                    self.previous_content_bottom =
+                        self.previous_content_bottom.max(y + l.baseline + l.descent);
+                }
                 LayoutNode {
                     rect: Rect::from_xywh(x, y, node.width, node.height),
                     content: LayoutContent::Line(LayoutLine {
@@ -137,6 +151,7 @@ impl Paginator {
                 let y = self.accumulated_y;
                 let x = self.current_x;
                 self.accumulated_y += node.height;
+                self.previous_content_bottom = self.previous_content_bottom.max(self.accumulated_y);
                 LayoutNode {
                     rect: Rect::from_xywh(x, y, node.width, node.height),
                     content: LayoutContent::Atom(LayoutAtom {
@@ -189,6 +204,9 @@ impl Paginator {
             measured.style.border.left
         };
 
+        if let Some(top) = box_content_top(&measured.style, measured.scope, box_y) {
+            self.previous_content_bottom = self.previous_content_bottom.max(top);
+        }
         self.accumulated_y += lead_border_top + measured.style.padding.top;
 
         let old_x = self.current_x;
@@ -289,12 +307,19 @@ impl Paginator {
         };
         self.accumulated_y += measured.style.padding.bottom + trail_border_bottom;
         let box_height = self.accumulated_y - box_y;
+        if box_content_top(&measured.style, measured.scope, box_y).is_some()
+            || measured.style.padding.bottom > 0.0
+            || measured.style.border.bottom > 0.0
+        {
+            self.previous_content_bottom = self.previous_content_bottom.max(self.accumulated_y);
+        }
+        let style = positioned_style(measured, &children, box_y);
 
         LayoutNode {
             rect: Rect::from_xywh(box_x, box_y, width, box_height),
             content: LayoutContent::Box(LayoutBox {
                 node: measured.node,
-                style: measured.style.clone(),
+                style,
                 children: children.into(),
                 attachment: None,
                 scope: measured.scope,
@@ -303,57 +328,17 @@ impl Paginator {
     }
 
     fn place_horizontal(&mut self, measured: &MeasuredBox, node: &MeasuredNode) -> LayoutNode {
-        let box_x = self.compute_box_x(measured, node.width);
-        let box_y = self.accumulated_y;
-
-        let collapse = measured.style.border_mode == BorderMode::Collapse;
-        let lead_border_left = if collapse {
-            0.0
-        } else {
-            measured.style.border.left
-        };
-        let lead_border_top = if collapse {
-            0.0
-        } else {
-            measured.style.border.top
-        };
-
-        let mut child_x = box_x + lead_border_left + measured.style.padding.left;
-        let child_y = box_y + lead_border_top + measured.style.padding.top;
-
-        let mut child_index: usize = 0;
-        let children: Vec<LayoutNode> = measured
-            .children
-            .iter()
-            .map(|child| {
-                let is_doc_child = !matches!(child.content, MeasuredContent::Spacing(_));
-                let layout_child =
-                    place_node_at(child, child_x, child_y, measured.node, child_index);
-                if is_doc_child {
-                    child_index += 1;
-                }
-                child_x += child.width;
-                if measured.style.border_mode == BorderMode::Collapse
-                    && let MeasuredContent::Box(child_box) = &child.content
-                {
-                    child_x -= child_box.style.border.right;
-                }
-                layout_child
-            })
-            .collect();
-
-        self.accumulated_y += node.height;
-
-        LayoutNode {
-            rect: Rect::from_xywh(box_x, box_y, node.width, node.height),
-            content: LayoutContent::Box(LayoutBox {
-                node: measured.node,
-                style: measured.style.clone(),
-                children: children.into(),
-                attachment: None,
-                scope: measured.scope,
-            }),
-        }
+        let x = self.compute_box_x(measured, node.width);
+        let placed = place_node_at(
+            node,
+            x,
+            self.accumulated_y,
+            measured.node,
+            0,
+            &mut self.previous_content_bottom,
+        );
+        self.accumulated_y = placed.rect.bottom();
+        placed
     }
 
     fn break_page(&mut self, children: &mut Vec<LayoutNode>) {
@@ -400,7 +385,13 @@ impl Paginator {
             return child.height > remaining;
         }
 
-        initial_keep_height(child, terminal_chrome_after).is_some_and(|keep| keep > remaining)
+        initial_keep_height(
+            child,
+            terminal_chrome_after,
+            self.accumulated_y,
+            self.previous_content_bottom,
+        )
+        .is_some_and(|keep| keep > remaining)
     }
 
     fn page_content_bottom(&self) -> f32 {
@@ -425,6 +416,7 @@ impl Paginator {
             self.page_content_top = page_end + self.margins.top;
             self.page_content_bottom = self.page_content_top + self.content_height;
             self.accumulated_y = self.page_content_top;
+            self.previous_content_bottom = page_end;
         } else {
             let is_first_page = self.pages.is_empty();
             let page_start = if is_first_page {
@@ -496,38 +488,6 @@ impl Paginator {
     }
 }
 
-fn child_border_top(node: &MeasuredNode) -> f32 {
-    match &node.content {
-        MeasuredContent::Box(b) => b.style.border.top,
-        _ => 0.0,
-    }
-}
-
-fn child_border_bottom(node: &MeasuredNode) -> Option<f32> {
-    match &node.content {
-        MeasuredContent::Box(b) => Some(b.style.border.bottom),
-        _ => None,
-    }
-}
-
-fn leading_chrome_height(b: &MeasuredBox) -> f32 {
-    let border_top = if b.style.border_mode == BorderMode::Collapse {
-        0.0
-    } else {
-        b.style.border.top
-    };
-    border_top + b.style.padding.top
-}
-
-fn trailing_chrome_height(b: &MeasuredBox) -> f32 {
-    let border_bottom = if b.style.border_mode == BorderMode::Collapse {
-        0.0
-    } else {
-        b.style.border.bottom
-    };
-    b.style.padding.bottom + border_bottom
-}
-
 fn terminal_child_index(b: &MeasuredBox) -> Option<usize> {
     let mut last = None;
     for (i, child) in b.children.iter().enumerate() {
@@ -547,120 +507,46 @@ fn initial_child_index(b: &MeasuredBox) -> Option<usize> {
         .position(|child| !matches!(child.content, MeasuredContent::Spacing(_)))
 }
 
-fn initial_keep_height(node: &MeasuredNode, terminal_chrome_after: f32) -> Option<f32> {
-    if node.page_break_policy() == PageBreakPolicy::Avoid {
-        return Some(node.height + terminal_chrome_after);
+fn initial_keep_height(
+    node: &MeasuredNode,
+    terminal_chrome_after: f32,
+    y: f32,
+    mut previous_content_bottom: f32,
+) -> Option<f32> {
+    if let MeasuredContent::Line(line) = &node.content {
+        return Some(
+            line_y(line, y, previous_content_bottom) - y + node.height + terminal_chrome_after,
+        );
     }
-
+    if node.page_break_policy() == PageBreakPolicy::Avoid {
+        let placed = place_node_at(node, 0.0, y, Dot::ROOT, 0, &mut previous_content_bottom);
+        return Some(placed.rect.bottom() - y + terminal_chrome_after);
+    }
     let MeasuredContent::Box(b) = &node.content else {
         return None;
     };
     if b.style.direction != Direction::Vertical {
         return None;
     }
-
     let first_child_index = initial_child_index(b)?;
     let child_terminal_chrome_after = if Some(first_child_index) == terminal_child_index(b) {
         terminal_chrome_after + trailing_chrome_height(b)
     } else {
         0.0
     };
-
-    Some(
-        leading_chrome_height(b)
-            + initial_keep_height(&b.children[first_child_index], child_terminal_chrome_after)?,
-    )
-}
-
-fn place_node_at(
-    node: &MeasuredNode,
-    x: f32,
-    y: f32,
-    parent: Dot,
-    child_index: usize,
-) -> LayoutNode {
-    match &node.content {
-        MeasuredContent::Box(b) => {
-            let mut offset_y = b.style.border.top + b.style.padding.top;
-            let mut offset_x = b.style.border.left + b.style.padding.left;
-            let children: Vec<LayoutNode> = match b.style.direction {
-                Direction::Vertical => {
-                    let mut idx: usize = 0;
-                    b.children
-                        .iter()
-                        .map(|child| {
-                            let is_doc_child =
-                                !matches!(child.content, MeasuredContent::Spacing(_));
-                            let c = place_node_at(child, x + offset_x, y + offset_y, b.node, idx);
-                            if is_doc_child {
-                                idx += 1;
-                            }
-                            offset_y += child.height;
-                            c
-                        })
-                        .collect()
-                }
-                Direction::Horizontal => {
-                    let mut idx: usize = 0;
-                    b.children
-                        .iter()
-                        .map(|child| {
-                            let is_doc_child =
-                                !matches!(child.content, MeasuredContent::Spacing(_));
-                            let c = place_node_at(child, x + offset_x, y + offset_y, b.node, idx);
-                            if is_doc_child {
-                                idx += 1;
-                            }
-                            offset_x += child.width;
-                            c
-                        })
-                        .collect()
-                }
-            };
-            let attachment = Some(ChildAttachment {
-                parent,
-                index: child_index,
-            });
-            LayoutNode {
-                rect: Rect::from_xywh(x, y, node.width, node.height),
-                content: LayoutContent::Box(LayoutBox {
-                    node: b.node,
-                    style: b.style.clone(),
-                    children: children.into(),
-                    attachment,
-                    scope: b.scope,
-                }),
-            }
-        }
-        MeasuredContent::Line(l) => LayoutNode {
-            rect: Rect::from_xywh(x, y, node.width, node.height),
-            content: LayoutContent::Line(LayoutLine {
-                measured: std::sync::Arc::clone(l),
-            }),
-        },
-        MeasuredContent::Atom(a) => LayoutNode {
-            rect: Rect::from_xywh(x, y, node.width, node.height),
-            content: LayoutContent::Atom(LayoutAtom {
-                node: a.node,
-                attachment: ChildAttachment {
-                    parent,
-                    index: child_index,
-                },
-            }),
-        },
-        MeasuredContent::Spacing(h) => LayoutNode {
-            rect: Rect::from_xywh(x, y, node.width, *h),
-            content: LayoutContent::Spacing(SpacingKind::Gap {
-                position: Position::new(parent, child_index),
-            }),
-        },
-        MeasuredContent::PageBreak => LayoutNode {
-            rect: Rect::from_xywh(x, y, 0.0, 0.0),
-            content: LayoutContent::Spacing(SpacingKind::Gap {
-                position: Position::new(parent, child_index),
-            }),
-        },
+    if let Some(top) = box_content_top(&b.style, b.scope, y) {
+        previous_content_bottom = previous_content_bottom.max(top);
     }
+    let leading = leading_chrome_height(b);
+    Some(
+        leading
+            + initial_keep_height(
+                &b.children[first_child_index],
+                child_terminal_chrome_after,
+                y + leading,
+                previous_content_bottom,
+            )?,
+    )
 }
 
 #[cfg(test)]

--- a/crates/editor-view/src/paginate/placement.rs
+++ b/crates/editor-view/src/paginate/placement.rs
@@ -1,0 +1,229 @@
+use editor_common::Rect;
+use editor_crdt::Dot;
+use editor_state::Position;
+
+use crate::measure::nodes::line_geometry::first_line_info;
+use crate::measure::text::measure::MeasuredLine;
+use crate::measure::text::ruby::RUBY_GAP;
+use crate::measure::types::{MeasuredBox, MeasuredContent, MeasuredNode};
+use crate::style::{BorderMode, BoxStyle, Direction};
+
+use super::types::{
+    ChildAttachment, LayoutAtom, LayoutBox, LayoutContent, LayoutLine, LayoutNode, SpacingKind,
+};
+
+pub(super) fn line_y(line: &MeasuredLine, y: f32, previous_content_bottom: f32) -> f32 {
+    let ruby_top = line
+        .ruby_annotations
+        .iter()
+        .map(|ruby| ruby.baseline_y - ruby.ascent)
+        .reduce(f32::min);
+    ruby_top.map_or(y, |top| y.max(previous_content_bottom + RUBY_GAP - top))
+}
+
+pub(crate) fn box_content_top(style: &BoxStyle, scope: bool, y: f32) -> Option<f32> {
+    (scope || style.monolithic || style.padding.top > 0.0 || style.border.top > 0.0)
+        .then_some(y + style.border.top)
+}
+
+/// The last painted boundary matters even when a line's leading extends below it.
+/// Transparent paragraph boxes and spacing do not consume that leading.
+pub(crate) fn content_bottom(node: &LayoutNode) -> Option<f32> {
+    match &node.content {
+        LayoutContent::Line(line) => {
+            (!line.is_phantom).then_some(node.rect.y + line.baseline + line.descent)
+        }
+        LayoutContent::Atom(_) => Some(node.rect.bottom()),
+        LayoutContent::Box(b) => {
+            let bottom = b
+                .children
+                .iter()
+                .filter_map(content_bottom)
+                .reduce(f32::max);
+            if box_content_top(&b.style, b.scope, node.rect.y).is_some()
+                || b.style.padding.bottom > 0.0
+                || b.style.border.bottom > 0.0
+            {
+                Some(bottom.unwrap_or(node.rect.bottom()).max(node.rect.bottom()))
+            } else {
+                bottom
+            }
+        }
+        LayoutContent::Spacing(_) => None,
+    }
+}
+
+pub(super) fn positioned_style(b: &MeasuredBox, children: &[LayoutNode], y: f32) -> BoxStyle {
+    fn first_line_y(node: &LayoutNode) -> Option<f32> {
+        match &node.content {
+            LayoutContent::Line(_) => Some(node.rect.y),
+            LayoutContent::Box(b) => b.children.iter().find_map(first_line_y),
+            _ => None,
+        }
+    }
+    let mut style = b.style.clone();
+    if style.decorations.is_empty() {
+        return style;
+    }
+    let mut top = y + leading_chrome_height(b);
+    let measured_top = b.children.iter().find_map(|child| {
+        let found = first_line_info(child).map(|line| top + line.top);
+        top += child.height;
+        found
+    });
+    if let Some((measured_top, placed_top)) =
+        measured_top.zip(children.iter().find_map(first_line_y))
+    {
+        for decoration in &mut style.decorations {
+            decoration.rect.y += placed_top - measured_top;
+        }
+    }
+    style
+}
+
+/// Place an indivisible subtree with the same ruby clearance as paginated lines.
+pub(super) fn place_node_at(
+    node: &MeasuredNode,
+    x: f32,
+    y: f32,
+    parent: Dot,
+    child_index: usize,
+    previous_content_bottom: &mut f32,
+) -> LayoutNode {
+    let placed = match &node.content {
+        MeasuredContent::Box(b) => {
+            if let Some(top) = box_content_top(&b.style, b.scope, y) {
+                *previous_content_bottom = previous_content_bottom.max(top);
+            }
+            let collapse = b.style.border_mode == BorderMode::Collapse;
+            let mut child_y = y + leading_chrome_height(b);
+            let mut child_x =
+                x + b.style.padding.left + if collapse { 0.0 } else { b.style.border.left };
+            let start_y = child_y;
+            let start_bottom = *previous_content_bottom;
+            let mut bottom = child_y;
+            let mut previous_border_bottom: f32 = 0.0;
+            let mut idx = 0;
+            let mut children = Vec::new();
+            for child in &b.children {
+                if b.style.direction == Direction::Horizontal {
+                    child_y = start_y;
+                    *previous_content_bottom = start_bottom;
+                } else if collapse {
+                    child_y -= previous_border_bottom.min(child_border_top(child));
+                }
+                let placed = place_node_at(
+                    child,
+                    child_x,
+                    child_y,
+                    b.node,
+                    idx,
+                    previous_content_bottom,
+                );
+                if !matches!(child.content, MeasuredContent::Spacing(_)) {
+                    idx += 1;
+                }
+                if b.style.direction == Direction::Horizontal {
+                    child_x += child.width;
+                    if collapse && let MeasuredContent::Box(child_box) = &child.content {
+                        child_x -= child_box.style.border.right;
+                    }
+                } else {
+                    child_y = placed.rect.bottom();
+                }
+                bottom = bottom.max(placed.rect.bottom());
+                previous_border_bottom = child_border_bottom(child).unwrap_or(0.0);
+                children.push(placed);
+            }
+            let height = node.height.max(bottom - y + trailing_chrome_height(b));
+            if b.style.direction == Direction::Horizontal {
+                for child in &mut children {
+                    child.rect.height = bottom - start_y;
+                }
+            }
+            let style = positioned_style(b, &children, y);
+            LayoutNode {
+                rect: Rect::from_xywh(x, y, node.width, height),
+                content: LayoutContent::Box(LayoutBox {
+                    node: b.node,
+                    style,
+                    children: children.into(),
+                    attachment: Some(ChildAttachment {
+                        parent,
+                        index: child_index,
+                    }),
+                    scope: b.scope,
+                }),
+            }
+        }
+        MeasuredContent::Line(line) => LayoutNode {
+            rect: Rect::from_xywh(
+                x,
+                line_y(line, y, *previous_content_bottom),
+                node.width,
+                node.height,
+            ),
+            content: LayoutContent::Line(LayoutLine {
+                measured: std::sync::Arc::clone(line),
+            }),
+        },
+        MeasuredContent::Atom(a) => LayoutNode {
+            rect: Rect::from_xywh(x, y, node.width, node.height),
+            content: LayoutContent::Atom(LayoutAtom {
+                node: a.node,
+                attachment: ChildAttachment {
+                    parent,
+                    index: child_index,
+                },
+            }),
+        },
+        MeasuredContent::Spacing(height) => LayoutNode {
+            rect: Rect::from_xywh(x, y, node.width, *height),
+            content: LayoutContent::Spacing(SpacingKind::Gap {
+                position: Position::new(parent, child_index),
+            }),
+        },
+        MeasuredContent::PageBreak => LayoutNode {
+            rect: Rect::from_xywh(x, y, 0.0, 0.0),
+            content: LayoutContent::Spacing(SpacingKind::Gap {
+                position: Position::new(parent, child_index),
+            }),
+        },
+    };
+    if let Some(bottom) = content_bottom(&placed) {
+        *previous_content_bottom = previous_content_bottom.max(bottom);
+    }
+    placed
+}
+
+pub(super) fn child_border_top(node: &MeasuredNode) -> f32 {
+    match &node.content {
+        MeasuredContent::Box(b) => b.style.border.top,
+        _ => 0.0,
+    }
+}
+
+pub(super) fn child_border_bottom(node: &MeasuredNode) -> Option<f32> {
+    match &node.content {
+        MeasuredContent::Box(b) => Some(b.style.border.bottom),
+        _ => None,
+    }
+}
+
+pub(super) fn leading_chrome_height(b: &MeasuredBox) -> f32 {
+    let border_top = if b.style.border_mode == BorderMode::Collapse {
+        0.0
+    } else {
+        b.style.border.top
+    };
+    border_top + b.style.padding.top
+}
+
+pub(super) fn trailing_chrome_height(b: &MeasuredBox) -> f32 {
+    let border_bottom = if b.style.border_mode == BorderMode::Collapse {
+        0.0
+    } else {
+        b.style.border.bottom
+    };
+    b.style.padding.bottom + border_bottom
+}

--- a/crates/editor-view/src/paginate/ruby_tests.rs
+++ b/crates/editor-view/src/paginate/ruby_tests.rs
@@ -1,0 +1,389 @@
+use editor_common::EdgeInsets;
+use editor_crdt::{Dot, InputEvent, ListOp, build_oplog};
+use editor_model::{
+    AliasLog, Anchor, Bias, DocLogs, DocView, Modifier, ModifierAttrLog, ModifierAttrOp,
+    NodeAttrLog, NodeType, SeqItem, SpanLog, SpanOp, project_document,
+};
+use editor_resource::Resource;
+
+use crate::measure::context::MeasureContext;
+use crate::measure::nodes::dispatch::measure_node;
+use crate::measure::types::MeasuredTree;
+
+use super::paginator::Paginator;
+use super::types::{LayoutContent, LayoutLine, LayoutNode, PaginatedLayout};
+
+fn document(paragraphs: &[(&str, Option<&str>)], line_height: u32, gap: u32) -> DocLogs {
+    wrapped_document(paragraphs, line_height, gap, &[])
+}
+
+fn wrapped_document(
+    paragraphs: &[(&str, Option<&str>)],
+    line_height: u32,
+    gap: u32,
+    wrappers: &[NodeType],
+) -> DocLogs {
+    let mut events = Vec::new();
+    let mut spans = SpanLog::new();
+    let mut parents = vec![Dot::ROOT];
+    for node_type in wrappers {
+        let pos = events.len();
+        let id = Dot::new(1, pos as u64 + 1);
+        events.push(InputEvent {
+            id,
+            parents: if pos == 0 {
+                vec![]
+            } else {
+                vec![Dot::new(1, pos as u64)]
+            },
+            op: ListOp::Ins {
+                pos,
+                item: SeqItem::Block {
+                    node_type: *node_type,
+                    parents: parents.clone(),
+                    attrs: vec![],
+                },
+            },
+        });
+        parents.push(id);
+    }
+    for (text, ruby) in paragraphs {
+        let para = Dot::new(1, events.len() as u64 + 1);
+        let first_char = Dot::new(1, para.clock + 1);
+        let items = std::iter::once(SeqItem::Block {
+            node_type: NodeType::Paragraph,
+            parents: parents.clone(),
+            attrs: vec![],
+        })
+        .chain(text.chars().map(SeqItem::Char));
+        for item in items {
+            let pos = events.len();
+            events.push(InputEvent {
+                id: Dot::new(1, pos as u64 + 1),
+                parents: if pos == 0 {
+                    vec![]
+                } else {
+                    vec![Dot::new(1, pos as u64)]
+                },
+                op: ListOp::Ins { pos, item },
+            });
+        }
+        if let Some(ruby) = ruby {
+            spans = spans
+                .apply(
+                    para,
+                    SpanOp::AddSpan {
+                        start: Anchor {
+                            id: first_char,
+                            bias: Bias::Before,
+                        },
+                        end: Anchor {
+                            id: Dot::new(1, events.len() as u64),
+                            bias: Bias::After,
+                        },
+                        modifier: Modifier::Ruby {
+                            text: (*ruby).to_string(),
+                        },
+                    },
+                )
+                .unwrap();
+        }
+    }
+    let mut block_modifiers = ModifierAttrLog::new();
+    for (i, modifier) in [
+        Modifier::LineHeight { value: line_height },
+        Modifier::BlockGap { value: gap },
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        block_modifiers = block_modifiers
+            .apply(
+                Dot::new(2, i as u64 + 1),
+                ModifierAttrOp::SetModifier {
+                    target: Dot::ROOT,
+                    modifier,
+                },
+            )
+            .unwrap();
+    }
+    DocLogs {
+        seq: build_oplog(&events),
+        spans,
+        block_modifiers,
+        node_attrs: NodeAttrLog::new(),
+        node_carries: ModifierAttrLog::new(),
+        aliases: AliasLog::new(),
+    }
+}
+
+fn layout(doc: &DocLogs, paginator: Paginator) -> PaginatedLayout {
+    let pd = project_document(doc).unwrap();
+    let view = DocView::new(&pd);
+    let measured = measure_node(
+        &mut crate::measure::Measurer::new(),
+        &view.root().unwrap(),
+        300.0,
+        &MeasureContext::default(),
+        &mut Resource::new_test(),
+    );
+    paginator.paginate(MeasuredTree { root: measured })
+}
+
+fn lines(node: &LayoutNode) -> Vec<(&LayoutNode, &LayoutLine)> {
+    match &node.content {
+        LayoutContent::Line(line) if !line.is_phantom => vec![(node, line)],
+        LayoutContent::Box(b) => b.children.iter().flat_map(lines).collect(),
+        _ => vec![],
+    }
+}
+
+fn ruby_top(node: &LayoutNode, line: &LayoutLine) -> f32 {
+    node.rect.y
+        + line
+            .ruby_annotations
+            .iter()
+            .map(|ruby| ruby.baseline_y - ruby.ascent)
+            .reduce(f32::min)
+            .expect("ruby annotation")
+}
+
+fn close(actual: f32, expected: f32) {
+    assert!(
+        (actual - expected).abs() < 0.001,
+        "got {actual}, expected {expected}"
+    );
+}
+
+#[test]
+fn page_margin_is_used_before_adding_only_the_missing_clearance() {
+    let plain = document(&[("abc", None)], 160, 0);
+    let ruby = document(&[("abc", Some("annotation"))], 160, 0);
+    for margin in [40.0, 1.0, 0.0] {
+        let paginator = || Paginator::paginated(380.0, 500.0, EdgeInsets::all(margin));
+        let plain = layout(&plain, paginator());
+        let ruby = layout(&ruby, paginator());
+        let (plain_node, plain_line) = lines(&plain.tree.root)[0];
+        let (ruby_node, ruby_line) = lines(&ruby.tree.root)[0];
+        close(ruby_node.rect.height, plain_node.rect.height);
+        close(ruby_line.baseline, plain_line.baseline);
+        if margin == 40.0 {
+            close(ruby_node.rect.y, plain_node.rect.y);
+            assert!(ruby_top(ruby_node, ruby_line) < ruby.pages[0].content_y_start);
+        } else {
+            close(ruby_top(ruby_node, ruby_line), 2.0);
+        }
+    }
+}
+
+#[test]
+fn adjacent_lines_share_all_available_leading_and_paragraph_spacing() {
+    for gap in [0, 100] {
+        let plain = document(&[("abc", None), ("def", None)], 240, gap);
+        let ruby = document(&[("abc", None), ("def", Some("annotation"))], 240, gap);
+        let paginator = || Paginator::continuous(380.0, 100_000.0, EdgeInsets::all(40.0));
+        let plain = layout(&plain, paginator());
+        let ruby = layout(&ruby, paginator());
+        let plain_lines = lines(&plain.tree.root);
+        let ruby_lines = lines(&ruby.tree.root);
+        for ((plain_node, _), (ruby_node, _)) in plain_lines.iter().zip(&ruby_lines) {
+            assert_eq!(ruby_node.rect, plain_node.rect);
+        }
+        let (previous, previous_line) = ruby_lines[0];
+        let (current, current_line) = ruby_lines[1];
+        assert!(
+            ruby_top(current, current_line)
+                >= previous.rect.y + previous_line.baseline + previous_line.descent + 2.0 - 0.001
+        );
+    }
+}
+
+#[test]
+fn tight_lines_add_only_the_missing_space() {
+    let state = document(&[("abc", None), ("def", Some("annotation"))], 100, 0);
+    let layout = layout(
+        &state,
+        Paginator::continuous(380.0, 100_000.0, EdgeInsets::all(40.0)),
+    );
+    let lines = lines(&layout.tree.root);
+    let (previous, previous_line) = lines[0];
+    let (current, current_line) = lines[1];
+    close(
+        ruby_top(current, current_line),
+        previous.rect.y + previous_line.baseline + previous_line.descent + 2.0,
+    );
+}
+
+#[test]
+fn indexed_previous_content_bottom_includes_earlier_tall_text() {
+    let mut doc = document(
+        &[("a", None), ("b", None), ("c", Some("annotation"))],
+        50,
+        0,
+    );
+    doc.spans = doc
+        .spans
+        .apply(
+            Dot::new(3, 1),
+            SpanOp::AddSpan {
+                start: Anchor {
+                    id: Dot::new(1, 2),
+                    bias: Bias::Before,
+                },
+                end: Anchor {
+                    id: Dot::new(1, 2),
+                    bias: Bias::After,
+                },
+                modifier: Modifier::FontSize { value: 6000 },
+            },
+        )
+        .unwrap();
+    let layout = layout(
+        &doc,
+        Paginator::continuous(380.0, 100_000.0, EdgeInsets::all(40.0)),
+    );
+    let all_lines = lines(&layout.tree.root);
+    let first_bottom = all_lines[0].0.rect.y + all_lines[0].1.baseline + all_lines[0].1.descent;
+    let second_bottom = all_lines[1].0.rect.y + all_lines[1].1.baseline + all_lines[1].1.descent;
+    assert!(first_bottom > second_bottom);
+    let ruby_node = all_lines[2].1.node;
+    let index = crate::query::layout_index::LayoutIndex::new(layout.tree, &layout.pages);
+    close(
+        index.box_entry(&ruby_node).unwrap().previous_content_bottom,
+        first_bottom,
+    );
+}
+
+#[test]
+fn automatic_page_break_recomputes_clearance_from_the_new_page_margin() {
+    let doc = document(&[("abc", None), ("def", Some("annotation"))], 100, 0);
+    let continuous = layout(
+        &doc,
+        Paginator::continuous(380.0, 100_000.0, EdgeInsets::all(40.0)),
+    );
+    let line_height = lines(&continuous.tree.root)[0].0.rect.height;
+    let paginated = layout(
+        &doc,
+        Paginator::paginated(380.0, 80.0 + 2.0 * line_height + 0.5, EdgeInsets::all(40.0)),
+    );
+    assert_eq!(paginated.pages.len(), 2);
+    let (node, line) = lines(&paginated.tree.root)[1];
+    close(node.rect.y, paginated.pages[1].content_y_start);
+    assert!(ruby_top(node, line) >= paginated.pages[1].y_start + 2.0);
+    assert!(ruby_top(node, line) < paginated.pages[1].content_y_start);
+    for (i, page) in paginated.pages.iter().enumerate() {
+        crate::page_fragment::build_page_fragment_tree(&paginated.tree, i, page);
+    }
+}
+
+#[test]
+fn callout_and_table_cell_use_padding_before_growing() {
+    for wrappers in [
+        &[NodeType::Callout][..],
+        &[NodeType::Table, NodeType::TableRow, NodeType::TableCell][..],
+    ] {
+        let plain = wrapped_document(&[("abc", None)], 160, 0, wrappers);
+        let ruby = wrapped_document(&[("abc", Some("annotation"))], 160, 0, wrappers);
+        let paginator = || Paginator::continuous(380.0, 100_000.0, EdgeInsets::all(40.0));
+        let plain = layout(&plain, paginator());
+        let ruby = layout(&ruby, paginator());
+        let (plain_node, _) = lines(&plain.tree.root)[0];
+        let (ruby_node, ruby_line) = lines(&ruby.tree.root)[0];
+        close(ruby_node.rect.height, plain_node.rect.height);
+        if wrappers[0] == NodeType::Callout {
+            assert_eq!(ruby_node.rect, plain_node.rect);
+        } else {
+            close(
+                ruby_top(ruby_node, ruby_line),
+                ruby.tree.root.rect.y + 1.0 + 2.0,
+            );
+            let delta = ruby_node.rect.y - plain_node.rect.y;
+            assert!(delta > 0.0);
+            close(
+                ruby.tree.root.rect.height - plain.tree.root.rect.height,
+                delta,
+            );
+        }
+    }
+}
+
+#[test]
+fn wrapped_lines_with_ruby_keep_two_pixels_between_annotations_and_base_text() {
+    let doc = document(
+        &[(
+            "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz",
+            Some(
+                "annotation annotation annotation annotation annotation annotation annotation annotation",
+            ),
+        )],
+        100,
+        0,
+    );
+    let layout = layout(
+        &doc,
+        Paginator::continuous(380.0, 100_000.0, EdgeInsets::all(40.0)),
+    );
+    let lines = lines(&layout.tree.root);
+    assert!(lines.len() > 2);
+    for pair in lines.windows(2) {
+        let (previous, previous_line) = pair[0];
+        let (current, current_line) = pair[1];
+        close(
+            ruby_top(current, current_line),
+            previous.rect.y + previous_line.baseline + previous_line.descent + 2.0,
+        );
+    }
+}
+
+#[test]
+fn ruby_does_not_change_hit_testing_in_previous_lines_leading() {
+    let doc = document(&[("abc", None), ("def", Some("annotation"))], 240, 0);
+    let layout = layout(
+        &doc,
+        Paginator::continuous(380.0, 100_000.0, EdgeInsets::all(40.0)),
+    );
+    let all_lines = lines(&layout.tree.root);
+    let (node, line) = all_lines[1];
+    let x = node.rect.x + line.ruby_annotations[0].x + 1.0;
+    let y = ruby_top(node, line) + 1.0;
+    assert!(y < all_lines[0].0.rect.bottom());
+    let expected_node = all_lines[0].1.node;
+    let index = crate::query::layout_index::LayoutIndex::new(layout.tree, &layout.pages);
+    let selection = crate::query::hit_test::hit_test(&index, 0, x, y).unwrap();
+    assert_eq!(selection.head.node, expected_node);
+    let previous_selection = crate::query::hit_test::hit_test(&index, 0, x, 50.0).unwrap();
+    let projected = project_document(&doc).unwrap();
+    let rects = crate::query::hit_test::cursor_hit_rects(
+        &index,
+        &DocView::new(&projected),
+        &previous_selection,
+    );
+    assert!(rects.iter().any(|rect| rect.rect.contains(x, y)));
+}
+
+#[test]
+fn continuous_page_fragments_include_ruby_crossing_the_rendering_boundary() {
+    use crate::page_fragment::{PageFragmentContent, PageFragmentNode};
+    fn contains_ruby(node: &PageFragmentNode) -> bool {
+        match &node.content {
+            PageFragmentContent::Line(line) => !line.ruby_annotations.is_empty(),
+            PageFragmentContent::Box(b) => b.children.iter().any(contains_ruby),
+            _ => false,
+        }
+    }
+    let doc = document(&[("abc", None), ("def", Some("annotation"))], 240, 0);
+    let layout = layout(
+        &doc,
+        Paginator::continuous(380.0, 20.0, EdgeInsets::all(40.0)),
+    );
+    assert_eq!(layout.pages.len(), 2);
+    let (node, line) = lines(&layout.tree.root)[1];
+    assert!(ruby_top(node, line) < layout.pages[1].y_start);
+    for (i, page) in layout.pages.iter().enumerate() {
+        let fragment = crate::page_fragment::build_page_fragment_tree(&layout.tree, i, page);
+        assert!(
+            contains_ruby(fragment.root.as_ref().unwrap()),
+            "missing ruby on rendering page {i}"
+        );
+    }
+}

--- a/crates/editor-view/src/query/layout_index.rs
+++ b/crates/editor-view/src/query/layout_index.rs
@@ -8,7 +8,9 @@ use smallvec::SmallVec;
 use std::sync::{Arc, OnceLock};
 
 use crate::page::{LayoutPage, PageRect};
+use crate::paginate::paginator::{box_content_top, content_bottom};
 use crate::paginate::types::{LayoutContent, LayoutLine, LayoutNode, LayoutTree, SpacingKind};
+use crate::style::Direction;
 
 type LayoutEntryId = usize;
 
@@ -42,6 +44,8 @@ impl std::ops::Deref for LayoutIndex {
 #[derive(Debug, Clone)]
 pub(crate) struct LayoutEntry {
     pub(crate) rect: Rect,
+    /// Unchanged geometry keeps this prefix value valid across content splices.
+    pub(crate) previous_content_bottom: f32,
     path: SmallVec<[usize; 8]>,
     ancestors: SmallVec<[Dot; 4]>,
 }
@@ -88,7 +92,7 @@ impl LayoutIndex {
             spatial: Vec::new(),
             entries_by_page: vec![Vec::new(); pages.len()],
         };
-        builder.build_node(&tree.root);
+        builder.build_node(&tree.root, f32::NEG_INFINITY);
         Self {
             tree,
             data: Arc::new(LayoutIndexData {
@@ -112,8 +116,8 @@ impl LayoutIndex {
     /// Reuse every derived structure (entries, node maps, per-page lists,
     /// spatial entries — even a built R-tree) under a new `LayoutTree` whose
     /// geometry is byte-identical to the old one. Sound only when the caller
-    /// has verified geometry equality; all index data derives from rects,
-    /// node ids and traversal structure, never from line content.
+    /// has verified geometry equality; index data derives from base text metrics,
+    /// box geometry, node ids and traversal structure, never from glyph content.
     pub(crate) fn rebind_tree(mut self, tree: LayoutTree) -> Self {
         self.tree = tree;
         self
@@ -125,8 +129,8 @@ impl LayoutIndex {
     }
 
     /// Whether `new_tree` is geometry-identical to the current tree at
-    /// `block`'s subtree — same rects, ids, structure and attachment; line
-    /// content is deliberately ignored (the index never derives from it).
+    /// `block`'s subtree — same base text metrics, box geometry, ids, structure and
+    /// attachment. Glyph content and ruby annotations do not affect the index.
     pub(crate) fn subtree_geometry_matches(&self, new_tree: &LayoutTree, block: &Dot) -> bool {
         let Some(&entry_id) = self.boxes_by_node_id.get(block) else {
             return false;
@@ -539,10 +543,10 @@ impl LayoutEntry {
 }
 
 impl LayoutIndexBuilder<'_> {
-    fn build_node(&mut self, node: &LayoutNode) {
+    fn build_node(&mut self, node: &LayoutNode, previous_content_bottom: f32) {
         match &node.content {
             LayoutContent::Box(b) => {
-                let id = self.add_entry(node.rect);
+                let id = self.add_entry(node.rect, previous_content_bottom);
                 self.boxes_by_node_id.insert(b.node, id);
                 if b.scope {
                     self.scope_by_node.insert(b.node, id);
@@ -551,26 +555,35 @@ impl LayoutIndexBuilder<'_> {
                     self.register_match_node(attachment.parent, id);
                 }
                 self.ancestors.push(b.node);
+                let mut previous_content_bottom = box_content_top(&b.style, b.scope, node.rect.y)
+                    .map_or(previous_content_bottom, |top| {
+                        previous_content_bottom.max(top)
+                    });
                 for (idx, child) in b.children.iter().enumerate() {
                     self.path.push(idx);
-                    self.build_node(child);
+                    self.build_node(child, previous_content_bottom);
                     self.path.pop();
+                    if b.style.direction == Direction::Vertical
+                        && let Some(bottom) = content_bottom(child)
+                    {
+                        previous_content_bottom = previous_content_bottom.max(bottom);
+                    }
                 }
                 self.ancestors.pop();
             }
             LayoutContent::Spacing(SpacingKind::Gap { .. }) => {
                 if !self.ancestors.is_empty() {
-                    self.add_entry(node.rect);
+                    self.add_entry(node.rect, previous_content_bottom);
                 }
             }
             LayoutContent::Line(line) if line.is_phantom => {}
             LayoutContent::Spacing(_) => {}
             LayoutContent::Line(line) => {
-                let id = self.add_entry(node.rect);
+                let id = self.add_entry(node.rect, previous_content_bottom);
                 self.register_match_node(line.node, id);
             }
             LayoutContent::Atom(atom) => {
-                let id = self.add_entry(node.rect);
+                let id = self.add_entry(node.rect, previous_content_bottom);
                 self.atoms_by_node_id.insert(atom.node, id);
                 self.register_match_node(atom.attachment.parent, id);
             }
@@ -584,10 +597,11 @@ impl LayoutIndexBuilder<'_> {
         }
     }
 
-    fn add_entry(&mut self, rect: Rect) -> LayoutEntryId {
+    fn add_entry(&mut self, rect: Rect, previous_content_bottom: f32) -> LayoutEntryId {
         let entry_id = self.entries.len();
         self.entries.push(LayoutEntry {
             rect,
+            previous_content_bottom,
             path: SmallVec::from_slice(&self.path),
             ancestors: SmallVec::from_slice(&self.ancestors),
         });
@@ -630,6 +644,10 @@ pub(crate) fn node_geometry_eq(a: &LayoutNode, b: &LayoutNode) -> bool {
             x.node == y.node
                 && x.attachment == y.attachment
                 && x.scope == y.scope
+                && x.style.direction == y.style.direction
+                && x.style.padding == y.style.padding
+                && x.style.border == y.style.border
+                && x.style.monolithic == y.style.monolithic
                 && x.children.len() == y.children.len()
                 && x.children
                     .iter()
@@ -637,7 +655,11 @@ pub(crate) fn node_geometry_eq(a: &LayoutNode, b: &LayoutNode) -> bool {
                     .all(|(c, d)| node_geometry_eq(c, d))
         }
         (LayoutContent::Line(x), LayoutContent::Line(y)) => {
-            x.node == y.node && x.is_phantom == y.is_phantom
+            x.node == y.node
+                && x.is_phantom == y.is_phantom
+                && x.baseline == y.baseline
+                && x.ascent == y.ascent
+                && x.descent == y.descent
         }
         (LayoutContent::Atom(x), LayoutContent::Atom(y)) => {
             x.node == y.node && x.attachment == y.attachment

--- a/crates/editor-view/src/query/paragraph_break.rs
+++ b/crates/editor-view/src/query/paragraph_break.rs
@@ -12,7 +12,6 @@ use editor_state::{
     paragraph_break_at_end, paragraph_break_ending_at,
 };
 
-use crate::measure::text::ruby::ruby_extra_top;
 use crate::page::{LayoutPage, PageRect};
 use crate::paginate::types::{LayoutContent, LayoutLine, SpacingKind};
 
@@ -181,18 +180,12 @@ fn geometry_for_line_entry(
     let pos = paragraph_break_range.anchor;
     let page_idx = page_for_y(pages, entry.rect.y)?;
     let x = entry.rect.x + super::grapheme::x_at_offset(line, &pos);
-    let band = ruby_extra_top(line.baseline, line.ascent, &line.ruby_annotations);
-    let height = (entry.rect.height - band).max(0.0);
+    let height = entry.rect.height;
     let width = height * 0.15;
     Some(ParagraphBreakGeometry {
         rect: PageRect::new(
             page_idx,
-            Rect::from_xywh(
-                x,
-                entry.rect.y + band - pages[page_idx].y_start,
-                width,
-                height,
-            ),
+            Rect::from_xywh(x, entry.rect.y - pages[page_idx].y_start, width, height),
         ),
         line_right: entry.rect.right(),
     })

--- a/crates/editor-view/src/query/selection.rs
+++ b/crates/editor-view/src/query/selection.rs
@@ -388,13 +388,12 @@ fn line_endpoint(
     pos: &Position,
 ) -> Option<PageRect> {
     let page_rect = layout_index.page_rect(entry.rect)?;
-    let band = ruby_band(line);
-    let height = (entry.rect.height - band).max(0.0);
+    let height = entry.rect.height;
     Some(PageRect::new(
         page_rect.page_idx,
         Rect::from_xywh(
             entry.rect.x + grapheme::x_at_offset(line, pos),
-            page_rect.rect.y + band,
+            page_rect.rect.y,
             0.0,
             height,
         ),
@@ -645,12 +644,8 @@ fn strut_line_has_selectable_child_range(line: &LayoutLine) -> bool {
             .is_some_and(|range| range.start < range.end)
 }
 
-fn ruby_band(line: &LayoutLine) -> f32 {
-    crate::measure::text::ruby::ruby_extra_top(line.baseline, line.ascent, &line.ruby_annotations)
-}
-
 fn text_area_height(line: &LayoutLine) -> f32 {
-    let height = (line.ascent + line.descent - ruby_band(line)).max(0.0);
+    let height = (line.ascent + line.descent).max(0.0);
     if height > 0.0 {
         height
     } else if !line.glyph_runs.is_empty() {
@@ -745,10 +740,9 @@ fn visit_line(
     };
 
     if let Some(page_idx) = page_for_y(pages, node.rect.y) {
-        let band = ruby_band(line);
-        let box_height = (node.rect.height - band).max(0.0);
+        let box_height = node.rect.height;
         let x = node.rect.x + x_start;
-        let box_top = node.rect.y + band - pages[page_idx].y_start;
+        let box_top = node.rect.y - pages[page_idx].y_start;
         let line_box = PageRect::with_meta(
             page_idx,
             Rect::from_xywh(x, box_top, width, box_height),
@@ -1406,7 +1400,11 @@ mod tests {
         let view = DocView::new(&pd);
         let (entry, line) = first_line_for_para(&index, &first_para).unwrap();
         assert!(!line.ruby_annotations.is_empty());
-        assert!(entry.rect.height > plain_break.height);
+        assert_close(
+            entry.rect.height,
+            plain_break.height,
+            "ruby preserves base line height",
+        );
 
         let text = Selection::new(Position::new(first_para, 0), Position::new(first_para, 3));
         let text_rect = selection_rects(&index, &text.resolve(&view).unwrap())[0].rect;

--- a/crates/editor-view/src/view.rs
+++ b/crates/editor-view/src/view.rs
@@ -242,6 +242,7 @@ impl View {
             content_width: f32,
             page_top: f32,
             page_bottom: f32,
+            previous_content_bottom: f32,
         }
 
         let mut seeds: Vec<SpliceSeed> = Vec::new();
@@ -254,9 +255,10 @@ impl View {
                 if seeds.iter().any(|s| s.dot == *dot) {
                     continue;
                 }
-                let Some(path) = index.box_path(dot) else {
+                let Some(entry) = index.box_entry(dot) else {
                     return false;
                 };
+                let path = entry.path();
                 // Rebuild the paginator's (current_x, current_width) context by
                 // replaying each vertical ancestor's content-box computation
                 // from its retained rect and style.
@@ -321,6 +323,11 @@ impl View {
                     content_width: w,
                     page_top,
                     page_bottom,
+                    previous_content_bottom: entry.previous_content_bottom.max(if continuous {
+                        0.0
+                    } else {
+                        page.y_start
+                    }),
                 });
             }
         }
@@ -346,6 +353,7 @@ impl View {
                 seed.parent,
                 seed.child_index,
                 seed.y,
+                seed.previous_content_bottom,
                 seed.x,
                 seed.content_width,
                 seed.page_top,
@@ -1880,6 +1888,74 @@ mod incremental_tests {
             .iter()
             .map(|p| (p.y_start, p.y_end, p.content_y_start, p.content_y_end))
             .collect()
+    }
+
+    #[test]
+    fn reconcile_ruby_content_edit_matches_full_layout() {
+        use editor_model::{Anchor, Bias, Modifier, ModifierAttrOp, SpanOp};
+
+        let mut g = OpGraph::<EditOp>::with_actor(1);
+        g.add_mut(seq_block(0, NodeType::Paragraph, vec![Dot::ROOT]))
+            .unwrap();
+        g.add_mut(seq_char(1, 'a')).unwrap();
+        let paragraph = g
+            .add_mut(seq_block(2, NodeType::Paragraph, vec![Dot::ROOT]))
+            .unwrap()
+            .id;
+        let base_char = g.add_mut(seq_char(3, 'b')).unwrap().id;
+        g.add_mut(EditOp::Span(SpanOp::AddSpan {
+            start: Anchor {
+                id: base_char,
+                bias: Bias::Before,
+            },
+            end: Anchor {
+                id: base_char,
+                bias: Bias::After,
+            },
+            modifier: Modifier::Ruby {
+                text: "annotation".into(),
+            },
+        }))
+        .unwrap();
+        for modifier in [
+            Modifier::LineHeight { value: 100 },
+            Modifier::BlockGap { value: 0 },
+        ] {
+            g.add_mut(EditOp::BlockModifier(ModifierAttrOp::SetModifier {
+                target: Dot::ROOT,
+                modifier,
+            }))
+            .unwrap();
+        }
+        g.commit_mut();
+        let mut projected = ProjectedState::from_graph(g).unwrap();
+        let pre = State::new(projected.clone(), None);
+        let mut view = make_view(800.0);
+        view.layout(&pre);
+        view.hit_test(0, 45.0, 50.0);
+        projected.take_layout_dirty();
+        projected.apply(seq_char(4, 'c')).unwrap();
+        let dirty = projected.take_layout_dirty();
+        let post = State::new(projected, None);
+        view.reconcile(&post, dirty, None, None);
+        assert!(
+            view.layout.as_ref().unwrap().layout_index.rtree_built(),
+            "unchanged base geometry must keep the index during a content splice"
+        );
+
+        let mut fresh = make_view(800.0);
+        fresh.layout(&post);
+        assert_eq!(
+            view.node_box_rects(&[paragraph]),
+            fresh.node_box_rects(&[paragraph])
+        );
+        assert_eq!(page_sig(&view), page_sig(&fresh));
+        for y in 0..100 {
+            assert_eq!(
+                view.hit_test(0, 45.0, y as f32),
+                fresh.hit_test(0, 45.0, y as f32)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
루비를 배치할 공간이 충분해도 줄 간격이 늘어나던 문제를 수정합니다.

기존에는 줄을 측정할 때 `ruby_extra_top`만큼 높이를 늘렸기 때문에, 이전 줄이나 페이지 여백의 빈 공간을 활용하지 못했습니다. 이제 본문 기준의 줄 높이를 유지하고, 실제 배치 단계에서 공간이 부족할 때만 줄을 아래로 이동합니다.

- 줄 간격·문단 간격·페이지 여백·박스 내부 여백을 먼저 활용하고, 부족한 간격만 추가합니다.
- 루비와 앞선 콘텐츠, 물리적 페이지 상단 사이에 최소 2px를 확보합니다.
- 선택 영역·본문 배경·문단 끝 표시에서 루비 높이를 빼던 보정은 제거합니다. 본문 기준의 크기와 hit test 동작은 유지합니다.
- 부분 갱신에 필요한 앞선 콘텐츠의 하단 위치를 저장해, 입력할 때 이전 문단들을 다시 탐색하지 않도록 합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>