### PR TITLE
에디터 DnD 인디케이터 지연 개선

### DIFF
--- a/apps/website/src/lib/editor-ffi/handlers/dnd.test.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/dnd.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleDragEnd, handleDragEnter, handleDragLeave, handleDragOver, handleDragStart, handleDrop } from './dnd';
 import type { Message } from '@typie/editor-ffi/browser';
 import type { AttachmentImportItem } from '../attachment-importer';
@@ -97,7 +97,7 @@ const createCtx = ({ readOnly = false, protectContent = false } = {}) => {
     readOnly,
     protectContent,
     isSelectionCollapsed: false,
-    clientToLocal: vi.fn(() => ({ page: 0, x: 10, y: 20 })),
+    clientToLocal: vi.fn<(x: number, y: number) => { page: number; x: number; y: number }>(() => ({ page: 0, x: 10, y: 20 })),
     selectionHitTest: vi.fn(() => true),
     copySelection: vi.fn(() => ({ text: 'Hello', html: '<p>Hello</p>' })),
     endNativeDragAdmission: vi.fn(),
@@ -151,12 +151,15 @@ const targetAtPoint = (root: HTMLElement, nodeId: string): HTMLElement => {
 };
 
 beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame'] });
   edgeAutoScroll.onScroll = null;
   Object.defineProperty(document, 'elementFromPoint', {
     configurable: true,
     value: vi.fn(() => null),
   });
 });
