### PR TITLE
안드로이드 커서 이동 후 한글 조합 오류 수정

### DIFF
--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionController.kt
@@ -25,12 +25,13 @@ internal class EditorInteractionController(
   override val effects: EditorInteractionEffects,
   override val geometry: EditorInteractionGeometry,
   private val uiStateProvider: () -> EditorUiState,
+  private val platformProvider: () -> Platform = { Platform.Desktop },
   override val semantics: EditorInteractionSemantics =
     EditorInteractionSemantics(
       effects = effects,
+      platform = platformProvider(),
       contextMenuStateProvider = { uiStateProvider().contextMenu },
     ),
-  private val platformProvider: () -> Platform = { Platform.Desktop },
   private val pointerInputEnabledProvider: () -> Boolean = { true },
   private val suppressedTapProvider: (Long) -> Boolean = { false },
   private val readOnlyProvider: () -> Boolean = { false },

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionScope.kt
@@ -56,6 +56,7 @@ internal class EditorInteractionScope(
   private val semantics =
     EditorInteractionSemantics(
       effects = this,
+      platform = platformProvider(),
       coroutineScope = coroutineScope,
       contextMenuStateProvider = {
         checkNotNull(uiState) { "Editor interaction scope has no UI state" }.contextMenu

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionSemantics.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/EditorInteractionSemantics.kt
@@ -14,14 +14,16 @@ import co.typie.editor.interaction.semantics.EditorSelectionHapticSemantic
 import co.typie.editor.interaction.semantics.EditorTableColumnResizeSemantic
 import co.typie.editor.interaction.semantics.EditorViewportZoomSemantic
 import co.typie.editor.runtime.EditorContextMenuState
+import co.typie.platform.Platform
 import kotlinx.coroutines.CoroutineScope
 
 internal class EditorInteractionSemantics(
   effects: EditorInteractionEffects,
   contextMenuStateProvider: () -> EditorContextMenuState,
   coroutineScope: CoroutineScope? = null,
+  platform: Platform = Platform.Desktop,
   val pointSelection: EditorPointSelectionSemantic =
-    EditorPointSelectionSemantic(effects = effects),
+    EditorPointSelectionSemantic(effects = effects, platform = platform),
   val contextMenu: EditorContextMenuSemantic =
     EditorContextMenuSemantic(stateProvider = contextMenuStateProvider),
   val selectionHandle: EditorSelectionHandleSemantic =

--- a/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemantic.kt
+++ b/apps/mobile/compose/src/commonMain/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemantic.kt
@@ -10,19 +10,25 @@ import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.SelectionPointUnit
 import co.typie.editor.interaction.EditorInteractionEffects
+import co.typie.platform.Platform
 import kotlin.concurrent.Volatile
 
-internal class EditorPointSelectionSemantic(private val effects: EditorInteractionEffects) {
+internal class EditorPointSelectionSemantic(
+  private val effects: EditorInteractionEffects,
+  private val platform: Platform,
+) {
   @Volatile private var pendingSelectionGeneration = 0L
 
   fun cancelPendingSelection() {
     pendingSelectionGeneration += 1
   }
 
+  // Android IMEs finish composition after updateSelection reports the new cursor
+  // together with the existing composing range, as a native EditText does.
   fun applySelection(editor: Editor, op: SelectionOp): EditorState? {
     val update =
       editor.updateNow {
-        if (editor.appliedState.ime?.composing != null) {
+        if (platform != Platform.Android && editor.appliedState.ime?.composing != null) {
           enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
         }
         enqueue(Message.Selection(op))
@@ -130,7 +136,7 @@ internal class EditorPointSelectionSemantic(private val effects: EditorInteracti
 
   fun enqueueCursorMove(editor: Editor, point: PagePoint): Boolean {
     return editor.runCallback {
-      if (editor.appliedState.ime?.composing != null) {
+      if (platform != Platform.Android && editor.appliedState.ime?.composing != null) {
         editor.enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
       }
       editor.enqueue(
@@ -163,7 +169,7 @@ internal class EditorPointSelectionSemantic(private val effects: EditorInteracti
   ): Boolean {
     val update =
       editor.update(admit = { generation == pendingSelectionGeneration }) {
-        if (editor.appliedState.ime?.composing != null) {
+        if (platform != Platform.Android && editor.appliedState.ime?.composing != null) {
           enqueue(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
         }
         enqueue(Message.Selection(op))

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/EditorInteractionControllerTest.kt
@@ -236,7 +236,7 @@ class EditorInteractionControllerTest {
     }
 
   @Test
-  fun `composition tap still moves on Android and with mouse or stylus on iOS`() =
+  fun `composition tap moves on Android without committing and commits for iOS mouse or stylus`() =
     runTest(StandardTestDispatcher()) {
       for ((platform, pointerType) in
         listOf(
@@ -265,10 +265,12 @@ class EditorInteractionControllerTest {
         controller.onPointerUp(1L, point, 40L)
         runCurrent()
         assertEquals(
-          listOf(
-            Message.TextInput(listOf(FlatImeOp.CommitAsIs)),
-            Message.Selection(SelectionOp.SetAt(0, 80f, 20f)),
-          ),
+          buildList {
+            if (platform != Platform.Android) {
+              add(Message.TextInput(listOf(FlatImeOp.CommitAsIs)))
+            }
+            add(Message.Selection(SelectionOp.SetAt(0, 80f, 20f)))
+          },
           fake.enqueued,
           "$platform $pointerType",
         )

--- a/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemanticTest.kt
+++ b/apps/mobile/compose/src/commonTest/kotlin/co/typie/editor/interaction/semantics/EditorPointSelectionSemanticTest.kt
@@ -19,6 +19,7 @@ import co.typie.editor.ffi.Selection
 import co.typie.editor.ffi.SelectionOp
 import co.typie.editor.ffi.SelectionPointUnit
 import co.typie.editor.interaction.EditorInteractionEffects
+import co.typie.platform.Platform
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -30,39 +31,45 @@ import kotlinx.coroutines.test.runTest
 @OptIn(ExperimentalCoroutinesApi::class)
 class EditorPointSelectionSemanticTest {
   @Test
-  fun `pointer selection commits marked text before moving in every dispatch path`() =
+  fun `pointer selection lets Android IME finish composition and commits before moving elsewhere`() =
     runTest(StandardTestDispatcher()) {
-      for (path in listOf("immediate", "suspending", "enqueued")) {
-        val fake =
-          FakeFfiEditor(
-            imeProvider = { _, _ ->
-              Ime(
-                text = "日本語 text",
-                windowStart = 0,
-                selection = ImeRange(3, 3),
-                composing = ImeRange(0, 3),
-              )
-            }
+      for (platform in Platform.entries) {
+        for (path in listOf("immediate", "suspending", "enqueued")) {
+          val fake =
+            FakeFfiEditor(
+              imeProvider = { _, _ ->
+                Ime(
+                  text = "日本語 text",
+                  windowStart = 0,
+                  selection = ImeRange(3, 3),
+                  composing = ImeRange(0, 3),
+                )
+              }
+            )
+          val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
+          editor.setImeSessionActive(true)
+          fake.applySnapshot(editor)
+          val semantic = EditorPointSelectionSemantic(effects = UnusedEffects, platform = platform)
+          val point = PagePoint(page = 0, x = 100f, y = 20f)
+          val selection = SelectionOp.SetAt(page = 0, x = 100f, y = 20f)
+
+          when (path) {
+            "immediate" -> semantic.applySelection(editor, selection)
+            "suspending" -> semantic.dispatchCursorMove(editor, point)
+            "enqueued" -> semantic.enqueueCursorMove(editor, point)
+          }
+          testScheduler.runCurrent()
+
+          assertEquals(
+            if (platform == Platform.Android) {
+              listOf(Message.Selection(selection))
+            } else {
+              listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs)), Message.Selection(selection))
+            },
+            fake.enqueued,
+            "$platform/$path",
           )
-        val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
-        editor.setImeSessionActive(true)
-        fake.applySnapshot(editor)
-        val semantic = EditorPointSelectionSemantic(effects = UnusedEffects)
-        val point = PagePoint(page = 0, x = 100f, y = 20f)
-        val selection = SelectionOp.SetAt(page = 0, x = 100f, y = 20f)
-
-        when (path) {
-          "immediate" -> semantic.applySelection(editor, selection)
-          "suspending" -> semantic.dispatchCursorMove(editor, point)
-          "enqueued" -> semantic.enqueueCursorMove(editor, point)
         }
-        testScheduler.runCurrent()
-
-        assertEquals(
-          listOf(Message.TextInput(listOf(FlatImeOp.CommitAsIs)), Message.Selection(selection)),
-          fake.enqueued,
-          path,
-        )
       }
     }
 
@@ -71,7 +78,8 @@ class EditorPointSelectionSemanticTest {
     runTest(StandardTestDispatcher()) {
       val fake = FakeFfiEditor(cursorProvider = { cursorAt(x = 20f) })
       val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
-      val semantic = EditorPointSelectionSemantic(effects = UnusedEffects)
+      val semantic =
+        EditorPointSelectionSemantic(effects = UnusedEffects, platform = Platform.Desktop)
       var onAppliedCalled = false
 
       assertTrue(
@@ -91,7 +99,8 @@ class EditorPointSelectionSemanticTest {
   @Test
   fun `cursor move semantic does not own selection hit admission`() =
     runTest(StandardTestDispatcher()) {
-      val semantic = EditorPointSelectionSemantic(effects = UnusedEffects)
+      val semantic =
+        EditorPointSelectionSemantic(effects = UnusedEffects, platform = Platform.Desktop)
       val rangeSelection =
         Selection(
           anchor = Position("text", 0, Affinity.Downstream),
@@ -128,7 +137,8 @@ class EditorPointSelectionSemanticTest {
           }
         }
       val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
-      val semantic = EditorPointSelectionSemantic(effects = UnusedEffects)
+      val semantic =
+        EditorPointSelectionSemantic(effects = UnusedEffects, platform = Platform.Desktop)
       var onAppliedCalled = false
 
       assertFalse(
@@ -153,7 +163,8 @@ class EditorPointSelectionSemanticTest {
         FakeFfiEditor(cursorProvider = { cursorAt(x = 20f) }, selectionProvider = { selection })
       val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
       fake.publishSnapshot(editor)
-      val semantic = EditorPointSelectionSemantic(effects = UnusedEffects)
+      val semantic =
+        EditorPointSelectionSemantic(effects = UnusedEffects, platform = Platform.Desktop)
 
       assertTrue(
         semantic.dispatchSelectionExtension(
@@ -195,7 +206,8 @@ class EditorPointSelectionSemanticTest {
       val editor = Editor(fake, this, StandardTestDispatcher(testScheduler))
       fake.publishSnapshot(editor)
       fake.enqueued.clear()
-      val semantic = EditorPointSelectionSemantic(effects = UnusedEffects)
+      val semantic =
+        EditorPointSelectionSemantic(effects = UnusedEffects, platform = Platform.Desktop)
 
       assertTrue(
         semantic.dispatchUnitSelection(

--- a/crates/editor-core/src/handle/text_input.rs
+++ b/crates/editor-core/src/handle/text_input.rs
@@ -8,7 +8,7 @@ use editor_model::{DocView, Modifier, ModifierType};
 use editor_state::{
     Affinity, Composition, FLAT_CLOSE, FLAT_OPEN, FlatSegment, Position, ProjectedState,
     ResolvedPosition, ResolvedPositionFlatExt, Selection, StablePosition, apply_pending,
-    as_gap_cursor, continuation_at, flat_chars, flat_segments_in_range, flat_size,
+    as_gap_cursor, continuation_at, flat_chars, flat_segments_in_range, flat_size, remap_selection,
     replacement_paint,
 };
 use editor_transaction::{HistoryMeta, MergeKind, Transaction};
@@ -320,7 +320,7 @@ struct FlatImeReduction {
     // must see the full replacement — trimming swallows a leading trigger
     // char that matches the selection's first character.
     untrimmed_text_change: Option<FlatImeTextChange>,
-    committed_composition: bool,
+    committed_composition_end: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -691,11 +691,11 @@ impl FlatImeState {
         let initial_sel_start = self.sel_start;
         let mut anchored_change: Option<FlatImeAnchoredChangeTracker> = None;
         let mut can_track_anchored_change = true;
-        let mut committed_composition = false;
+        let mut committed_composition_end = None;
 
         for op in ops {
             if matches!(op, FlatImeOp::CommitAsIs) && self.has_valid_composition() {
-                committed_composition = true;
+                committed_composition_end = self.comp.map(|(_, end)| end);
             }
             if let Some(change) = self.apply(op) {
                 if !can_track_anchored_change {
@@ -742,7 +742,7 @@ impl FlatImeState {
             state: self,
             text_change,
             untrimmed_text_change,
-            committed_composition,
+            committed_composition_end,
         }
     }
 }
@@ -979,7 +979,7 @@ fn handle_flat_ime_segment(
         return Ok(());
     }
 
-    let mut committed_composition = false;
+    let mut committed_composition_end = None;
     let mut tail_coordinates = None;
     let committed_insert = (|| -> Result<bool, EditorError> {
         let reach: Vec<_> = ops.iter().chain(tail.iter()).cloned().collect();
@@ -1022,7 +1022,7 @@ fn handle_flat_ime_segment(
             delete_paint = None;
         }
 
-        let reduced_committed_composition = reduced.committed_composition;
+        let reduced_committed_composition_end = reduced.committed_composition_end;
         let result = reduced.state;
         let untrimmed_text_change = reduced.untrimmed_text_change;
         let Some(text_change) = reduced.text_change else {
@@ -1132,6 +1132,7 @@ fn handle_flat_ime_segment(
                 let composition = result
                     .comp
                     .map(|(start, end)| (capture(start), capture(end)));
+                let committed_end = reduced_committed_composition_end.and_then(&mut capture);
                 let tail_positions = (!tail.is_empty()).then(|| {
                     (result.text.base..=result.text.base + result.text.chars.len())
                         .map(&mut capture)
@@ -1278,6 +1279,8 @@ fn handle_flat_ime_segment(
                 if has_text_delta && !tr.doc_changed() {
                     return Ok(());
                 }
+                committed_composition_end =
+                    committed_end.and_then(|end| end.resolve(tr, &inserted));
 
                 {
                     let composition = composition.and_then(|(start, end)| {
@@ -1335,16 +1338,42 @@ fn handle_flat_ime_segment(
         }
 
         editor.ime_delete_paint = next_delete_paint;
-        committed_composition = reduced_committed_composition;
-
         Ok(!text_change.insert.is_empty() && result.comp.is_none())
     })()?;
 
-    if committed_composition || committed_insert {
+    if committed_composition_end.is_some() || committed_insert {
         let resource = Arc::clone(&editor.resource);
         let resource = resource.lock().unwrap();
         editor.transact(|tr| {
+            // Finishing composition can arrive after the user moves the caret.
+            // Replace at the committed text, preserving the user's new selection.
+            let restore = if let Some(end) = committed_composition_end {
+                let view = tr.view();
+                let current = tr.selection().and_then(|s| s.resolve(&view));
+                if current.is_some_and(|s| s.is_collapsed() && s.head().to_flat() == end) {
+                    None
+                } else {
+                    let target = selection_from_flat_range(&view, end, end)?;
+                    let before = tr.state().clone();
+                    tr.set_selection(Some(target))?;
+                    Some(before)
+                }
+            } else {
+                None
+            };
             commands::optional!(commands::try_text_replacement(&resource))(tr)?;
+            if let Some(before) = restore {
+                let selection = before
+                    .selection
+                    .and_then(|s| remap_selection(s, &before, tr.state()))
+                    .ok_or(CommandError::Corrupted(
+                        "IME commit selection could not be restored".into(),
+                    ))?;
+                tr.set_selection(Some(selection))?;
+                tr.keep_pending_modifiers();
+                // Backspace at the moved caret must not undo this replacement.
+                tr.update_meta(|meta| meta.history = HistoryMeta::Record);
+            }
             Ok(())
         })?;
     }

--- a/crates/editor-core/src/ime.rs
+++ b/crates/editor-core/src/ime.rs
@@ -146,7 +146,8 @@ impl Editor {
         // composition is invisible to the editor) — and happens at moments that
         // already diverge for the IME (jumps, Enter, rewrites). Two violations
         // re-anchor unconditionally: the window no longer contains the cursor,
-        // and the hard cap that keeps the window bounded.
+        // and the hard cap on retained before-context. A live composition is
+        // still included below even when the cursor moves beyond that cap.
         let natural_start = sel_start.saturating_sub(before_limit);
         let window_start = match self.ime_window_anchor {
             Some(anchor) => {
@@ -169,6 +170,11 @@ impl Editor {
             }
             None => natural_start,
         };
+        // A native cursor move can leave composition behind until the IME ends
+        // it. Keep both ranges in the window so the host can report real offsets.
+        let window_start = state
+            .composition
+            .map_or(window_start, |c| window_start.min(c.start));
         // Keep trailing context relative to the whole composition, not its
         // internal caret. Otherwise moving inside marked text changes the
         // window's text and looks like an external edit to the IME.
@@ -414,6 +420,59 @@ mod tests {
             editor.state().composition,
             Some(Composition { start: 1, end: 2 })
         );
+    }
+
+    #[test]
+    fn ime_keeps_composition_visible_after_cursor_moves_until_ime_finishes_it() {
+        let (state, p1) = state! {
+            doc { root { p1: paragraph { text("abcdefghijklmnopqrstuvwxyz") } } }
+            selection: (p1, 0)
+        };
+        let mut editor = Editor::new_test(state);
+        editor.ime(1, 1).unwrap().unwrap();
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::Compose { text: "한".into() }],
+        });
+        let before = editor.ime(1, 1).unwrap().unwrap();
+        editor.view.layout(&editor.state);
+
+        // Android moves the cursor first, then lets the IME finish its preedit.
+        // The new cursor is beyond the window's normal re-anchoring hard cap.
+        editor.apply(Message::Selection {
+            op: SelectionOp::SetAt {
+                page: 0,
+                x: 9999.0,
+                y: 5.0,
+            },
+        });
+        let moved = editor.ime(1, 1).unwrap().unwrap();
+        assert_eq!(moved.selection, ImeRange { start: 28, end: 28 });
+        assert_eq!(moved.composing, before.composing);
+        assert!(moved.window_start <= 1, "{moved:?}");
+        assert!(
+            moved.text.contains("한abcdefghijklmnopqrstuvwxyz"),
+            "{moved:?}"
+        );
+
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::CommitAsIs],
+        });
+        assert!(editor.state().composition.is_none());
+        assert_eq!(
+            editor.ime(1, 1).unwrap().unwrap().selection,
+            moved.selection
+        );
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::Compose { text: "ㄱ".into() }],
+        });
+        let after = editor.ime(64, 64).unwrap().unwrap();
+        let doc = editor.state().view();
+        assert_eq!(
+            editor_state::flat_text(&doc, 0..editor_state::flat_size(&doc)),
+            "\u{2028}한abcdefghijklmnopqrstuvwxyzㄱ\u{2029}"
+        );
+        assert_eq!(after.composing, Some(ImeRange { start: 28, end: 29 }));
+        assert_eq!(editor.state().selection.unwrap().head.node, p1);
     }
 
     #[test]

--- a/crates/editor-core/src/text_replacement_tests.rs
+++ b/crates/editor-core/src/text_replacement_tests.rs
@@ -1034,6 +1034,101 @@ fn replacement_fires_on_commit_as_is() {
 }
 
 #[test]
+fn commit_after_cursor_move_does_not_replace_destination_text() {
+    let (s, p1) = state! {
+        doc { root { p1: paragraph { text("ㅎㅎ 본문") } } }
+        selection: (p1, 5)
+    };
+    let mut editor = editor_with_rules(s, vec![rule("ㅎㅎ", "웃음", false)]);
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::Compose { text: "한".into() }],
+    });
+    editor.apply(Message::Selection {
+        op: SelectionOp::Set {
+            selection: Selection::collapsed(Position::new(p1, 2)),
+        },
+    });
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::CommitAsIs],
+    });
+
+    let (expected, ..) = state! {
+        doc { root { p1: paragraph { text("ㅎㅎ 본문한") } } }
+        selection: (p1, 2)
+    };
+    assert_state_eq!(editor.state(), &expected);
+    assert!(editor.state().composition.is_none());
+
+    editor.apply(Message::TextInput {
+        ops: vec![FlatImeOp::Compose { text: "ㄱ".into() }],
+    });
+    assert_eq!(flat_text(&editor), "\u{2028}ㅎㅎㄱ 본문한\u{2029}");
+    assert_eq!(caret_flat(&editor), 4);
+    assert_eq!(
+        editor.state().composition,
+        Some(Composition { start: 3, end: 4 })
+    );
+}
+
+#[test]
+fn commit_after_cursor_move_replaces_at_composition_and_preserves_selection() {
+    for (anchor, head, expected_anchor, expected_head) in [(2, 2, 2, 2), (6, 6, 7, 7), (6, 4, 7, 5)]
+    {
+        let (s, p1) = state! {
+            doc { root { p1: paragraph { text("ㅎㅎ 본문") } } }
+            selection: (p1, 3)
+        };
+        let mut editor = editor_with_rules(
+            s,
+            vec![rule("ㅎㅎ", "웃음", false), rule("한", "한글", false)],
+        );
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::Compose { text: "한".into() }],
+        });
+        editor.apply(Message::Selection {
+            op: SelectionOp::Set {
+                selection: Selection::new(Position::new(p1, anchor), Position::new(p1, head)),
+            },
+        });
+        let moved_selection = editor.state().selection;
+        editor.apply(Message::TextInput {
+            ops: vec![FlatImeOp::CommitAsIs],
+        });
+
+        assert_eq!(flat_text(&editor), "\u{2028}ㅎㅎ 한글본문\u{2029}");
+        assert_eq!(
+            editor.state().selection,
+            Selection::new(
+                Position::new(p1, expected_anchor),
+                Position::new(p1, expected_head),
+            )
+            .normalize(&editor.state().view()),
+        );
+        assert!(editor.state().composition.is_none());
+
+        editor.apply(Message::History {
+            op: HistoryOp::Undo,
+        });
+        assert_eq!(flat_text(&editor), "\u{2028}ㅎㅎ 한본문\u{2029}");
+        assert_eq!(editor.state().selection, moved_selection);
+        editor.apply(Message::History {
+            op: HistoryOp::Redo,
+        });
+
+        // Backspace acts on the moved selection, not on the replacement at the old composition.
+        key(&mut editor, Key::Backspace);
+        assert_eq!(
+            flat_text(&editor),
+            match (anchor, head) {
+                (2, 2) => "\u{2028}ㅎ 한글본문\u{2029}",
+                (6, 6) => "\u{2028}ㅎㅎ 한글본\u{2029}",
+                _ => "\u{2028}ㅎㅎ 한글\u{2029}",
+            },
+        );
+    }
+}
+
+#[test]
 fn commit_barrier_replaces_before_later_op_in_same_text_input() {
     let (s, ..) = state! {
         doc { root { p1: paragraph { text("") } } }


### PR DESCRIPTION
안드로이드 디자인키보드에서 한글 조합 중 커서를 옮긴 뒤 입력하면, 이전 조합이 새 커서 앞의 기존 글자를 덮어쓰는 문제를 수정합니다.

예를 들어 문서 끝에서 ‘한’을 조합하다 앞 문장의 다른 위치를 탭하고 입력을 이어가면, 키보드가 이전 ‘한’을 계속 조합 중인 것으로 처리해 이동한 위치의 기존 글자를 대체할 수 있었습니다.

## 원인

기존 포인터 선택 처리는 커서를 옮기기 전에 `CommitAsIs`로 에디터의 조합을 확정했습니다. 따라서 키보드에는 새 커서 위치와 함께 “조합 없음” 상태가 전달됐습니다.

하지만 에디터의 조합을 확정하는 것만으로 키보드 내부의 한글 조합 상태까지 종료되지는 않습니다. 디자인키보드는 새 커서가 기존 조합 범위에서 벗어났다는 정보를 받아야 내부 조합을 정리하는데, 타이피가 조합 범위를 먼저 지워 이 판단에 필요한 정보가 사라졌습니다.

## 변경 내용

### Android에서 키보드가 조합을 종료하도록 처리

Android에서는 포인터로 커서를 옮길 때 조합을 먼저 확정하지 않습니다. 새 커서 위치와 기존 조합 범위를 함께 전달하고, 키보드가 `finishComposingText`를 보내 조합을 종료하도록 합니다.

이는 일반 Android 입력창처럼 선택 범위와 조합 범위를 독립적으로 다루는 방식입니다. 키보드를 강제로 재시작하거나 내부 상태를 직접 초기화하지 않습니다.

iOS는 조합 중 선택 범위가 조합 범위 안에 있어야 하는 입력 계약이 있으므로, 이 순서 변경은 Android에만 적용합니다.

### 커서를 멀리 옮겨도 기존 조합 범위 유지

에디터는 키보드에 문서 전체가 아닌 커서 주변의 텍스트를 제공합니다. 커서를 멀리 옮기면 기존 조합이 이 범위 밖으로 밀려날 수 있으므로, 조합이 끝날 때까지 새 커서와 기존 조합을 모두 포함하도록 범위를 조정합니다.

이를 통해 커서 이동 거리에 관계없이 키보드에 실제 조합 좌표를 전달합니다.

### 텍스트 대치를 실제 조합 확정 위치에서 수행

조합 종료가 커서 이동 뒤에 도착할 수 있으므로, 자동 텍스트 대치를 현재 커서 기준으로 실행해서는 안 됩니다.

예를 들어 `ㅎㅎ → 웃음` 규칙이 있을 때 다른 곳에서 ‘한’을 조합하다 기존 `ㅎㅎ` 뒤로 이동하면, ‘한’의 조합 종료가 엉뚱하게 기존 `ㅎㅎ`를 대치할 수 있습니다.

조합이 확정된 끝 위치를 기록하고 그 위치에서 대치를 수행하도록 수정합니다. 대치로 글자 수가 달라져도 사용자가 옮긴 커서·선택을 보존하며, 새 위치에서 백스페이스를 눌렀을 때 다른 위치의 대치를 되돌리지 않도록 이력 처리도 조정합니다.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>