### PR TITLE
웹 에디터 타일의 픽셀 렌더링 설정 복원

### DIFF
--- a/crates/editor-ffi/src/platform/wasm_browser.rs
+++ b/crates/editor-ffi/src/platform/wasm_browser.rs
@@ -171,9 +171,11 @@ impl SurfaceHandle {
                 bottom - top,
             ),
         )?;
+        // Glyphs are already rasterized at the surface scale. Preserve those
+        // pixels when the browser places a tile between device pixels.
         canvas.set_attribute(
             "style",
-            &format!("position:absolute;left:-1px;top:-1px;width:{width}px;height:{height}px;",),
+            &format!("position:absolute;left:-1px;top:-1px;width:{width}px;height:{height}px;image-rendering:pixelated;",),
         )?;
         let ctx = canvas
             .get_context("2d")?


### PR DESCRIPTION
타일 기반 렌더링으로 전환하면서 누락된 `image-rendering: pixelated`를 각 타일 캔버스에 복원합니다. 브라우저가 본문 픽셀을 화면에 표시할 때 기존의 이미지 보간 정책을 유지하도록 합니다.

- Chromium의 간소화한 재현에서 125%·150% 배율의 추가 보간이 줄어드는 것을 확인

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>