### PR TITLE
tracked range 조회와 삭제된 anchor 탐색 최적화

### DIFF
--- a/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-frame-sync.browser.test.ts
@@ -1049,6 +1049,36 @@ describe('web editor frame synchronization', () => {
     expect(editor.publishedRevision).toBeGreaterThanOrEqual(restore.revision);
   });
 
+  it('publishes current tracked range geometry after reflow and removes deleted review anchors', async () => {
+    const { editor } = await mountEditor(continuousDoc('prefix target suffix'));
+    editor.updateNow((request) => request.enqueue({ type: 'selection', op: { type: 'set_flat', start: 8, end: 14 } }));
+    const selection = editor.appliedSnapshot.selection;
+    const frozen = selection && editor.freezeSelection(selection);
+    if (!frozen) throw new Error('Expected a frozen review selection');
+    editor.updateNow(() => editor.setPrismReviewRanges([{ id: 'review', selection: frozen, tone: 'issue' }]));
+    await waitForPresentation(editor);
+    const before = editor.published?.snapshot;
+    const original = before?.trackedRanges.find((range) => range.id === 'review');
+    expect(original?.text).toBe('target');
+
+    editor.updateNow((request) => {
+      request.enqueue({ type: 'selection', op: { type: 'set_flat', start: 1, end: 1 } });
+      request.enqueue({ type: 'insertion', op: { type: 'text', text: 'prefix '.repeat(30) } });
+    });
+    await waitForPresentation(editor);
+    const moved = editor.published?.snapshot.trackedRanges.find((range) => range.id === 'review');
+    expect(moved?.text).toBe('target');
+    expect(moved?.rects).not.toEqual(original?.rects);
+    expect(before?.trackedRanges.find((range) => range.id === 'review')).toEqual(original);
+
+    editor.updateNow((request) => {
+      request.enqueue({ type: 'selection', op: { type: 'set_frozen', selection: frozen } });
+      request.enqueue({ type: 'insertion', op: { type: 'text', text: '' } });
+    });
+    await waitForPresentation(editor);
+    expect(editor.published?.snapshot.trackedRanges.find((range) => range.id === 'review')).toBeUndefined();
+  });
+
   it('smoothly reveals a spellcheck result after its page surface was virtualized', async () => {
     const pageCount = 8;
     const errorId = 'far-spellcheck-error';

--- a/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
+++ b/apps/website/src/lib/editor-ffi/editor-host-failure.test.ts
@@ -1536,7 +1536,7 @@ describe('Editor guarded core invocation', () => {
     editor.destroy();
   });
 
-  it('retains freshly resolved tracked geometry for an older published snapshot', async () => {
+  it.each(['doc', 'page_sizes'] as const)('refreshes tracked ranges on %s while retaining older snapshot geometry', async (field) => {
     const { editor, core } = await createEditor();
     const stale = {
       id: 'prism-issue:0',
@@ -1554,20 +1554,33 @@ describe('Editor guarded core invocation', () => {
       })
       .mockReturnValueOnce({
         revision: { value: 3 },
+        events: [{ type: 'state_changed', fields: [field] }],
+        request_outcomes: [],
+      })
+      .mockReturnValueOnce({
+        revision: { value: 4 },
         events: [{ type: 'state_changed', fields: ['ime'] }],
         request_outcomes: [],
       });
 
     editor.enqueue({ type: 'history', op: { type: 'undo' } });
     frames.at(-1)?.(0);
-    const publishedCandidate = editor.appliedSnapshot;
-    expect(editor.freshTrackedRanges()).toEqual([fresh]);
+    const beforeEdit = editor.appliedSnapshot;
 
     editor.enqueue({ type: 'history', op: { type: 'undo' } });
     frames.at(-1)?.(0);
-
+    const afterEdit = editor.appliedSnapshot;
     expect(editor.appliedRevision).toBe(3);
-    expect(editor.trackedRangeForSnapshot(stale.id, publishedCandidate)).toEqual(fresh);
+    expect(afterEdit.trackedRanges).toEqual([fresh]);
+    expect(editor.trackedRangeForSnapshot(stale.id, beforeEdit)).toEqual(stale);
+
+    core.tracked_ranges.mockClear();
+    editor.enqueue({ type: 'history', op: { type: 'undo' } });
+    frames.at(-1)?.(0);
+    expect(editor.appliedSnapshot.trackedRanges).toBe(afterEdit.trackedRanges);
+    expect(editor.trackedRangeForSnapshot(stale.id, afterEdit)).toEqual(fresh);
+    expect(editor.trackedRangeForSnapshot(stale.id, editor.appliedSnapshot)).toEqual(fresh);
+    expect(core.tracked_ranges).not.toHaveBeenCalled();
 
     editor.destroy();
   });

--- a/apps/website/src/lib/editor-ffi/editor.svelte.ts
+++ b/apps/website/src/lib/editor-ffi/editor.svelte.ts
@@ -335,8 +335,6 @@ export class Editor {
   #appliedWaiters = new Set<AppliedWaiter>();
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
   #publicationWaiters = new Set<PublicationWaiter>();
-  #freshRanges: TrackedRange[] = [];
-  #freshRangesFor: EditorSnapshot | undefined;
 
   #applied = $state.raw<EditorSnapshot>({
     revision: 0,
@@ -358,10 +356,6 @@ export class Editor {
     rootModifiers: [],
     trackedRanges: [],
   });
-  // Snapshot trackedRanges preserve semantic registry changes, while their rects can move on
-  // unrelated document edits. Resolve only active consumers and retain their revision geometry.
-  #resolvedTrackedRanges = new WeakMap<EditorSnapshot, Map<string, TrackedRange | undefined>>();
-
   #viewport = $state<Viewport>({ width: 0, height: 0, scale_factor: 1 });
   #appliedViewport: Viewport = { width: 0, height: 0, scale_factor: 1 };
   #applyViewportResize = debounce(() => {
@@ -635,7 +629,10 @@ export class Editor {
         pageData,
         rootAttrs,
         rootModifiers: fields.has('block') || fields.has('modifiers') ? core.root_modifiers() : previous.rootModifiers,
-        trackedRanges: fields.has('tracked_ranges') ? core.tracked_ranges() : previous.trackedRanges,
+        // Resolved ranges depend on document positions and layout as well as registration.
+        // Selection and IME-only ticks reuse the same immutable result.
+        trackedRanges:
+          fields.has('tracked_ranges') || fields.has('doc') || fields.has('page_sizes') ? core.tracked_ranges() : previous.trackedRanges,
       };
     });
   }
@@ -1513,18 +1510,6 @@ export class Editor {
   }
 
   trackedRangeForSnapshot(id: string, snapshot: EditorSnapshot): TrackedRange | undefined {
-    let resolved = this.#resolvedTrackedRanges.get(snapshot);
-    if (resolved?.has(id)) return resolved.get(id);
-    if (snapshot === this.#applied) {
-      const range = this.#invokeCore((core) => core.tracked_range(id));
-      if (!resolved) {
-        // eslint-disable-next-line svelte/prefer-svelte-reactivity
-        resolved = new Map();
-        this.#resolvedTrackedRanges.set(snapshot, resolved);
-      }
-      resolved.set(id, range);
-      return range;
-    }
     return snapshot.trackedRanges.find((range) => range.id === id);
   }
 
@@ -2524,23 +2509,6 @@ export class Editor {
 
       if (result.type === 'failed') this.#reportError(result.error, `Failed to add prism review range: ${item.id}`);
     }
-  }
-
-  // 스냅숏의 trackedRanges는 코어가 tracked_ranges 필드를 낼 때만 갈린다(materializeSnapshot) — 본문이
-  // 리플로우해도 그 필드는 안 서므로 rects가 옛 자리에 굳는다. 여백은 rects로 좌표를 잡으니 지금 것을 직접 읽는다.
-  freshTrackedRanges(): TrackedRange[] {
-    // 레지스트리는 tick에서만 갈리고 그때마다 #applied가 새 객체가 된다 — 한 판에 한 번만 마샬한다
-    if (this.#freshRangesFor !== this.#applied) {
-      this.#freshRanges = this.#invokeCore((core) => core.tracked_ranges());
-      this.#freshRangesFor = this.#applied;
-      // 이 snapshot이 게시된 뒤 다음 판이 먼저 적용되어도, 호스트는 그 캔버스와 짝인 지금 좌표를 써야 한다.
-      // snapshot 사본에만 남은 stale id는 undefined로 고정해 옛 rect로 되돌아가지 않게 한다.
-      // eslint-disable-next-line svelte/prefer-svelte-reactivity -- immutable snapshot cache installed into a WeakMap
-      const resolved = new Map<string, TrackedRange | undefined>(this.#applied.trackedRanges.map((range) => [range.id, undefined]));
-      for (const range of this.#freshRanges) resolved.set(range.id, range);
-      this.#resolvedTrackedRanges.set(this.#applied, resolved);
-    }
-    return this.#freshRanges;
   }
 
   clearPrismReviewRanges(): void {

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismMarginLayer.svelte
@@ -180,10 +180,7 @@
   // 의미 좌표는 판이 바뀔 때만 갱신한다. presentation 측정은 아래 effect 한 곳에서 수행한다.
   $effect(() => {
     const editor = ctx.editor;
-    void editor?.publishedRevision;
-    untrack(() => {
-      trackedRanges = new Map(editor?.freshTrackedRanges().map((range) => [range.id, range]));
-    });
+    trackedRanges = new Map(editor?.published?.snapshot.trackedRanges.map((range) => [range.id, range]));
   });
 
   // 항목 집합이나 현재 presentation geometry가 바뀌면 캐시된 의미 좌표를 화면에 다시 투영한다.

--- a/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
+++ b/apps/website/src/routes/website/(dashboard)/[slug]/v2/@prism-review/PrismReviewMargin.svelte
@@ -542,10 +542,7 @@
 
     const current = editor;
     if (!current) return raw.map((place) => join(place, false));
-    // 스냅숏 사본의 trackedRanges는 코어가 그 필드를 낼 때만 갈린다 — 문단을 지워 range가 빠져도
-    // 사본에는 남아 자리 잃음이 다음 새로고침까지 드러나지 않는다. 판이 갈릴 때마다 지금 것을 받는다.
-    void current.appliedSnapshot.revision;
-    const alive = new Set(current.freshTrackedRanges().map((range) => range.id));
+    const alive = new Set(current.appliedSnapshot.trackedRanges.map((range) => range.id));
     return raw.map((place) =>
       join(
         place,

--- a/crates/editor-model/src/view/mod.rs
+++ b/crates/editor-model/src/view/mod.rs
@@ -180,6 +180,17 @@ impl<'a> NodeView<'a> {
     pub fn leaf_child_count(&self) -> usize {
         self.tree_node().map_or(0, |n| n.children.leaf_count())
     }
+    /// Whether a direct leaf was moved here by copy-identity projection, which
+    /// can make the children's display order differ from their sequence order.
+    pub fn has_redirected_leaf(&self) -> bool {
+        self.leaf_child_count() > 0
+            && self
+                .view
+                .doc
+                .redirected
+                .keys()
+                .any(|leaf| self.view.block_of(*leaf) == Some(self.id))
+    }
     /// Flat width of this block including its two boundary sentinels (the root
     /// reports its sentinel-free total via [`DocView::root_flat_total`]). Reads
     /// the maintained flat index — `O(1)`.

--- a/crates/editor-state/src/stable_position.rs
+++ b/crates/editor-state/src/stable_position.rs
@@ -410,6 +410,16 @@ fn offset_within(c: &NodeView, target: Dot, ctx: &StableResolveCtx) -> usize {
     let Some(r) = ctx.resolver.position(d) else {
         return 0;
     };
+    // Root blocks and inline children without redirected leaves preserve sequence
+    // order. Fixed-role containers and synthetic blocks retain the linear path;
+    // synthetic blocks inherit the preceding rank there.
+    if (c.id() == Dot::ROOT || c.spec().is_textblock())
+        && !c.has_redirected_leaf()
+        && c.child_blocks().all(|block| block.dot().is_some())
+        && let Some(offset) = offset_within_ordered(c, r, ctx)
+    {
+        return offset;
+    }
     let mut offset = 0usize;
     let mut prev_real: Option<usize> = None;
     for child in c.children() {
@@ -437,6 +447,22 @@ fn offset_within(c: &NodeView, target: Dot, ctx: &StableResolveCtx) -> usize {
         }
     }
     offset
+}
+
+fn offset_within_ordered(c: &NodeView, rank: usize, ctx: &StableResolveCtx) -> Option<usize> {
+    let mut lo = 0;
+    let mut hi = c.child_count();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let dot = child_elem_id(&c.child_at(mid)?);
+        let child_rank = ctx.resolver.visible_position(dot)?;
+        if child_rank < rank {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    Some(lo)
 }
 
 /// Resolves a chain step to a live node in the current projection. A real step
@@ -1441,6 +1467,120 @@ mod tests {
     }
 
     #[test]
+    fn deleted_boundaries_match_linear_resolution_in_root_and_text_children() {
+        for inline in [false, true] {
+            let mut items = vec![(Dot::new(1, 1), block(NodeType::Paragraph, vec![Dot::ROOT]))];
+            items.extend((2..=65).map(|clock| {
+                (
+                    Dot::new(1, clock),
+                    if inline {
+                        SeqItem::Char('a')
+                    } else {
+                        block(NodeType::Paragraph, vec![Dot::ROOT])
+                    },
+                )
+            }));
+            let mut events = ins_only(&items);
+            // Delete boundaries at the beginning, middle and end of the host.
+            for index in (1..items.len()).rev().filter(|i| i % 3 == 1) {
+                let parent = events.last().unwrap().id;
+                events.push(InputEvent {
+                    id: Dot::new(1, events.len() as u64 + 1),
+                    parents: vec![parent],
+                    op: ListOp::Del { pos: index, len: 1 },
+                });
+            }
+            let logs = doclogs(&events);
+            let projected = project_document(&logs).unwrap();
+            let view = DocView::new(&projected);
+            let ctx = StableResolveCtx::new(&view, &logs.seq);
+            let host = if inline {
+                view.node(items[0].0).unwrap()
+            } else {
+                view.root().unwrap()
+            };
+            for (dot, _) in &items[1..] {
+                let expected = v1_offset_within(&host, *dot, &ctx, &mut false);
+                assert_eq!(offset_within(&host, *dot, &ctx), expected);
+            }
+        }
+    }
+
+    #[test]
+    fn deleted_anchor_in_redirected_paragraph_keeps_its_boundary() {
+        use editor_model::EditOp;
+
+        let mut state = crate::ProjectedState::empty();
+        let original = state
+            .view()
+            .root()
+            .unwrap()
+            .child_blocks()
+            .next()
+            .unwrap()
+            .id();
+        let insert = |pos, c| {
+            EditOp::Seq(ListOp::Ins {
+                pos,
+                item: SeqItem::Char(c),
+            })
+        };
+        let a = state.apply(insert(1, 'a')).unwrap().id;
+        let z = state.apply(insert(2, 'z')).unwrap().id;
+        let q = state.apply(insert(3, 'q')).unwrap().id;
+        let captured = StablePosition::capture(&Position::new(original, 3), &state.view());
+        let moved = state
+            .apply(EditOp::Seq(ListOp::Ins {
+                pos: 4,
+                item: block(NodeType::Paragraph, vec![Dot::ROOT]),
+            }))
+            .unwrap()
+            .id;
+        let copied_a = state.apply(insert(5, 'a')).unwrap().id;
+        state
+            .apply(EditOp::Alias(AliasOp {
+                pairs: vec![
+                    AliasRun {
+                        old_start: original,
+                        len: 1,
+                        new_start: moved,
+                    },
+                    AliasRun {
+                        old_start: a,
+                        len: 1,
+                        new_start: copied_a,
+                    },
+                ],
+            }))
+            .unwrap();
+        // Moving the original paragraph redirects z/q behind the copied a.
+        state
+            .apply(EditOp::Seq(ListOp::Del { pos: 0, len: 2 }))
+            .unwrap();
+        state
+            .apply(EditOp::Seq(ListOp::Del { pos: 1, len: 1 }))
+            .unwrap();
+
+        let view = state.view();
+        let host = view.node(moved).unwrap();
+        assert_eq!(
+            host.children()
+                .map(|child| child_elem_id(&child))
+                .collect::<Vec<_>>(),
+            vec![copied_a, z]
+        );
+        assert!(view.leaf(q).is_none());
+        // Display order is a,z, while sequence order is z,a. The deleted q
+        // boundary must keep the linear resolver's a|z position, not az|.
+        for ctx in [
+            StableResolveCtx::from_live(&view, state.seq_checkout()),
+            StableResolveCtx::new(&view, state.seq()),
+        ] {
+            assert_eq!(captured.resolve(&ctx), Some(Position::new(moved, 1)));
+        }
+    }
+
+    #[test]
     fn deleted_host_block_walks_to_live_ancestor() {
         let root = Dot::ROOT;
         let p0 = Dot::new(1, 1);
@@ -1527,6 +1667,13 @@ mod tests {
         let post = project_document(&post_logs).unwrap();
         let post_view = DocView::new(&post);
         let ctx = StableResolveCtx::new(&post_view, &post_logs.seq);
+        let fold_view = post_view.node(fold).unwrap();
+        for target in [content, title] {
+            assert_eq!(
+                offset_within(&fold_view, target, &ctx),
+                v1_offset_within(&fold_view, target, &ctx, &mut false),
+            );
+        }
         let r = sp.resolve(&ctx).unwrap();
         if let Some(host) = post_view.node(r.node) {
             assert!(r.offset <= host.children().count(), "offset in range");
@@ -2487,6 +2634,16 @@ mod tests {
             .filter(|e| matches!(e.op, ListOp::Ins { .. }))
             .map(|e| e.dot)
             .collect();
+        let ctx = StableResolveCtx::from_live(&ordered, state.seq_checkout());
+        for host in all_block_nodes(&ordered) {
+            for target in all_dots.iter().step_by((all_dots.len() / 4).max(1)).take(4) {
+                assert_eq!(
+                    offset_within(&host, *target, &ctx),
+                    v1_offset_within(&host, *target, &ctx, &mut false),
+                    "boundary lookup diverged from linear resolution",
+                );
+            }
+        }
         for dot in &all_dots {
             let a = ordered
                 .leaf(*dot)


### PR DESCRIPTION
PRISM 리뷰가 활성화된 문서에서 연속 입력할 때 발생하는 tracked range 조회 비용을 줄입니다. 웹 호스트에서는 snapshot의 갱신 조건을 수정해 중복 조회를 제거하고, 공통 Rust 엔진에서는 삭제된 anchor의 위치를 찾는 탐색을 최적화합니다.

## 웹: tracked range 조회 결과를 snapshot에서 관리

기존 `EditorSnapshot.trackedRanges`는 엔진의 `tracked_ranges` 변경 알림에만 갱신됐습니다. 하지만 tracked range의 등록 상태가 그대로여도 본문 편집이나 reflow로 위치와 rect가 달라질 수 있습니다.

이를 보완하기 위해 리뷰 UI는 applied snapshot이 바뀔 때마다 `freshTrackedRanges()`로 엔진을 다시 조회하고, 별도 캐시에 결과를 보관했습니다. 이 구조에서는 tracked range에 영향을 주지 않는 IME·selection 변경에도 전체 range의 위치 계산과 FFI 변환이 반복됐습니다.

`#materializeSnapshot`에서 tracked range의 실제 의존성을 반영하도록 변경합니다.

- `tracked_ranges`, `doc`, `page_sizes` 중 하나가 변경되면 `core.tracked_ranges()`로 결과를 갱신합니다.
- IME·selection만 변경되면 이전 snapshot의 `trackedRanges`를 재사용합니다.
- `freshTrackedRanges()`와 별도 `WeakMap` 캐시를 제거하고, `trackedRangeForSnapshot()`도 전달받은 snapshot에서 조회합니다.

소비자는 필요한 시점의 snapshot을 명시적으로 사용합니다.

- `PrismReviewMargin`: 최신 `appliedSnapshot.trackedRanges`로 range의 유효성과 ‘자리 잃음’ 상태를 판단합니다.
- `PrismMarginLayer`: `published.snapshot.trackedRanges`로 레일과 여백 좌표를 계산해, 표시 중인 캔버스와 같은 revision을 사용합니다.

## 엔진: 삭제된 anchor의 boundary lookup 최적화

`StablePosition`이 가리키던 블록이나 문자가 삭제되면, `offset_within`은 살아 있는 상위 노드에서 해당 boundary의 위치를 찾습니다. 기존 구현은 모든 자식을 순회하며 각각의 CRDT sequence position을 조회했습니다. 삭제된 문단을 가리키는 anchor가 여러 개 남아 있으면 이 비용이 range 조회마다 반복됩니다.

문서 root와 text block 중 자식의 sequence order가 보장되는 경우에는 binary search를 적용합니다. 전체 자식에 대해 수행하던 sequence position 조회를 binary search에 필요한 조회로 줄입니다.

기존 boundary semantics를 보존하기 위해 다음 경우에는 linear scan을 유지합니다.

- `Fold`처럼 자식이 고정된 역할을 가지는 container
- synthetic block을 자식으로 가지는 경우
- copy-identity projection의 redirected leaf를 포함하는 경우
- 탐색에 필요한 자식이나 sequence position을 조회할 수 없는 경우

특히 redirected leaf는 문단 이동·복사 이후 다른 문단으로 재배치되므로, 표시 순서와 sequence order가 달라질 수 있습니다. `NodeView.has_redirected_leaf()`로 해당 노드만 binary search에서 제외합니다.

## 성능 확인

리뷰가 활성화된 재현 문서에서 한글을 자동 반복 입력한 측정 결과입니다.

| 항목 | 변경 전 | 변경 후 |
|---|---:|---:|
| 키 입력당 tracked range 조회 횟수 | 약 5회 | 약 2회 |
| tracked range 조회 1회 평균 시간 | 약 9.4ms | 약 1.0ms |

## 검증

- 문서·레이아웃 변경 시 tracked range 갱신, 이전 snapshot의 geometry 보존, IME-only 변경 시 조회 결과 재사용 검증
- 실제 WASM에서 reflow 후 range rect 이동과 본문 삭제 후 range 제거 반영 검증
- 삭제된 boundary 및 redirected leaf가 있는 문단의 anchor 복구 검증
- 무작위 문서 변경에서 기존 linear scan과 boundary lookup 결과 비교
- `editor-model`, `editor-state`, `editor-core` 테스트 2,073개 통과
- 관련 웹 unit/browser regression test, Clippy, 타입·포맷 검사 통과
- 웹 release WASM 빌드 통과

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>