+
+afterEach(() => vi.useRealTimers());
 
 describe('handleDragStart', () => {
   it('starts internal selection drag and exposes html/plain data for external drops', () => {
@@ -282,12 +285,81 @@ describe('handleDragEnter', () => {
 });
 
 describe('handleDragOver', () => {
+  it('accepts native drag events immediately and applies only the latest point each frame', () => {
+    const { ctx, editor, messages } = createCtx();
+    editor.clientToLocal.mockImplementation((x: number, y: number) => ({ page: 0, x, y }));
+    const transfer = createDataTransfer({ types: ['text/plain'] });
+    const first = createDragEvent(transfer);
+    const last = { ...createDragEvent(transfer), clientX: 180, clientY: 260, altKey: true };
+
+    handleDragOver(ctx, first);
+    handleDragOver(ctx, last);
+
+    expect(first.preventDefault).toHaveBeenCalled();
+    expect(last.preventDefault).toHaveBeenCalled();
+    expect(transfer.dropEffect).toBe('copy');
+    expect(messages).toEqual([]);
+
+    vi.advanceTimersToNextFrame();
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        op: expect.objectContaining({ type: 'over', x: 180, y: 260, modifiers: expect.objectContaining({ alt: true }) }),
+      }),
+    ]);
+  });
+
+  it.each(['leave', 'end', 'drop'] as const)('does not apply a queued hover after %s', (end) => {
+    const { ctx, messages } = createCtx();
+    const transfer = createDataTransfer({ types: ['text/plain'], data: { 'text/plain': 'hello' } });
+    const event = createDragEvent(transfer);
+    handleDragOver(ctx, event);
+
+    if (end === 'leave') handleDragLeave(ctx, event);
+    else if (end === 'end') handleDragEnd(ctx);
+    else handleDrop(ctx, event, vi.fn());
+    const completed = [...messages];
+    vi.advanceTimersToNextFrame();
+
+    expect(messages).toEqual(completed);
+    expect(messages.at(-1)).toEqual(expect.objectContaining({ op: expect.objectContaining({ type: end }) }));
+  });
+
+  it('uses the drop coordinates immediately even before the queued hover frame', () => {
+    const { ctx, editor, messages } = createCtx();
+    editor.clientToLocal.mockImplementation((x, y) => ({ page: 0, x, y }));
+    const transfer = createDataTransfer({ types: ['text/plain'], data: { 'text/plain': 'hello' } });
+    handleDragOver(ctx, createDragEvent(transfer));
+
+    handleDrop(ctx, { ...createDragEvent(transfer), clientX: 190, clientY: 280 }, vi.fn());
+    vi.advanceTimersToNextFrame();
+
+    expect(messages).toEqual([
+      expect.objectContaining({ op: expect.objectContaining({ type: 'over', x: 190, y: 280 }) }),
+      expect.objectContaining({ op: expect.objectContaining({ type: 'drop', x: 190, y: 280 }) }),
+    ]);
+  });
+
+  it('retains attachment kinds after the native event data store becomes unavailable', () => {
+    const { ctx, attachmentState, extensionAreaEl, canReusePlaceholder } = createCtx();
+    targetAtPoint(extensionAreaEl, 'image-node');
+    canReusePlaceholder.mockImplementation((nodeId, kind) => nodeId === 'image-node' && kind === 'image');
+    const transfer = createDataTransfer({ items: [{ kind: 'file', type: 'image/png' }] });
+
+    handleDragOver(ctx, createDragEvent(transfer, extensionAreaEl));
+    Object.defineProperty(transfer, 'items', { value: [] });
+    vi.advanceTimersToNextFrame();
+
+    expect(attachmentState.attachmentDropTargetNodeId).toBe('image-node');
+  });
+
   it('prevents default when a transferable payload has editor-local coordinates', () => {
     const { ctx, messages, updateNow } = createCtx();
     const dataTransfer = createDataTransfer({ files: [createFile('image.png', 'image/png')] });
     const event = createDragEvent(dataTransfer);
 
     handleDragOver(ctx, event);
+    vi.advanceTimersToNextFrame();
 
     expect(messages).toEqual([
       {
@@ -313,6 +385,7 @@ describe('handleDragOver', () => {
     const event = createDragEvent(dataTransfer);
 
     handleDragOver(ctx, event);
+    vi.advanceTimersToNextFrame();
 
     expect(messages).toEqual([
       {
@@ -339,6 +412,7 @@ describe('handleDragOver', () => {
     const event = createDragEvent(dataTransfer);
 
     handleDragOver(ctx, event);
+    vi.advanceTimersToNextFrame();
 
     expect(messages).toEqual([
       {
@@ -368,6 +442,7 @@ describe('handleDragOver', () => {
     const event = createDragEvent(dataTransfer);
 
     handleDragOver(ctx, event);
+    vi.advanceTimersToNextFrame();
 
     expect(messages).toEqual([]);
     expect(updateNow).not.toHaveBeenCalled();
@@ -396,9 +471,11 @@ describe('handleDragOver', () => {
     const event = createDragEvent(createDataTransfer({ files: [createFile('image.png', 'image/png')] }), extensionAreaEl);
 
     handleDragOver(ctx, event);
+    vi.advanceTimersToNextFrame();
     expect(attachmentState.attachmentDropTargetNodeId).toBe('first-node');
 
     edgeAutoScroll.onScroll?.(150, 230);
+    vi.advanceTimersToNextFrame();
 
     expect(editor.clientToLocal).toHaveBeenLastCalledWith(150, 230);
     expect(document.elementFromPoint).toHaveBeenLastCalledWith(150, 230);
@@ -445,6 +522,7 @@ describe('external attachment target', () => {
     const dataTransfer = createDataTransfer({ files: [png] });
 
     handleDragOver(ctx, createDragEvent(dataTransfer, extensionAreaEl));
+    vi.advanceTimersToNextFrame();
 
     expect(attachmentState.attachmentDropTargetNodeId).toBe('image-node');
     expect(messages).toEqual([
@@ -476,6 +554,7 @@ describe('external attachment target', () => {
     const dataTransfer = createDataTransfer({ files: [png, pdf] });
 
     handleDragOver(ctx, createDragEvent(dataTransfer, extensionAreaEl));
+    vi.advanceTimersToNextFrame();
     handleDrop(ctx, createDragEvent(dataTransfer, extensionAreaEl), vi.fn());
 
     expect(importAtDrop).toHaveBeenCalledWith(
@@ -496,6 +575,7 @@ describe('external attachment target', () => {
     const dataTransfer = createDataTransfer({ files: [png, pdf] });
 
     handleDragOver(ctx, createDragEvent(dataTransfer, extensionAreaEl));
+    vi.advanceTimersToNextFrame();
 
     expect(attachmentState.attachmentDropTargetNodeId).toBeNull();
     expect(messages.at(-1)).toEqual({
@@ -528,6 +608,7 @@ describe('external attachment target', () => {
     canReusePlaceholder.mockReturnValue(true);
 
     handleDragOver(ctx, createDragEvent(createDataTransfer({ files: [createFile('image.png', 'image/png')] }), extensionAreaEl));
+    vi.advanceTimersToNextFrame();
 
     expect(attachmentState.attachmentDropTargetNodeId).toBeNull();
     expect(canReusePlaceholder).not.toHaveBeenCalled();
@@ -538,6 +619,7 @@ describe('external attachment target', () => {
 
     attachmentState.attachmentDropTargetNodeId = 'node';
     handleDragOver(ctx, createDragEvent(createDataTransfer(), extensionAreaEl));
+    vi.advanceTimersToNextFrame();
     expect(attachmentState.attachmentDropTargetNodeId).toBeNull();
 
     attachmentState.attachmentDropTargetNodeId = 'node';

--- a/apps/website/src/lib/editor-ffi/handlers/dnd.ts
+++ b/apps/website/src/lib/editor-ffi/handlers/dnd.ts
@@ -11,6 +11,21 @@ type EditorInstance = NonNullable<EditorContext['editor']>;
 
 const internalDndEditors = new WeakSet<EditorInstance>();
 const dndEdgeAutoScrolls = new WeakMap<EditorInstance, EditorEdgeAutoScroll>();
+const dndOverFrames = new WeakMap<EditorInstance, { id: number; update: () => void }>();
+
+const scheduleDndOver = (editor: EditorInstance, update: () => void): void => {
+  const pending = dndOverFrames.get(editor);
+  if (pending) {
+    pending.update = update;
+    return;
+  }
+  const frame = { id: 0, update };
+  frame.id = requestAnimationFrame(() => {
+    dndOverFrames.delete(editor);
+    frame.update();
+  });
+  dndOverFrames.set(editor, frame);
+};
 
 let EMPTY_DRAG_IMAGE: HTMLImageElement | null = null;
 const setEmptyDragImage = (dataTransfer: DataTransfer): void => {
@@ -33,7 +48,12 @@ const edgeAutoScrollFor = (editor: EditorInstance): EditorEdgeAutoScroll => {
   return edgeAutoScroll;
 };
 
-const stopDndEdgeAutoScroll = (editor: EditorInstance): void => {
+const stopDndHover = (editor: EditorInstance): void => {
+  const pending = dndOverFrames.get(editor);
+  if (pending) {
+    cancelAnimationFrame(pending.id);
+    dndOverFrames.delete(editor);
+  }
   dndEdgeAutoScrolls.get(editor)?.stop();
 };
 
@@ -146,13 +166,8 @@ const updateAttachmentDropTarget = (
   root: EventTarget | null,
   clientX: number,
   clientY: number,
-  dataTransfer: DataTransfer,
+  kinds: readonly AttachmentImportItem['kind'][] | undefined,
 ): string | null => {
-  if (hasInternalSelectionDrag(editor, dataTransfer)) {
-    setAttachmentDropTarget(ctx, null);
-    return null;
-  }
-  const kinds = hoverAttachmentKinds(dataTransfer);
   const nodeId = kinds ? (reusableAttachmentNode(ctx, editor, root, clientX, clientY, kinds)?.nodeId ?? null) : null;
   setAttachmentDropTarget(ctx, nodeId);
   return nodeId;
@@ -178,7 +193,7 @@ const dispatchDndOverAtClient = (
   ctx: EditorContext,
   editor: EditorInstance,
   root: EventTarget | null,
-  dataTransfer: DataTransfer,
+  kinds: readonly AttachmentImportItem['kind'][] | undefined,
   clientX: number,
   clientY: number,
   modifiers: InputModifiers,
@@ -186,7 +201,7 @@ const dispatchDndOverAtClient = (
   const local = editor.clientToLocal(clientX, clientY);
   if (!local) return false;
 
-  const reuseNodeId = updateAttachmentDropTarget(ctx, editor, root, clientX, clientY, dataTransfer);
+  const reuseNodeId = updateAttachmentDropTarget(ctx, editor, root, clientX, clientY, kinds);
   editor.updateNow(() => {
     editor.enqueue({
       type: 'dnd',
@@ -207,6 +222,7 @@ const dropEffectFromTransfer = (editor: EditorInstance, dataTransfer: DataTransf
 export const handleDragStart = (ctx: EditorContext, event: DragEvent) => {
   setAttachmentDropTarget(ctx, null);
   const editor = ctx.editor;
+  if (editor) stopDndHover(editor);
   const dataTransfer = event.dataTransfer;
   if (!editor || !dataTransfer || editor.isSelectionCollapsed) {
     event.preventDefault();
@@ -291,7 +307,7 @@ export const handleDragOver = (ctx: EditorContext, event: DragEvent) => {
   const root = event.currentTarget;
   if (!editor || !dataTransfer || editor.readOnly) {
     setAttachmentDropTarget(ctx, null);
-    if (editor) stopDndEdgeAutoScroll(editor);
+    if (editor) stopDndHover(editor);
     return;
   }
 
@@ -299,42 +315,37 @@ export const handleDragOver = (ctx: EditorContext, event: DragEvent) => {
   if (!local || !hasTransferablePayload(editor, dataTransfer)) {
     setDropEffect(dataTransfer, 'none');
     setAttachmentDropTarget(ctx, null);
-    stopDndEdgeAutoScroll(editor);
+    stopDndHover(editor);
     return;
   }
 
   const modifiers = modifiersFromEvent(event);
-  const reuseNodeId = updateAttachmentDropTarget(ctx, editor, root, event.clientX, event.clientY, dataTransfer);
-  editor.updateNow(() => {
-    editor.enqueue({
-      type: 'dnd',
-      op: { type: 'over', page: local.page, x: local.x, y: local.y, reuse_node_id: reuseNodeId ?? undefined, modifiers },
+  // DataTransfer is only readable during the native event. Retain its kinds,
+  // then resolve the latest pointer against the layout at the next frame.
+  const kinds = hasInternalSelectionDrag(editor, dataTransfer) ? undefined : hoverAttachmentKinds(dataTransfer);
+  const updateAtClient = (clientX: number, clientY: number) => {
+    scheduleDndOver(editor, () => {
+      if (ctx.editor !== editor || editor.destroyed || editor.readOnly) {
+        setAttachmentDropTarget(ctx, null);
+        stopDndHover(editor);
+        return;
+      }
+      if (!dispatchDndOverAtClient(ctx, editor, root, kinds, clientX, clientY, modifiers)) {
+        setAttachmentDropTarget(ctx, null);
+      }
     });
-  });
-  if (ctx.editor !== editor || editor.destroyed || editor.readOnly) {
-    setAttachmentDropTarget(ctx, null);
-    stopDndEdgeAutoScroll(editor);
-    return;
-  }
+  };
   event.preventDefault();
   setDropEffect(dataTransfer, dropEffectFromTransfer(editor, dataTransfer, modifiers));
-  edgeAutoScrollFor(editor).update(editor, { clientX: event.clientX, clientY: event.clientY }, (clientX, clientY) => {
-    if (ctx.editor !== editor || editor.destroyed || editor.readOnly) {
-      setAttachmentDropTarget(ctx, null);
-      stopDndEdgeAutoScroll(editor);
-      return;
-    }
-
-    if (!dispatchDndOverAtClient(ctx, editor, root, dataTransfer, clientX, clientY, modifiers)) {
-      setAttachmentDropTarget(ctx, null);
-    }
-  });
+  updateAtClient(event.clientX, event.clientY);
+  edgeAutoScrollFor(editor).update(editor, { clientX: event.clientX, clientY: event.clientY }, updateAtClient);
 };
 
 export const handleDragLeave = (ctx: EditorContext, event: DragEvent) => {
   const editor = ctx.editor;
   if (!editor || editor.readOnly) {
     setAttachmentDropTarget(ctx, null);
+    if (editor) stopDndHover(editor);
     return;
   }
 
@@ -346,7 +357,7 @@ export const handleDragLeave = (ctx: EditorContext, event: DragEvent) => {
 
   setAttachmentDropTarget(ctx, null);
   editor.updateNow(() => editor.enqueue({ type: 'dnd', op: { type: 'leave' } }));
-  stopDndEdgeAutoScroll(editor);
+  stopDndHover(editor);
 };
 
 export const handleDrop = (ctx: EditorContext, event: DragEvent, onFailure: AttachmentImportFailureHandler) => {
@@ -356,7 +367,7 @@ export const handleDrop = (ctx: EditorContext, event: DragEvent, onFailure: Atta
     setAttachmentDropTarget(ctx, null);
     return;
   }
-  stopDndEdgeAutoScroll(editor);
+  stopDndHover(editor);
   if (!dataTransfer || editor.readOnly) {
     setAttachmentDropTarget(ctx, null);
     return;
@@ -442,7 +453,7 @@ export const handleDragEnd = (ctx: EditorContext) => {
   const editor = ctx.editor;
   if (!editor) return;
   internalDndEditors.delete(editor);
-  stopDndEdgeAutoScroll(editor);
+  stopDndHover(editor);
   editor.gesture.handleNativeDragEnd();
   editor.endNativeDragAdmission({ restoreFocus: false });
   editor.updateNow(() => editor.enqueue({ type: 'dnd', op: { type: 'end' } }));

--- a/crates/editor-core/src/tests/perf_dnd_over.rs
+++ b/crates/editor-core/src/tests/perf_dnd_over.rs
@@ -1,5 +1,5 @@
-//! Temporary perf probe for internal-selection DnD `Over` judgment across
-//! block-spanning selections.
+//! Perf probes for external-image DnD hit testing and internal-selection
+//! `Over` judgment across block-spanning selections.
 //! Run: cargo test -p editor-core --profile profiling perf_dnd_over -- --ignored --nocapture
 //! Profile: cargo test -p editor-core --profile profiling perf_dnd_over --no-run
 //!          samply record <target/profiling/deps/editor_core-*> perf_dnd_over_profile_target --ignored --nocapture
@@ -137,6 +137,68 @@ fn median(vals: &mut [Duration]) -> Duration {
 }
 
 type Scenario = (&'static str, (usize, usize), (usize, usize));
+
+#[test]
+#[ignore]
+fn perf_dnd_over_external_image() {
+    for n in [100, 1000, 5000] {
+        let fixture = build_fixture(n, 8);
+        let mut editor = Editor::new_test(fixture.state.clone());
+        editor.apply(Message::System {
+            event: SystemEvent::Initialize,
+        });
+        editor.apply(Message::Dnd {
+            op: DndOp::EnterExternal {
+                payload: ExternalDndPayloadKind::ImageFiles,
+            },
+        });
+        let points = [
+            over_point(&editor, fixture.paras[n / 2]),
+            over_point(&editor, fixture.paras[n / 2 + 1]),
+        ];
+        let mut hit = Vec::new();
+        let mut judgment = Vec::new();
+        let mut over = Vec::new();
+        for round in 0..30 {
+            let (page, x, y) = points[round % points.len()];
+            let start = Instant::now();
+            std::hint::black_box(editor.view().drop_target_at(page, x, y));
+            hit.push(start.elapsed());
+            let start = Instant::now();
+            assert!(crate::handle::judge_apply_drop(
+                editor.state(),
+                &editor.resource.lock().unwrap(),
+                Position::new(fixture.paras[n / 2 + round % points.len()], 0),
+                &DndDropPayload::Files {
+                    request_id: String::new(),
+                    kinds: vec![AttachmentPlaceholderKind::Image],
+                    reuse_node_id: None,
+                },
+                InputModifiers::default(),
+                None,
+            ));
+            judgment.push(start.elapsed());
+            let start = Instant::now();
+            editor.apply(Message::Dnd {
+                op: DndOp::Over {
+                    page,
+                    x,
+                    y,
+                    reuse_node_id: None,
+                    modifiers: InputModifiers::default(),
+                },
+            });
+            over.push(start.elapsed());
+            assert!(editor.drop_indicator_for_test().is_some());
+        }
+        eprintln!(
+            "[external image n={n}] hit={:?} judgment={:?} over={:?}",
+            median(&mut hit),
+            median(&mut judgment),
+            median(&mut over)
+        );
+    }
+}
 
 fn scenarios(len: usize) -> Vec<Scenario> {
     vec![

--- a/crates/editor-view/src/paginate/paginator.rs
+++ b/crates/editor-view/src/paginate/paginator.rs
@@ -225,7 +225,10 @@ impl Paginator {
         let terminal_child_index = terminal_child_index(measured);
 
         for (raw_child_index, child) in measured.children.iter().enumerate() {
-            let is_doc_child = !matches!(child.content, MeasuredContent::Spacing(_));
+            let is_doc_child = matches!(
+                child.content,
+                MeasuredContent::Box(_) | MeasuredContent::Atom(_) | MeasuredContent::PageBreak
+            );
 
             // 1. Gap absorption at page start (paginated only)
             if self.is_paginated()

--- a/crates/editor-view/src/paginate/placement.rs
+++ b/crates/editor-view/src/paginate/placement.rs
@@ -120,7 +120,10 @@ pub(super) fn place_node_at(
                     idx,
                     previous_content_bottom,
                 );
-                if !matches!(child.content, MeasuredContent::Spacing(_)) {
+                if matches!(
+                    child.content,
+                    MeasuredContent::Box(_) | MeasuredContent::Atom(_) | MeasuredContent::PageBreak
+                ) {
                     idx += 1;
                 }
                 if b.style.direction == Direction::Horizontal {

--- a/crates/editor-view/src/query/dnd.rs
+++ b/crates/editor-view/src/query/dnd.rs
@@ -34,14 +34,14 @@ fn dnd_position(
             layout_index.entry_is_in_scope(entry, scope) && !std::ptr::eq(entry, scope)
         };
         let in_scope = |entry: &LayoutEntry| layout_index.entry_is_in_scope(entry, scope);
-        exact_dnd_position(layout_index, view, point, &in_scope_descendant)
-            .or_else(|| exact_dnd_position(layout_index, view, point, &in_scope))
-            .or_else(|| closest_dnd_position(layout_index, view, point, &in_scope_descendant))
-            .or_else(|| closest_dnd_position(layout_index, view, point, &in_scope))
+        exact_dnd_position(layout_index, point, &in_scope_descendant)
+            .or_else(|| exact_dnd_position(layout_index, point, &in_scope))
+            .or_else(|| closest_dnd_position(layout_index, point, &in_scope_descendant))
+            .or_else(|| closest_dnd_position(layout_index, point, &in_scope))
     } else {
         let all_entries = |_: &LayoutEntry| true;
-        exact_dnd_position(layout_index, view, point, &all_entries)
-            .or_else(|| closest_dnd_position(layout_index, view, point, &all_entries))
+        exact_dnd_position(layout_index, point, &all_entries)
+            .or_else(|| closest_dnd_position(layout_index, point, &all_entries))
     }?;
 
     position.resolve(view).is_some().then_some(position)
@@ -49,7 +49,6 @@ fn dnd_position(
 
 fn exact_dnd_position(
     layout_index: &LayoutIndex,
-    view: &DocView,
     point: LayoutPoint,
     include: &impl Fn(&LayoutEntry) -> bool,
 ) -> Option<Position> {
@@ -58,14 +57,13 @@ fn exact_dnd_position(
             if !include(entry) {
                 return None;
             }
-            dnd_position_for_candidate(layout_index, view, entry, node, point)
+            dnd_position_for_candidate(layout_index, entry, node, point)
         })
         .map(|(_, position)| position)
 }
 
 fn closest_dnd_position(
     layout_index: &LayoutIndex,
-    view: &DocView,
     point: LayoutPoint,
     include: &impl Fn(&LayoutEntry) -> bool,
 ) -> Option<Position> {
@@ -74,20 +72,19 @@ fn closest_dnd_position(
             if !include(entry) {
                 return None;
             }
-            dnd_position_for_candidate(layout_index, view, entry, node, point)
+            dnd_position_for_candidate(layout_index, entry, node, point)
         })
         .map(|(_, position)| position)
 }
 
 fn dnd_position_for_candidate(
     layout_index: &LayoutIndex,
-    view: &DocView,
     entry: &LayoutEntry,
     node: &crate::paginate::types::LayoutNode,
     point: LayoutPoint,
 ) -> Option<Position> {
     is_dnd_entry(entry, node)
-        .then(|| dnd_position_for_entry(layout_index, view, entry, point))
+        .then(|| dnd_position_for_entry(layout_index, entry, point))
         .flatten()
 }
 
@@ -103,7 +100,6 @@ fn is_dnd_entry(_entry: &LayoutEntry, node: &crate::paginate::types::LayoutNode)
 
 fn dnd_position_for_entry(
     layout_index: &LayoutIndex,
-    view: &DocView,
     entry: &LayoutEntry,
     point: LayoutPoint,
 ) -> Option<Position> {
@@ -113,7 +109,7 @@ fn dnd_position_for_entry(
             atom.attachment.parent,
             atom.attachment.index + 1,
         )),
-        LayoutContent::Box(b) => box_edge_position(layout_index, view, b, point),
+        LayoutContent::Box(b) => box_edge_position(layout_index, b, point),
         LayoutContent::Spacing(SpacingKind::Gap { position }) => Some(*position),
         LayoutContent::Spacing(SpacingKind::Fill) => None,
     }
@@ -131,7 +127,6 @@ struct DropChild {
 
 fn box_edge_position(
     layout_index: &LayoutIndex,
-    view: &DocView,
     b: &crate::paginate::types::LayoutBox,
     point: LayoutPoint,
 ) -> Option<Position> {
@@ -143,7 +138,6 @@ fn box_edge_position(
     if point.y < page.content_y_start {
         let first = drop_children_in_y_range(
             layout_index,
-            view,
             &b.node,
             page.content_y_start,
             page.content_y_end,
@@ -155,7 +149,6 @@ fn box_edge_position(
     if point.y > page.content_y_end {
         let last = drop_children_in_y_range(
             layout_index,
-            view,
             &b.node,
             page.content_y_start,
             page.content_y_end,
@@ -165,7 +158,7 @@ fn box_edge_position(
         return Some(Position::new(b.node, last.offset + 1));
     }
 
-    let children = drop_children(layout_index, view, &b.node);
+    let children = drop_children(layout_index, &b.node);
     let first = children.first()?;
     if point.y < first.rect.y {
         return Some(Position::new(b.node, first.offset));
@@ -179,46 +172,35 @@ fn box_edge_position(
     None
 }
 
-fn drop_children(layout_index: &LayoutIndex, view: &DocView, parent: &Dot) -> Vec<DropChild> {
+fn drop_children(layout_index: &LayoutIndex, parent: &Dot) -> Vec<DropChild> {
     layout_index
         .direct_child_entries(parent)
-        .filter_map(|entry| drop_child(layout_index, view, parent, entry))
+        .filter_map(|entry| drop_child(layout_index, parent, entry))
         .collect()
 }
 
 fn drop_children_in_y_range(
     layout_index: &LayoutIndex,
-    view: &DocView,
     parent: &Dot,
     y_start: f32,
     y_end: f32,
 ) -> Vec<DropChild> {
     layout_index
         .direct_child_entries_in_y_range(parent, y_start, y_end)
-        .filter_map(|entry| drop_child(layout_index, view, parent, entry))
+        .filter_map(|entry| drop_child(layout_index, parent, entry))
         .collect()
 }
 
-fn drop_child(
-    layout_index: &LayoutIndex,
-    view: &DocView,
-    parent: &Dot,
-    entry: &LayoutEntry,
-) -> Option<DropChild> {
-    match entry.content(layout_index)? {
-        LayoutContent::Box(b) => {
-            let child_ref = view.node(b.node)?;
-            (child_ref.parent()?.id() == *parent).then(|| DropChild {
-                offset: child_ref.index().unwrap_or(0),
-                rect: entry.rect,
-            })
-        }
-        LayoutContent::Atom(atom) => (atom.attachment.parent == *parent).then_some(DropChild {
-            offset: atom.attachment.index,
-            rect: entry.rect,
-        }),
-        LayoutContent::Line(_) | LayoutContent::Spacing(_) => None,
-    }
+fn drop_child(layout_index: &LayoutIndex, parent: &Dot, entry: &LayoutEntry) -> Option<DropChild> {
+    let attachment = match entry.content(layout_index)? {
+        LayoutContent::Box(b) => b.attachment.as_ref()?,
+        LayoutContent::Atom(atom) => &atom.attachment,
+        LayoutContent::Line(_) | LayoutContent::Spacing(_) => return None,
+    };
+    (attachment.parent == *parent).then_some(DropChild {
+        offset: attachment.index,
+        rect: entry.rect,
+    })
 }
 
 fn promote_outer_edge_drop_position(
@@ -277,10 +259,7 @@ fn drop_indicator_from_position(
 
 fn block_drop_indicator(layout_index: &LayoutIndex, position: Position) -> Option<DropIndicator> {
     let node_rect = layout_index.box_rect(&position.node)?;
-    let children: Vec<_> = layout_index
-        .direct_child_entries(&position.node)
-        .filter(|entry| !matches!(entry.content(layout_index), Some(LayoutContent::Spacing(_))))
-        .collect();
+    let children = drop_children(layout_index, &position.node);
     let (x, width) = children
         .first()
         .map(|child| (child.rect.x, child.rect.width))
@@ -329,6 +308,7 @@ mod tests {
     use crate::paginate::paginator::Paginator;
     use crate::paginate::types::LayoutContent;
     use crate::query::grapheme;
+    use crate::view_state::GapPhantom;
 
     use super::*;
 
@@ -610,6 +590,94 @@ mod tests {
             "cell padding drop should be a block boundary, got {:?}",
             bottom_indicator
         );
+    }
+
+    #[test]
+    fn drop_after_gap_phantom_keeps_document_child_offset() {
+        for ancestors in [
+            vec![],
+            vec![NodeType::Table, NodeType::TableRow, NodeType::TableCell],
+        ] {
+            let mut parents = vec![Dot::ROOT];
+            let mut items = Vec::new();
+            for node_type in ancestors {
+                let id = Dot::new(19, parents.len() as u64);
+                items.push((
+                    id,
+                    SeqItem::Block {
+                        node_type,
+                        parents: parents.clone(),
+                        attrs: vec![],
+                    },
+                ));
+                parents.push(id);
+            }
+            let container = *parents.last().unwrap();
+            let Node::Image(image) = NodeType::Image.into_node() else {
+                unreachable!()
+            };
+            let paragraph = Dot::new(19, 11);
+            items.extend([
+                (
+                    Dot::new(19, 10),
+                    SeqItem::BlockAtom {
+                        leaf: AtomLeaf::Image { node: image },
+                        parents: parents.clone(),
+                    },
+                ),
+                (
+                    paragraph,
+                    SeqItem::Block {
+                        node_type: NodeType::Paragraph,
+                        parents,
+                        attrs: vec![],
+                    },
+                ),
+                (Dot::new(19, 12), SeqItem::Char('x')),
+            ]);
+            let pd = project_document(&logs(&items)).unwrap();
+            let view = DocView::new(&pd);
+            for paginator in [
+                Paginator::continuous(400.0, 100_000.0, EdgeInsets::ZERO),
+                Paginator::paginated(400.0, 800.0, EdgeInsets::ZERO),
+            ] {
+                let measured = measure_node(
+                    &mut crate::measure::Measurer::new(),
+                    &view.root().unwrap(),
+                    400.0,
+                    &MeasureContext {
+                        gap_phantom: Some(GapPhantom {
+                            parent: container,
+                            index: 0,
+                        }),
+                        ..Default::default()
+                    },
+                    &mut Resource::new_test(),
+                );
+                let layout = paginator.paginate(MeasuredTree { root: measured });
+                let index = LayoutIndex::new(layout.tree, &layout.pages);
+                let children = drop_children(&index, &container);
+                assert_eq!(
+                    children
+                        .iter()
+                        .map(|child| child.offset)
+                        .collect::<Vec<_>>(),
+                    vec![0, 1]
+                );
+                let image_rect = children[0].rect;
+                let paragraph_rect = index.box_rect(&paragraph).unwrap();
+                let x = paragraph_rect.x + paragraph_rect.width * 0.5;
+                let y = image_rect.y + image_rect.height * 0.5;
+                let (position, indicator) = drop_target_at(&index, &view, 0, x, y)
+                    .expect("dropping on the image must resolve to its following document slot");
+                assert_eq!(position, Position::new(container, 1));
+                let DropIndicator::Block { y: indicator_y, .. } = indicator else {
+                    panic!("expected a block indicator between the image and paragraph")
+                };
+                let expected_y = (image_rect.bottom() + paragraph_rect.y) * 0.5;
+                assert!((indicator_y - expected_y).abs() < 0.01);
+            }
+        }
     }
 
     fn two_para_gap_doc() -> DocLogs {


### PR DESCRIPTION
에디터 내부·외부에서 텍스트나 이미지를 드래그할 때 인디케이터가 커서를 늦게 따라오는 문제를 개선합니다.

- `dragover`마다 동기 갱신하던 처리를 최신 커서 위치만 보관하고 `requestAnimationFrame`에서 한 번 갱신하도록 변경합니다. 자동 스크롤도 같은 경로를 사용하며, 실제 드롭은 최종 좌표에서 즉시 처리하고 드롭·취소·영역 이탈 시 예약된 갱신을 해제합니다.
- Rust의 드롭 위치 탐색에서 각 자식의 부모와 순서를 `DocView`로 반복 조회하던 부분을 레이아웃의 기존 `ChildAttachment` 정보로 대체합니다. 탐색 함수들에 전달하던 불필요한 `DocView` 인자도 제거합니다.
- 두 레이아웃 배치 경로에서 블록 사이의 가상 커서 줄을 실제 문서 자식 수에서 제외합니다. 인디케이터 계산도 위치 탐색과 같은 `drop_children()` 결과를 사용하도록 통일해, 삽입 순서와 표시 위치가 어긋나는 문제를 수정합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>