### PR TITLE
앱 레이아웃 갱신 시 핀치 overzoom이 풀리는 문제 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemantic.kt
@@ -165,7 +165,11 @@ internal class EditorViewportZoomSemantic(
         ?: currentConfig.createIndirectSession(focalInRootPx, timestampMillis)
         ?: return false
     if (currentConfig.pageSizes !== session.pageSizes) {
-      session = currentConfig.createIndirectSession(focalInRootPx, timestampMillis) ?: return false
+      session =
+        currentConfig
+          .createIndirectSession(focalInRootPx, timestampMillis)
+          ?.copy(rawZoom = session.rawZoom, lastTimestampMillis = session.lastTimestampMillis)
+          ?: return false
     }
 
     val rawZoom = session.rawZoom * scaleFactor
@@ -651,12 +655,12 @@ private fun EditorViewportZoomSemanticConfig.rebasePinchSession(
     anchor = anchor,
     startSample = session.lastSample,
     startScrollOffset = viewportState.effectiveTransformScrollTarget,
-    startRawZoom = displayZoom,
+    startRawZoom = session.rawZoom,
     startAnchorDisplayPosition = anchorDisplayPosition,
     startFocal = toRootDp(session.lastSample.focalInRootPx),
     pageSizes = pageSizes,
     lastSample = session.lastSample,
-    rawZoom = displayZoom,
+    rawZoom = session.rawZoom,
   )
 }
 

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorViewportZoomSemanticTest.kt
@@ -452,6 +452,62 @@ class EditorViewportZoomSemanticTest {
   }
 
   @Test
+  fun `pinch overzoom stays unchanged across page geometry updates while fingers stay still`() {
+    for (distancePx in listOf(5f, 250f)) {
+      val fixture = Fixture()
+      val start = EditorPinchSample(focalInRootPx = Offset(80f, 150f), distancePx = 100f)
+      val sample = start.copy(distancePx = distancePx)
+      assertTrue(fixture.semantic.beginPinch(start))
+      assertTrue(fixture.semantic.updatePinch(sample))
+      val overzoom = fixture.zoomController.displayZoom
+
+      repeat(2) { index ->
+        fixture.updatePresentation(
+          pageSizes = listOf(PageSize(width = 720f, height = 970f + index * 10f)),
+          pageOffsets = mapOf(0 to Offset.Zero),
+          displayZoom = fixture.zoomController.displayZoom,
+        )
+
+        assertTrue(fixture.semantic.updatePinch(sample))
+
+        assertEquals(overzoom, fixture.zoomController.displayZoom, 0.0001f)
+        assertTrue(fixture.viewportState.isTransforming)
+      }
+    }
+  }
+
+  @Test
+  fun `indirect overzoom stays cumulative across page geometry updates`() {
+    for (scaleFactor in listOf(0.05f, 2.5f)) {
+      val fixture = Fixture()
+      val uninterrupted = Fixture()
+      val focal = Offset(80f, 150f)
+      for (current in listOf(fixture, uninterrupted)) {
+        assertTrue(current.semantic.beginIndirect())
+        assertTrue(current.semantic.updateIndirectScale(focal, scaleFactor))
+      }
+
+      repeat(2) { index ->
+        fixture.updatePresentation(
+          pageSizes = listOf(PageSize(width = 720f, height = 970f + index * 10f)),
+          pageOffsets = mapOf(0 to Offset.Zero),
+          displayZoom = fixture.zoomController.displayZoom,
+        )
+
+        assertTrue(fixture.semantic.updateIndirectScale(focal, 0.99f))
+        assertTrue(uninterrupted.semantic.updateIndirectScale(focal, 0.99f))
+
+        assertEquals(
+          uninterrupted.zoomController.displayZoom,
+          fixture.zoomController.displayZoom,
+          0.0001f,
+        )
+        assertTrue(fixture.viewportState.isTransforming)
+      }
+    }
+  }
+
+  @Test
   fun `pinch samples resolve an absolute target from a root-stable focal`() {
     val fixture =
       Fixture(


### PR DESCRIPTION
핀치 중 레이아웃이 갱신되면 탄성 보정된 화면 배율을 누적 줌으로 다시 사용하면서, overzoom이 간헐적으로 풀리고 화면이 튀었습니다.

터치 핀치와 트랙패드 줌 모두 레이아웃 갱신 시 누적 줌을 보존하도록 수정했습니다. 확대·축소 한계에서 페이지 정보가 반복 갱신되는 회귀 테스트를 추가했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>