### PR TITLE
앱 에디터 placeholder 폰트와 줄 높이 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/placeholder/EditorDocumentPlaceholder.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/screen/editor/editor/placeholder/EditorDocumentPlaceholder.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -63,10 +62,15 @@ internal fun EditorDocumentPlaceholder(
     ) ?: return
   val textColor = AppTheme.colors.textHint
   val fontSize = with(density) { placement.fontSizePx.dp.toSp() }
-  val lineHeight = with(density) { (placement.fontSizePx * placement.lineHeightRatio).dp.toSp() }
+  // Keep the engine's line-height ratio independent of Android's nonlinear font scaling.
+  val lineHeight = placement.lineHeightRatio.em
   val letterSpacing = placement.letterSpacingEm.em
   val textStyle =
-    TextStyle(fontSize = fontSize, lineHeight = lineHeight, letterSpacing = letterSpacing)
+    AppTheme.typography.body.copy(
+      fontSize = fontSize,
+      lineHeight = lineHeight,
+      letterSpacing = letterSpacing,
+    )
   val firstLineTextStyle =
     textStyle.copy(
       lineHeightStyle =


### PR DESCRIPTION
빈 문서 placeholder가 시스템 글꼴을 사용하고, Android에서 시스템 글자 크기를 확대하면 본문보다 아래로 내려가던 문제를 수정합니다.

placeholder에 앱 기본 글꼴인 SUIT를 적용하고, 줄 높이를 em 단위로 전달해 시스템 글자 크기 설정과 관계없이 엔진의 줄 높이 비율을 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>